### PR TITLE
Parse and level-map postgres log output (#4)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,5 +96,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260420184626-e10c466a9529 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/codefly-dev/core => /Users/antoine/Development/deus/codefly.dev/core

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/codefly-dev/core v0.1.164 h1:TN/l4OZfAKNXXxM6zc6daBSobTSrKdKQ6p/o9MZD6xM=
+github.com/codefly-dev/core v0.1.164/go.mod h1:R9Cf6qKv26ywwZ1zFivF20jIsfgarS0pXff6baDVXSE=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
 github.com/containerd/errdefs v1.0.0/go.mod h1:+YBYIdtsnF4Iw6nWZhJcqGSg/dwvV7tyJ/kCkyJ2k+M=
 github.com/containerd/errdefs/pkg v0.3.0 h1:9IKJ06FvyNlexW690DXuQNx2KA2cUJXx151Xdx3ZPPE=

--- a/pglog.go
+++ b/pglog.go
@@ -1,0 +1,123 @@
+package main
+
+// pglog.go — structured rendering of the postgres server log stream.
+//
+// Both runtimes (Docker and nix) point the postgres process's stderr at our
+// Wool logger. Raw, every line carries postgres' own timestamp + PID prefix
+// ("2026-06-16 14:56:37.312 UTC [35801] LOG:  ...") and lands at a single
+// undifferentiated level, so ERROR/FATAL never stand out and routine chatter
+// can't be filtered. pgLogWriter sits between postgres and Wool: it splits the
+// stream into lines, parses the stock log_line_prefix, drops the redundant
+// timestamp (Wool stamps its own), keeps the PID as a compact field, and emits
+// each line at the Wool level its postgres severity maps to.
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/codefly-dev/core/wool"
+)
+
+// pgLogLine matches a line produced by postgres' stock log_line_prefix ("%m
+// [%p] "): an ISO timestamp with timezone, the PID in brackets, then
+// "SEVERITY:  message". Capture groups: 1=PID, 2=severity, 3=message.
+var pgLogLine = regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? \S+ \[(\d+)\] (\w+):\s*(.*)$`)
+
+// pgLogWriter parses the postgres log stream and re-emits each line through
+// Wool at a severity-mapped level. It implements io.Writer so it can be handed
+// to the runner in place of the raw logger.
+type pgLogWriter struct {
+	w   *wool.Wool
+	buf []byte
+}
+
+func newPGLogWriter(w *wool.Wool) *pgLogWriter {
+	return &pgLogWriter{w: w}
+}
+
+var _ io.Writer = (*pgLogWriter)(nil)
+
+// Write buffers incoming bytes and flushes complete (newline-terminated) lines.
+// The runner may deliver postgres output either line-by-line (native) or in raw
+// chunks spanning line boundaries (Docker's stdcopy), so a partial trailing line
+// is held until its newline arrives.
+func (p *pgLogWriter) Write(b []byte) (int, error) {
+	p.buf = append(p.buf, b...)
+	for {
+		i := bytes.IndexByte(p.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(bytes.TrimRight(p.buf[:i], "\r"))
+		p.buf = p.buf[i+1:]
+		p.emit(line)
+	}
+	return len(b), nil
+}
+
+// emit parses one postgres log line and forwards it at the mapped Wool level.
+// Lines that don't match the postgres prefix (e.g. initdb progress) pass
+// through at INFO so nothing is silently dropped.
+func (p *pgLogWriter) emit(line string) {
+	if strings.TrimSpace(line) == "" {
+		return
+	}
+	m := pgLogLine.FindStringSubmatch(line)
+	if m == nil {
+		p.w.Info(line)
+		return
+	}
+	pid, severity, msg := m[1], m[2], m[3]
+	level := pgSeverityToLevel(severity)
+	// Checkpoint/restartpoint summaries are high-frequency, low-value LOG
+	// chatter — drop them below the default INFO threshold so they're filtered
+	// unless someone is explicitly looking at debug output.
+	if level == wool.INFO && isPGRoutineNoise(msg) {
+		level = wool.DEBUG
+	}
+	p.logAt(level, msg, wool.Field("pid", pid))
+}
+
+func (p *pgLogWriter) logAt(level wool.Loglevel, msg string, fields ...*wool.LogField) {
+	switch level {
+	case wool.FATAL:
+		p.w.Fatal(msg, fields...)
+	case wool.ERROR:
+		p.w.Error(msg, fields...)
+	case wool.WARN:
+		p.w.Warn(msg, fields...)
+	case wool.DEBUG:
+		p.w.Debug(msg, fields...)
+	default:
+		p.w.Info(msg, fields...)
+	}
+}
+
+// pgSeverityToLevel maps a postgres message severity onto a Wool log level.
+// PANIC/FATAL/ERROR/WARNING map to their direct equivalents; LOG/INFO/NOTICE
+// are routine operational output and map to INFO; DEBUG1..DEBUG5 map to DEBUG.
+// An unrecognized severity defaults to INFO rather than being hidden.
+func pgSeverityToLevel(severity string) wool.Loglevel {
+	switch severity {
+	case "PANIC", "FATAL":
+		return wool.FATAL
+	case "ERROR":
+		return wool.ERROR
+	case "WARNING":
+		return wool.WARN
+	case "LOG", "INFO", "NOTICE":
+		return wool.INFO
+	}
+	if strings.HasPrefix(severity, "DEBUG") {
+		return wool.DEBUG
+	}
+	return wool.INFO
+}
+
+// isPGRoutineNoise reports whether a LOG message is high-frequency background
+// bookkeeping (checkpoints, restartpoints) worth de-emphasizing.
+func isPGRoutineNoise(msg string) bool {
+	return strings.HasPrefix(msg, "checkpoint ") || strings.HasPrefix(msg, "restartpoint ")
+}

--- a/pglog_test.go
+++ b/pglog_test.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/codefly-dev/core/wool"
+)
+
+// capturingProcessor records every Log emitted through Wool so tests can
+// assert on the level, message, and fields the pgLogWriter produced.
+type capturingProcessor struct {
+	logs []*wool.Log
+}
+
+func (c *capturingProcessor) Process(l *wool.Log) { c.logs = append(c.logs, l) }
+
+// newCaptureWool returns a Wool wired to a capturing processor at TRACE level
+// (so even de-emphasized DEBUG lines are recorded).
+func newCaptureWool() (*wool.Wool, *capturingProcessor) {
+	cap := &capturingProcessor{}
+	w := wool.Get(context.Background()).WithLogger(cap)
+	w.WithLoglevel(wool.TRACE)
+	return w, cap
+}
+
+func fieldValue(l *wool.Log, key string) (any, bool) {
+	for _, f := range l.Fields {
+		if f.Key == key {
+			return f.Value, true
+		}
+	}
+	return nil, false
+}
+
+func TestPGLogWriter_ParsesSeverityAndStripsPrefix(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		wantLevel wool.Loglevel
+		wantMsg   string
+		wantPID   string
+	}{
+		{
+			name:      "startup LOG maps to INFO",
+			line:      `2026-06-16 14:56:37.339 UTC [35801] LOG:  database system is ready to accept connections`,
+			wantLevel: wool.INFO,
+			wantMsg:   "database system is ready to accept connections",
+			wantPID:   "35801",
+		},
+		{
+			name:      "WARNING maps to WARN",
+			line:      `2026-06-16 14:56:37.339 UTC [35801] WARNING:  here be dragons`,
+			wantLevel: wool.WARN,
+			wantMsg:   "here be dragons",
+			wantPID:   "35801",
+		},
+		{
+			name:      "ERROR maps to ERROR",
+			line:      `2026-06-16 14:56:37.339 UTC [35801] ERROR:  relation "missing" does not exist`,
+			wantLevel: wool.ERROR,
+			wantMsg:   `relation "missing" does not exist`,
+			wantPID:   "35801",
+		},
+		{
+			name:      "FATAL maps to FATAL",
+			line:      `2026-06-16 14:56:37.339 UTC [35804] FATAL:  the database system is starting up`,
+			wantLevel: wool.FATAL,
+			wantMsg:   "the database system is starting up",
+			wantPID:   "35804",
+		},
+		{
+			name:      "PANIC maps to FATAL",
+			line:      `2026-06-16 14:56:37.339 UTC [35804] PANIC:  could not write to file`,
+			wantLevel: wool.FATAL,
+			wantMsg:   "could not write to file",
+			wantPID:   "35804",
+		},
+		{
+			name:      "DEBUG1 maps to DEBUG",
+			line:      `2026-06-16 14:56:37.339 UTC [35804] DEBUG1:  forked new backend`,
+			wantLevel: wool.DEBUG,
+			wantMsg:   "forked new backend",
+			wantPID:   "35804",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w, cap := newCaptureWool()
+			pw := newPGLogWriter(w)
+			if _, err := pw.Write([]byte(tc.line + "\n")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			if len(cap.logs) != 1 {
+				t.Fatalf("expected 1 log, got %d", len(cap.logs))
+			}
+			got := cap.logs[0]
+			if got.Level != tc.wantLevel {
+				t.Errorf("level: got %v want %v", got.Level, tc.wantLevel)
+			}
+			if got.Message != tc.wantMsg {
+				t.Errorf("message: got %q want %q", got.Message, tc.wantMsg)
+			}
+			pid, ok := fieldValue(got, "pid")
+			if !ok || pid != tc.wantPID {
+				t.Errorf("pid field: got %v (present=%v) want %q", pid, ok, tc.wantPID)
+			}
+		})
+	}
+}
+
+func TestPGLogWriter_CheckpointDeEmphasized(t *testing.T) {
+	w, cap := newCaptureWool()
+	pw := newPGLogWriter(w)
+	line := `2026-06-16 15:01:37.350 UTC [35802] LOG:  checkpoint complete: wrote 2 buffers (0.0%); 0 WAL file(s) added`
+	if _, err := pw.Write([]byte(line + "\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if len(cap.logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(cap.logs))
+	}
+	// A LOG line that would normally be INFO is dropped to DEBUG because it is
+	// routine checkpoint noise.
+	if cap.logs[0].Level != wool.DEBUG {
+		t.Errorf("checkpoint level: got %v want DEBUG", cap.logs[0].Level)
+	}
+}
+
+func TestPGLogWriter_UnparsedLinePassesThrough(t *testing.T) {
+	w, cap := newCaptureWool()
+	pw := newPGLogWriter(w)
+	if _, err := pw.Write([]byte("initializing database system\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if len(cap.logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(cap.logs))
+	}
+	got := cap.logs[0]
+	if got.Level != wool.INFO {
+		t.Errorf("level: got %v want INFO", got.Level)
+	}
+	if got.Message != "initializing database system" {
+		t.Errorf("message: got %q", got.Message)
+	}
+}
+
+func TestPGLogWriter_BuffersPartialLines(t *testing.T) {
+	w, cap := newCaptureWool()
+	pw := newPGLogWriter(w)
+	// A single log line split across two writes (as Docker's raw stdcopy may
+	// deliver it) must surface as exactly one parsed entry.
+	if _, err := pw.Write([]byte(`2026-06-16 14:56:37.339 UTC [35801] LOG:  listening`)); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	if len(cap.logs) != 0 {
+		t.Fatalf("expected no log before newline, got %d", len(cap.logs))
+	}
+	if _, err := pw.Write([]byte(" on port 5432\n")); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	if len(cap.logs) != 1 {
+		t.Fatalf("expected 1 log, got %d", len(cap.logs))
+	}
+	if cap.logs[0].Message != "listening on port 5432" {
+		t.Errorf("message: got %q", cap.logs[0].Message)
+	}
+}
+
+func TestPGLogWriter_SkipsBlankLines(t *testing.T) {
+	w, cap := newCaptureWool()
+	pw := newPGLogWriter(w)
+	if _, err := pw.Write([]byte("\n   \n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if len(cap.logs) != 0 {
+		t.Errorf("expected blank lines skipped, got %d logs", len(cap.logs))
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -153,7 +153,7 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 	if rc := req.GetRuntimeContext(); rc != nil && rc.Kind == resources.RuntimeContextNix {
 		w.Debug("using nix runtime for postgres", wool.Field("port", instance.Port))
 		nixpg, errNix := newNixPostgres(ctx, s.Location, uint16(instance.Port),
-			s.postgresUser, s.postgresPassword, s.DatabaseName, s.LogLevel, s.Wool)
+			s.postgresUser, s.postgresPassword, s.DatabaseName, s.LogLevel, newPGLogWriter(s.Wool))
 		if errNix != nil {
 			return s.Runtime.InitError(errNix)
 		}
@@ -174,7 +174,7 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 		return s.Runtime.InitError(err)
 	}
 
-	runner.WithOutput(s.Wool)
+	runner.WithOutput(newPGLogWriter(s.Wool))
 	runner.WithPortMapping(ctx, uint16(instance.Port), s.postgresPort)
 
 	runner.WithEnvironmentVariables(


### PR DESCRIPTION
Closes #4.

## Summary
- Postgres streamed its server log through Wool as undifferentiated FORWARD-level lines, each carrying postgres' own timestamp + PID prefix — so `ERROR`/`FATAL` never stood out, routine `LOG` chatter couldn't be filtered, and the timestamp duplicated the one Wool already attaches.
- Adds a parsing `io.Writer` (`pgLogWriter`) in front of Wool, wired into both the Docker and nix runtime paths, that reads the stock `log_line_prefix`, drops the redundant timestamp, keeps the PID as a compact field, maps postgres severity onto Wool levels, and de-emphasizes high-frequency checkpoint/restartpoint noise to `DEBUG`.

## Test plan
- [x] `go build ./... && go vet ./...`
- [x] `go test -run TestPGLogWriter ./...` — severity mapping, prefix stripping, checkpoint de-emphasis, split-line buffering, blank-line skipping
- [x] nix integration test (`go test ./...`) shows postgres startup lines rendered with mapped levels + `pid` fields and no timestamp clutter
- [ ] Docker integration test (`TestCreateToRunDocker`) requires a running Docker daemon; not available in this environment (fails to connect to `docker.sock`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PostgreSQL logs are now captured and seamlessly integrated into the application's logging system with intelligent severity mapping
  * Routine checkpoint and restart-point messages are automatically de-emphasized to reduce log noise
  * Partial log lines are correctly buffered and assembled across multiple writes
  * Unparsed log entries are safely passed through to preserve all output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->