### PR TITLE
Backfill historical release assets (#6)

### DIFF
--- a/.github/scripts/release-backfill.sh
+++ b/.github/scripts/release-backfill.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+validate_tag() {
+  local source_dir=$1
+  local tag_ref="refs/tags/$RELEASE_TAG"
+
+  git check-ref-format "$tag_ref" >/dev/null
+  git -C "$source_dir" show-ref --verify --quiet "$tag_ref"
+
+  local head_commit
+  local tag_commit
+  head_commit=$(git -C "$source_dir" rev-parse --verify 'HEAD^{commit}')
+  tag_commit=$(git -C "$source_dir" rev-parse --verify "${tag_ref}^{commit}")
+  if [[ "$head_commit" != "$tag_commit" ]]; then
+    echo "$RELEASE_TAG does not point at the checked-out commit" >&2
+    return 1
+  fi
+
+  printf 'GORELEASER_CURRENT_TAG=%s\n' "$RELEASE_TAG" >>"$GITHUB_ENV"
+}
+
+publish_release() {
+  local dist_dir=$1
+  local changelog="$dist_dir/CHANGELOG.md"
+  local release_pages
+  local release
+
+  shopt -s nullglob
+  local assets=("$dist_dir"/*.tar.gz "$dist_dir"/*_checksums.txt)
+  shopt -u nullglob
+
+  if ((${#assets[@]} == 0)); then
+    echo "no release assets found in $dist_dir" >&2
+    return 1
+  fi
+  if [[ ! -f "$changelog" ]]; then
+    echo "release changelog not found at $changelog" >&2
+    return 1
+  fi
+
+  release_pages=$(gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/releases?per_page=100")
+  release=$(jq -c --arg tag "$RELEASE_TAG" \
+    '[.[][] | select(.tag_name == $tag)][0] // empty' <<<"$release_pages")
+
+  if [[ -z "$release" ]]; then
+    gh release create "$RELEASE_TAG" \
+      --repo "$GITHUB_REPOSITORY" \
+      --verify-tag \
+      --latest=false \
+      --title "$RELEASE_TAG" \
+      --notes-file "$changelog" \
+      "${assets[@]}"
+    return
+  fi
+
+  local missing_assets=()
+  local asset
+  for asset in "${assets[@]}"; do
+    if ! jq -e --arg name "${asset##*/}" \
+      '.assets[]? | select(.name == $name)' <<<"$release" >/dev/null; then
+      missing_assets+=("$asset")
+    fi
+  done
+
+  if ((${#missing_assets[@]} > 0)); then
+    gh release upload "$RELEASE_TAG" "${missing_assets[@]}" \
+      --repo "$GITHUB_REPOSITORY"
+  fi
+
+  if [[ "$(jq -r '.draft' <<<"$release")" == "true" ]]; then
+    gh release edit "$RELEASE_TAG" \
+      --repo "$GITHUB_REPOSITORY" \
+      --draft=false \
+      --latest=false
+  fi
+}
+
+: "${RELEASE_TAG:?RELEASE_TAG is required}"
+
+case "${1:-}" in
+validate-tag)
+  : "${GITHUB_ENV:?GITHUB_ENV is required}"
+  validate_tag "${2:?source directory is required}"
+  ;;
+publish)
+  : "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+  : "${GH_TOKEN:?GH_TOKEN is required}"
+  publish_release "${2:?distribution directory is required}"
+  ;;
+*)
+  echo "usage: $0 {validate-tag SOURCE_DIR|publish DIST_DIR}" >&2
+  exit 2
+  ;;
+esac

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -4,8 +4,59 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing tag to rebuild and publish
+        required: true
+        type: string
 
 jobs:
   release:
+    if: github.event_name == 'push'
     uses: codefly-dev/core/.github/workflows/go-service-release.yml@main
     secrets: inherit
+
+  backfill:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag }}
+      - name: Validate tag
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: test "$(git describe --tags --exact-match)" = "$RELEASE_TAG"
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Repair dependency metadata
+        run: |
+          cp go.mod "${{ runner.temp }}/release.mod"
+          cp go.sum "${{ runner.temp }}/release.sum"
+          go mod tidy -modfile="${{ runner.temp }}/release.mod"
+      - name: Test
+        run: go test -v ./...
+        env:
+          GOFLAGS: -modfile=${{ runner.temp }}/release.mod
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: '~> v2'
+          args: release --clean --skip=publish,announce
+        env:
+          GOFLAGS: -modfile=${{ runner.temp }}/release.mod
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --verify-tag \
+            --latest=false \
+            --title "$RELEASE_TAG" \
+            --notes-file dist/CHANGELOG.md \
+            dist/*.tar.gz dist/*_checksums.txt

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -22,23 +22,29 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Check out release source
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag }}
+          path: release-source
       - name: Validate tag
         env:
           RELEASE_TAG: ${{ inputs.tag }}
-        run: test "$(git describe --tags --exact-match)" = "$RELEASE_TAG"
+        run: .github/scripts/release-backfill.sh validate-tag release-source
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: release-source/go.mod
+          cache-dependency-path: release-source/go.sum
       - name: Repair dependency metadata
         run: |
-          cp go.mod "${{ runner.temp }}/release.mod"
-          cp go.sum "${{ runner.temp }}/release.sum"
+          cp release-source/go.mod "${{ runner.temp }}/release.mod"
+          cp release-source/go.sum "${{ runner.temp }}/release.sum"
+          cd release-source
           go mod tidy -modfile="${{ runner.temp }}/release.mod"
       - name: Test
         run: go test -v ./...
+        working-directory: release-source
         env:
           GOFLAGS: -modfile=${{ runner.temp }}/release.mod
       - name: Run GoReleaser
@@ -46,17 +52,11 @@ jobs:
         with:
           version: '~> v2'
           args: release --clean --skip=publish,announce
+          workdir: release-source
         env:
           GOFLAGS: -modfile=${{ runner.temp }}/release.mod
       - name: Publish release
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
           RELEASE_TAG: ${{ inputs.tag }}
-        run: |
-          gh release create "$RELEASE_TAG" \
-            --repo "$GITHUB_REPOSITORY" \
-            --verify-tag \
-            --latest=false \
-            --title "$RELEASE_TAG" \
-            --notes-file dist/CHANGELOG.md \
-            dist/*.tar.gz dist/*_checksums.txt
+        run: .github/scripts/release-backfill.sh publish release-source/dist

--- a/release_backfill_test.go
+++ b/release_backfill_test.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReleaseBackfillUsesRequestedTagWhenCommitHasMultipleTags(t *testing.T) {
+	repository := t.TempDir()
+	runTestCommand(t, repository, nil, "git", "init", "--quiet")
+	runTestCommand(t, repository, nil, "git", "config", "user.name", "Test")
+	runTestCommand(t, repository, nil, "git", "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(repository, "service"), []byte("postgres"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runTestCommand(t, repository, nil, "git", "add", "service")
+	runTestCommand(t, repository, nil, "git", "commit", "--quiet", "-m", "release")
+	runTestCommand(t, repository, []string{"GIT_COMMITTER_DATE=2026-07-01T00:00:00Z"}, "git", "tag", "-a", "v1.0.0", "-m", "v1.0.0")
+	runTestCommand(t, repository, []string{"GIT_COMMITTER_DATE=2026-07-02T00:00:00Z"}, "git", "tag", "-a", "v1.0.1", "-m", "v1.0.1")
+	runTestCommand(t, repository, nil, "git", "checkout", "--quiet", "--detach")
+
+	if described := strings.TrimSpace(runTestCommand(t, repository, nil, "git", "describe", "--tags", "--exact-match")); described == "v1.0.0" {
+		t.Fatalf("test requires git describe to select the other tag, got %s", described)
+	}
+
+	environmentFile := filepath.Join(t.TempDir(), "github-env")
+	runReleaseBackfill(t, []string{
+		"RELEASE_TAG=v1.0.0",
+		"GITHUB_ENV=" + environmentFile,
+	}, "validate-tag", repository)
+
+	environment, err := os.ReadFile(environmentFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(environment), "GORELEASER_CURRENT_TAG=v1.0.0\n"; got != want {
+		t.Fatalf("GitHub environment = %q, want %q", got, want)
+	}
+}
+
+func TestReleaseBackfillUploadsOnlyMissingAssetsToExistingRelease(t *testing.T) {
+	dist := newReleaseDist(t)
+	fixture := filepath.Join(t.TempDir(), "releases.json")
+	if err := os.WriteFile(fixture, []byte(`[[
+		{
+			"tag_name": "v0.0.103",
+			"draft": false,
+			"assets": [{"name": "service-postgres_0.0.103_linux_amd64.tar.gz"}]
+		}
+	]]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(t.TempDir(), "gh.log")
+	bin := fakeGitHubCLI(t)
+
+	runReleaseBackfill(t, []string{
+		"PATH=" + bin + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GH_LOG=" + log,
+		"GH_RELEASES_FIXTURE=" + fixture,
+		"GH_TOKEN=test-token",
+		"GITHUB_REPOSITORY=codefly-dev/service-postgres",
+		"RELEASE_TAG=v0.0.103",
+	}, "publish", dist)
+
+	calls := readCalls(t, log)
+	if len(calls) != 2 {
+		t.Fatalf("gh calls = %q, want API lookup and one upload", calls)
+	}
+	if !strings.HasPrefix(calls[1], "release upload v0.0.103 ") {
+		t.Fatalf("second gh call = %q, want release upload", calls[1])
+	}
+	if strings.Contains(calls[1], "linux_amd64") {
+		t.Fatalf("upload replaced an existing asset: %q", calls[1])
+	}
+	for _, missing := range []string{"darwin_arm64", "checksums.txt"} {
+		if !strings.Contains(calls[1], missing) {
+			t.Fatalf("upload omitted %s: %q", missing, calls[1])
+		}
+	}
+}
+
+func TestReleaseBackfillCreatesReleaseWhenMissing(t *testing.T) {
+	dist := newReleaseDist(t)
+	fixture := filepath.Join(t.TempDir(), "releases.json")
+	if err := os.WriteFile(fixture, []byte(`[[]]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(t.TempDir(), "gh.log")
+	bin := fakeGitHubCLI(t)
+
+	runReleaseBackfill(t, []string{
+		"PATH=" + bin + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GH_LOG=" + log,
+		"GH_RELEASES_FIXTURE=" + fixture,
+		"GH_TOKEN=test-token",
+		"GITHUB_REPOSITORY=codefly-dev/service-postgres",
+		"RELEASE_TAG=v0.0.103",
+	}, "publish", dist)
+
+	calls := readCalls(t, log)
+	if len(calls) != 2 {
+		t.Fatalf("gh calls = %q, want API lookup and release creation", calls)
+	}
+	if !strings.HasPrefix(calls[1], "release create v0.0.103 ") {
+		t.Fatalf("second gh call = %q, want release create", calls[1])
+	}
+	for _, expected := range []string{"linux_amd64", "darwin_arm64", "checksums.txt", "--latest=false"} {
+		if !strings.Contains(calls[1], expected) {
+			t.Fatalf("release creation omitted %s: %q", expected, calls[1])
+		}
+	}
+}
+
+func TestReleaseBackfillCompletesExistingDraft(t *testing.T) {
+	dist := newReleaseDist(t)
+	fixture := filepath.Join(t.TempDir(), "releases.json")
+	if err := os.WriteFile(fixture, []byte(`[[
+		{
+			"tag_name": "v0.0.103",
+			"draft": true,
+			"assets": []
+		}
+	]]`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(t.TempDir(), "gh.log")
+	bin := fakeGitHubCLI(t)
+
+	runReleaseBackfill(t, []string{
+		"PATH=" + bin + string(os.PathListSeparator) + os.Getenv("PATH"),
+		"GH_LOG=" + log,
+		"GH_RELEASES_FIXTURE=" + fixture,
+		"GH_TOKEN=test-token",
+		"GITHUB_REPOSITORY=codefly-dev/service-postgres",
+		"RELEASE_TAG=v0.0.103",
+	}, "publish", dist)
+
+	calls := readCalls(t, log)
+	if len(calls) != 3 {
+		t.Fatalf("gh calls = %q, want API lookup, asset upload, and draft publication", calls)
+	}
+	if !strings.HasPrefix(calls[1], "release upload v0.0.103 ") {
+		t.Fatalf("second gh call = %q, want release upload", calls[1])
+	}
+	if got, want := calls[2], "release edit v0.0.103 --repo codefly-dev/service-postgres --draft=false --latest=false"; got != want {
+		t.Fatalf("third gh call = %q, want %q", got, want)
+	}
+}
+
+func newReleaseDist(t *testing.T) string {
+	t.Helper()
+	dist := t.TempDir()
+	for name, contents := range map[string]string{
+		"CHANGELOG.md":                                 "changes",
+		"service-postgres_0.0.103_checksums.txt":       "checksums",
+		"service-postgres_0.0.103_darwin_arm64.tar.gz": "darwin",
+		"service-postgres_0.0.103_linux_amd64.tar.gz":  "linux",
+	} {
+		if err := os.WriteFile(filepath.Join(dist, name), []byte(contents), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dist
+}
+
+func fakeGitHubCLI(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir()
+	source := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s ' "$@" >>"$GH_LOG"
+printf '\n' >>"$GH_LOG"
+if [[ "${1:-}" == "api" ]]; then
+  cat "$GH_RELEASES_FIXTURE"
+fi
+`
+	path := filepath.Join(bin, "gh")
+	if err := os.WriteFile(path, []byte(source), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+func readCalls(t *testing.T, path string) []string {
+	t.Helper()
+	output, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimSpace(string(output)), "\n")
+}
+
+func runReleaseBackfill(t *testing.T, environment []string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command("bash", append([]string{".github/scripts/release-backfill.sh"}, arguments...)...)
+	command.Env = append(os.Environ(), environment...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("release backfill failed: %v\n%s", err, output)
+	}
+	return string(output)
+}
+
+func runTestCommand(t *testing.T, directory string, environment []string, name string, arguments ...string) string {
+	t.Helper()
+	command := exec.Command(name, arguments...)
+	command.Dir = directory
+	command.Env = append(os.Environ(), environment...)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s failed: %v\n%s", name, err, output)
+	}
+	return string(output)
+}


### PR DESCRIPTION
Closes #6.

## Summary

- Keep normal tag releases on the shared workflow while providing a safe path to recover failed historical tags.
- Repair stale dependency metadata outside the tagged worktree so GoReleaser retains clean-tree and exact-tag validation.
- Publish historical releases without replacing the current release as `Latest`.

## Test plan

- [x] `actionlint .github/workflows/releaser.yml`
- [x] `go test ./...`
- [x] Run `go test ./...` against `v0.0.103` with repaired dependency metadata
- [x] Run GoReleaser for `v0.0.103` with publishing disabled and verify all expected archive names
- [x] Download the published Linux asset from its public URL and verify its SHA-256 checksum
