### PR TITLE
Release Postgres agent v0.0.109

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.108
+version: 0.0.109


### PR DESCRIPTION
## Summary

- Publish the reviewed promotable GitOps contract from #17 as an immutable official plugin version.

## Test plan

- [x] `go test ./...`