### PR TITLE
Render Postgres from typed references (#21)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.109
+version: 0.0.110

--- a/builder.go
+++ b/builder.go
@@ -175,41 +175,126 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
 
-	return s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
+	parameters := &DeploymentTemplateParameters{
+		WithBootstrap: true,
+		ManagedImage:  s.dockerImage().FullName(),
+	}
+	var promotableConfiguration *v0.Configuration
+	response, err := s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
 		EnvironmentVariables: s.EnvironmentVariables,
 		Templates:            deploymentFS,
-		Parameters: DeploymentTemplateParameters{
-			WithBootstrap: true,
-			ManagedImage:  s.dockerImage().FullName(),
-		},
+		Parameters:           parameters,
 		Prepare: func(ctx context.Context, deployment *services.KustomizeDeploymentContext) error {
-			instance, err := resources.FindNetworkInstanceInNetworkMappings(ctx, req.GetNetworkMappings(), s.TcpEndpoint, resources.NewPublicNetworkAccess())
-			if err != nil {
-				return err
+			configuration, prepareErr := s.prepareDeployment(ctx, deployment, parameters)
+			if prepareErr != nil {
+				return prepareErr
 			}
-			configuration, err := s.CreateConnectionConfiguration(ctx, req.GetConfiguration(), instance, !s.Settings.WithoutSSL)
-			if err != nil {
-				return err
-			}
-			ownerConnection, err := s.createOwnerConnectionString(ctx, req.GetConfiguration(), instance.Address, !s.Settings.WithoutSSL)
-			if err != nil {
-				return err
-			}
-			// These values are private to the Postgres StatefulSet/bootstrap Job.
-			// Only the capability-scoped configuration above is exported to
-			// dependent services.
-			deployment.AddSecrets(
-				resources.Env("POSTGRES_USER", s.postgresUser),
-				resources.Env("POSTGRES_PASSWORD", s.postgresPassword),
-				resources.Env("POSTGRES_DB", s.DatabaseName),
-				resources.Env("POSTGRES_READ_ONLY_PASSWORD", s.readOnlyPassword),
-				resources.Env("POSTGRES_READ_WRITE_PASSWORD", s.readWritePassword),
-				resources.Env(migrationConnectionEnvironmentKey, ownerConnection),
-			)
 			s.Wool.Debug("exporting configuration", wool.Field("conf", resources.MakeConfigurationSummary(configuration)))
+			if deployment.Profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+				promotableConfiguration = configuration
+				return nil
+			}
 			return deployment.ExportConfiguration(ctx, configuration)
 		},
 	})
+	if err != nil ||
+		response.GetState().GetState() != builderv0.DeploymentStatus_SUCCESS ||
+		promotableConfiguration == nil {
+		return response, err
+	}
+	response.Configuration = promotableConfiguration
+	return response, nil
+}
+
+func (s *Builder) prepareDeployment(
+	ctx context.Context,
+	deployment *services.KustomizeDeploymentContext,
+	parameters *DeploymentTemplateParameters,
+) (*v0.Configuration, error) {
+	req := deployment.Request
+	instance, err := resources.FindNetworkInstanceInNetworkMappings(
+		ctx,
+		req.GetNetworkMappings(),
+		s.TcpEndpoint,
+		resources.NewPublicNetworkAccess(),
+	)
+	if err != nil {
+		return nil, err
+	}
+	if deployment.Profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+		workloadReferences, referencesErr := selectPromotableSecretReferences(
+			deployment.Kubernetes.GetSecretReferences(),
+		)
+		if referencesErr != nil {
+			return nil, referencesErr
+		}
+		parameters.StatefulSetSecretReferences = workloadReferences.StatefulSet
+		parameters.BootstrapJobSecretReferences = workloadReferences.BootstrapJob
+		return s.promotableConnectionConfiguration(instance), nil
+	}
+
+	configuration, err := s.CreateConnectionConfiguration(ctx, req.GetConfiguration(), instance, !s.WithoutSSL)
+	if err != nil {
+		return nil, err
+	}
+	ownerConnection, err := s.createOwnerConnectionString(ctx, req.GetConfiguration(), instance.Address, !s.WithoutSSL)
+	if err != nil {
+		return nil, err
+	}
+	// These raw workload values stay in the ephemeral profile's generated
+	// Secret; callers receive only the managed-resource configuration.
+	deployment.AddSecrets(
+		resources.Env("POSTGRES_USER", s.postgresUser),
+		resources.Env("POSTGRES_PASSWORD", s.postgresPassword),
+		resources.Env("POSTGRES_DB", s.DatabaseName),
+		resources.Env("POSTGRES_READ_ONLY_PASSWORD", s.readOnlyPassword),
+		resources.Env("POSTGRES_READ_WRITE_PASSWORD", s.readWritePassword),
+		resources.Env(migrationConnectionEnvironmentKey, ownerConnection),
+	)
+	return configuration, nil
+}
+
+type promotableWorkloadSecretReferences struct {
+	StatefulSet  map[string]*builderv0.KubernetesSecretKeyReference
+	BootstrapJob map[string]*builderv0.KubernetesSecretKeyReference
+}
+
+func selectPromotableSecretReferences(
+	references map[string]*builderv0.KubernetesSecretKeyReference,
+) (*promotableWorkloadSecretReferences, error) {
+	statefulSetEnvironmentVariables := []string{
+		"POSTGRES_USER",
+		"POSTGRES_PASSWORD",
+		"POSTGRES_DB",
+	}
+	bootstrapJobEnvironmentVariables := []string{
+		"POSTGRES_USER",
+		"POSTGRES_READ_ONLY_PASSWORD",
+		"POSTGRES_READ_WRITE_PASSWORD",
+		migrationConnectionEnvironmentKey,
+	}
+	selected := make(map[string]*builderv0.KubernetesSecretKeyReference)
+	for _, environmentVariable := range append(statefulSetEnvironmentVariables, bootstrapJobEnvironmentVariables...) {
+		reference := references[environmentVariable]
+		if reference == nil || reference.GetName() == "" || reference.GetKey() == "" {
+			return nil, fmt.Errorf("postgres deployment requires a typed Kubernetes Secret reference for %s", environmentVariable)
+		}
+		if reference.GetOptional() {
+			return nil, fmt.Errorf("%s Kubernetes Secret reference must not be optional", environmentVariable)
+		}
+		selected[environmentVariable] = reference
+	}
+	selectForWorkload := func(environmentVariables []string) map[string]*builderv0.KubernetesSecretKeyReference {
+		workloadReferences := make(map[string]*builderv0.KubernetesSecretKeyReference, len(environmentVariables))
+		for _, environmentVariable := range environmentVariables {
+			workloadReferences[environmentVariable] = selected[environmentVariable]
+		}
+		return workloadReferences
+	}
+	return &promotableWorkloadSecretReferences{
+		StatefulSet:  selectForWorkload(statefulSetEnvironmentVariables),
+		BootstrapJob: selectForWorkload(bootstrapJobEnvironmentVariables),
+	}, nil
 }
 
 type create struct {

--- a/builder.go
+++ b/builder.go
@@ -175,17 +175,28 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
 
-	return s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
+	var promotableConfiguration *v0.Configuration
+	response, err := s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
 		EnvironmentVariables: s.EnvironmentVariables,
 		Templates:            deploymentFS,
 		Parameters: DeploymentTemplateParameters{
 			WithBootstrap: true,
 			ManagedImage:  s.dockerImage().FullName(),
+			DatabaseName:  s.DatabaseName,
 		},
 		Prepare: func(ctx context.Context, deployment *services.KustomizeDeploymentContext) error {
 			instance, err := resources.FindNetworkInstanceInNetworkMappings(ctx, req.GetNetworkMappings(), s.TcpEndpoint, resources.NewPublicNetworkAccess())
 			if err != nil {
 				return err
+			}
+			if deployment.Profile == builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1 {
+				references, err := s.promotableSecretReferences(deployment.Kubernetes.GetSecretReferences())
+				if err != nil {
+					return err
+				}
+				deployment.Kubernetes.SecretReferences = references
+				promotableConfiguration = s.promotableConnectionConfiguration(instance)
+				return nil
 			}
 			configuration, err := s.CreateConnectionConfiguration(ctx, req.GetConfiguration(), instance, !s.Settings.WithoutSSL)
 			if err != nil {
@@ -210,6 +221,46 @@ func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) 
 			return deployment.ExportConfiguration(ctx, configuration)
 		},
 	})
+	if err != nil ||
+		response.GetState().GetState() != builderv0.DeploymentStatus_SUCCESS ||
+		promotableConfiguration == nil {
+		return response, err
+	}
+	response.Configuration = promotableConfiguration
+	return response, nil
+}
+
+func (s *Builder) promotableSecretReferences(
+	configured map[string]*builderv0.KubernetesSecretKeyReference,
+) (map[string]*builderv0.KubernetesSecretKeyReference, error) {
+	references := make(map[string]*builderv0.KubernetesSecretKeyReference, 5)
+	secretName := ""
+	for _, key := range []string{
+		"POSTGRES_USER",
+		"POSTGRES_PASSWORD",
+		"POSTGRES_READ_ONLY_PASSWORD",
+		"POSTGRES_READ_WRITE_PASSWORD",
+	} {
+		configurationKey := resources.ServiceSecretConfigurationKeyFromUnique(s.Unique(), "postgres", key)
+		reference := configured[configurationKey]
+		if reference == nil {
+			return nil, fmt.Errorf("Postgres GitOps rendering requires a typed Kubernetes Secret reference for %s", configurationKey)
+		}
+		if reference.GetOptional() {
+			return nil, fmt.Errorf("Postgres Secret reference for %s must not be optional", configurationKey)
+		}
+		if secretName == "" {
+			secretName = reference.GetName()
+		} else if reference.GetName() != secretName {
+			return nil, fmt.Errorf("Postgres credential references must use one Kubernetes Secret")
+		}
+		references[key] = reference
+	}
+	references[migrationConnectionEnvironmentKey] = &builderv0.KubernetesSecretKeyReference{
+		Name: secretName,
+		Key:  migrationConnectionEnvironmentKey,
+	}
+	return references, nil
 }
 
 type create struct {

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/codefly-dev/core/agents/services"
 	agenttesting "github.com/codefly-dev/core/agents/testing"
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	"github.com/codefly-dev/core/resources"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDeploymentTemplatesWithMigration(t *testing.T) {
@@ -15,6 +21,7 @@ func TestDeploymentTemplatesWithMigration(t *testing.T) {
 		ManagedImage:  image.FullName(),
 	})
 	assertMigrationResource(t, dir, true)
+	assertEphemeralSecret(t, dir)
 }
 
 func TestDeploymentTemplatesWithoutBootstrap(t *testing.T) {
@@ -22,6 +29,27 @@ func TestDeploymentTemplatesWithoutBootstrap(t *testing.T) {
 		ManagedImage: image.FullName(),
 	})
 	assertMigrationResource(t, dir, false)
+}
+
+func TestEphemeralDeploymentRetainsValueBasedConfigurationAndSecret(t *testing.T) {
+	builder, networkMappings := newDeploymentTestBuilder(t)
+	builder.DatabaseName = "accounts"
+	destination := t.TempDir()
+	request := promotableDeploymentRequest(destination, networkMappings, nil)
+	request.GetDeployment().GetKubernetes().Profile = builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_EPHEMERAL_LOCAL_APPLY_V1
+	request.Configuration = testPostgresConfiguration("migration-owner", "owner-secret", "reader-secret", "writer-secret")
+
+	response, err := builder.Deploy(context.Background(), request)
+	require.NoError(t, err)
+	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+	require.False(t, response.GetDeployment().GetKubernetes().GetValidation().GetPromotable())
+	require.NotEmpty(t, configurationValue(t, response.GetConfiguration(), ownerConnectionKey))
+
+	secret := readDeploymentFile(t, destination, "overlays", "test", "secret.yaml")
+	require.Contains(t, secret, "kind: Secret")
+	require.Contains(t, secret, "POSTGRES_PASSWORD: b3duZXItc2VjcmV0")
+	require.Contains(t, secret, "POSTGRES_READ_ONLY_PASSWORD: cmVhZGVyLXNlY3JldA==")
+	require.Contains(t, secret, "POSTGRES_READ_WRITE_PASSWORD: d3JpdGVyLXNlY3JldA==")
 }
 
 func assertMigrationResource(t *testing.T, dir string, expected bool) {
@@ -33,4 +61,234 @@ func assertMigrationResource(t *testing.T, dir string, expected bool) {
 	if got := strings.Contains(string(content), "- job.yaml"); got != expected {
 		t.Fatalf("migration resource present = %t, want %t:\n%s", got, expected, content)
 	}
+}
+
+func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSecrets(t *testing.T) {
+	builder, networkMappings := newDeploymentTestBuilder(t)
+	destination := t.TempDir()
+
+	response, err := builder.Deploy(context.Background(), promotableDeploymentRequest(
+		destination,
+		networkMappings,
+		promotablePostgresSecretReferences(),
+	))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	output := response.GetDeployment().GetKubernetes()
+	require.Equal(t, builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1, output.GetProfile())
+	require.Equal(t, services.KubernetesManifestContractVersion, output.GetContractVersion())
+	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_PASSED, output.GetValidation().GetStaticValidation())
+	require.Equal(t, builderv0.KubernetesManifestValidation_STATUS_NOT_RUN, output.GetValidation().GetServerSideValidation())
+	require.True(t, output.GetValidation().GetPromotable())
+
+	configuration := response.GetConfiguration()
+	require.Equal(t, builder.Unique(), configuration.GetOrigin())
+	require.Equal(t, resources.RuntimeContextFree, configuration.GetRuntimeContext().GetKind())
+	require.Len(t, configuration.GetInfos(), 1)
+	require.Equal(t, "postgres", configuration.GetInfos()[0].GetName())
+	values := configuration.GetInfos()[0].GetConfigurationValues()
+	require.Len(t, values, 2)
+	for _, key := range []string{readOnlyConnectionKey, readWriteConnectionKey} {
+		var matched *basev0.ConfigurationValue
+		for _, value := range values {
+			if value.GetKey() == key {
+				matched = value
+				break
+			}
+		}
+		require.NotNil(t, matched, "missing configuration value %q", key)
+		require.True(t, matched.GetSecret(), "configuration value %q is not secret", key)
+		require.Empty(t, matched.GetValue(), "configuration value %q leaked data", key)
+	}
+	for _, value := range values {
+		require.NotEqual(t, ownerConnectionKey, value.GetKey())
+	}
+
+	statefulSet := readDeploymentFile(t, destination, "base", "stateful-set.yaml")
+	for _, expected := range []string{
+		image.FullName(),
+		"name: POSTGRES_USER",
+		"name: POSTGRES_PASSWORD",
+		"name: POSTGRES_DB",
+		"optional: false",
+	} {
+		require.Contains(t, statefulSet, expected)
+	}
+	for _, unexpected := range []string{
+		"envFrom:",
+		"name: POSTGRES_READ_ONLY_PASSWORD",
+		"name: POSTGRES_READ_WRITE_PASSWORD",
+		"name: " + migrationConnectionEnvironmentKey,
+		"name: UNRELATED_SECRET",
+	} {
+		require.NotContains(t, statefulSet, unexpected)
+	}
+
+	job := readDeploymentFile(t, destination, "base", "job.yaml")
+	for _, expected := range []string{
+		"registry.example.com/module/postgres@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"name: POSTGRES_USER",
+		"name: POSTGRES_READ_ONLY_PASSWORD",
+		"name: POSTGRES_READ_WRITE_PASSWORD",
+		"name: " + migrationConnectionEnvironmentKey,
+		"optional: false",
+	} {
+		require.Contains(t, job, expected)
+	}
+	for _, unexpected := range []string{
+		"envFrom:",
+		"name: POSTGRES_PASSWORD",
+		"name: POSTGRES_DB",
+		"name: UNRELATED_SECRET",
+	} {
+		require.NotContains(t, job, unexpected)
+	}
+}
+
+func TestPromotableGitOpsDeploymentRejectsMissingOrOptionalRequiredSecretReferences(t *testing.T) {
+	required := []string{
+		"POSTGRES_USER",
+		"POSTGRES_PASSWORD",
+		"POSTGRES_DB",
+		"POSTGRES_READ_ONLY_PASSWORD",
+		"POSTGRES_READ_WRITE_PASSWORD",
+		migrationConnectionEnvironmentKey,
+	}
+	for _, environmentVariable := range required {
+		t.Run("missing/"+environmentVariable, func(t *testing.T) {
+			builder, networkMappings := newDeploymentTestBuilder(t)
+			references := promotablePostgresSecretReferences()
+			delete(references, environmentVariable)
+
+			response, err := builder.Deploy(context.Background(), promotableDeploymentRequest(
+				t.TempDir(),
+				networkMappings,
+				references,
+			))
+			require.NoError(t, err)
+			require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
+			require.Contains(t, response.GetState().GetMessage(), "requires a typed Kubernetes Secret reference for "+environmentVariable)
+			require.Nil(t, response.GetConfiguration())
+		})
+
+		t.Run("optional/"+environmentVariable, func(t *testing.T) {
+			builder, networkMappings := newDeploymentTestBuilder(t)
+			references := promotablePostgresSecretReferences()
+			references[environmentVariable].Optional = true
+
+			response, err := builder.Deploy(context.Background(), promotableDeploymentRequest(
+				t.TempDir(),
+				networkMappings,
+				references,
+			))
+			require.NoError(t, err)
+			require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
+			require.Contains(t, response.GetState().GetMessage(), environmentVariable+" Kubernetes Secret reference must not be optional")
+			require.Nil(t, response.GetConfiguration())
+		})
+	}
+}
+
+func newDeploymentTestBuilder(t *testing.T) (*Builder, []*basev0.NetworkMapping) {
+	t.Helper()
+	ctx := context.Background()
+	builder := NewBuilder()
+	identity := &basev0.ServiceIdentity{
+		Workspace: "workspace",
+		Module:    "module",
+		Name:      "postgres",
+		Version:   "1.2.3",
+	}
+	require.NoError(t, builder.HeadlessLoad(ctx, identity))
+	builder.Information = &services.Information{
+		Service: resources.ToServiceWithCase(builder.Identity),
+		Module:  resources.ToModuleWithCase(builder.Identity),
+	}
+	builder.EnvironmentVariables.SetIdentity(identity)
+	builder.TcpEndpoint = &basev0.Endpoint{
+		Name:    "tcp",
+		Module:  identity.Module,
+		Service: identity.Name,
+		Api:     "tcp",
+	}
+	instance := resources.NewNetworkInstance("postgres.example.com", 5432)
+	instance.Access = resources.NewPublicNetworkAccess()
+	return builder, []*basev0.NetworkMapping{{
+		Endpoint:  builder.TcpEndpoint,
+		Instances: []*basev0.NetworkInstance{instance},
+	}}
+}
+
+func promotableDeploymentRequest(
+	destination string,
+	networkMappings []*basev0.NetworkMapping,
+	secretReferences map[string]*builderv0.KubernetesSecretKeyReference,
+) *builderv0.DeploymentRequest {
+	const digest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	return &builderv0.DeploymentRequest{
+		Environment:     &basev0.Environment{Name: "test"},
+		NetworkMappings: networkMappings,
+		Deployment: &builderv0.Deployment{
+			Kind: &builderv0.Deployment_Kubernetes{
+				Kubernetes: &builderv0.KubernetesDeployment{
+					Namespace:        "codefly-test",
+					Destination:      destination,
+					BuildContext:     &builderv0.DockerBuildContext{DockerRepository: "registry.example.com", ImageDigest: digest},
+					Profile:          builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+					SecretReferences: secretReferences,
+				},
+			},
+		},
+	}
+}
+
+func promotablePostgresSecretReferences() map[string]*builderv0.KubernetesSecretKeyReference {
+	return map[string]*builderv0.KubernetesSecretKeyReference{
+		"POSTGRES_USER": {
+			Name: "postgres-stateful-set",
+			Key:  "username",
+		},
+		"POSTGRES_PASSWORD": {
+			Name: "postgres-stateful-set",
+			Key:  "password",
+		},
+		"POSTGRES_DB": {
+			Name: "postgres-stateful-set",
+			Key:  "database",
+		},
+		"POSTGRES_READ_ONLY_PASSWORD": {
+			Name: "postgres-bootstrap",
+			Key:  "read-only-password",
+		},
+		"POSTGRES_READ_WRITE_PASSWORD": {
+			Name: "postgres-bootstrap",
+			Key:  "read-write-password",
+		},
+		migrationConnectionEnvironmentKey: {
+			Name: "postgres-bootstrap",
+			Key:  "migration-connection",
+		},
+		"UNRELATED_SECRET": {
+			Name: "unrelated-secret",
+			Key:  "token",
+		},
+	}
+}
+
+func assertEphemeralSecret(t *testing.T, dir string) {
+	t.Helper()
+	require.Contains(t, readDeploymentFile(t, dir, "base", "kustomization.yaml"), "- namespace.yaml")
+	require.Contains(t, readDeploymentFile(t, dir, "base", "namespace.yaml"), "kind: Namespace")
+	require.Contains(t, readDeploymentFile(t, dir, "overlays", "test", "kustomization.yaml"), "- secret.yaml")
+	secret := readDeploymentFile(t, dir, "overlays", "test", "secret.yaml")
+	require.Contains(t, secret, "kind: Secret")
+	require.Contains(t, secret, "CODEFLY_TEST_SECRET: c2VjcmV0")
+}
+
+func readDeploymentFile(t *testing.T, directory string, elements ...string) string {
+	t.Helper()
+	content, err := os.ReadFile(filepath.Join(append([]string{directory}, elements...)...))
+	require.NoError(t, err)
+	return string(content)
 }

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -102,6 +102,13 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 		require.NotEqual(t, ownerConnectionKey, value.GetKey())
 	}
 
+	baseKustomization := readDeploymentFile(t, destination, "base", "kustomization.yaml")
+	require.NotContains(t, baseKustomization, "namespace.yaml")
+	overlayKustomization := readDeploymentFile(t, destination, "overlays", "test", "kustomization.yaml")
+	require.NotContains(t, overlayKustomization, "secret.yaml")
+	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "base", "namespace.yaml")))
+	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "overlays", "test", "secret.yaml")))
+
 	statefulSet := readDeploymentFile(t, destination, "base", "stateful-set.yaml")
 	for _, expected := range []string{
 		image.FullName(),

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/codefly-dev/core/agents/services"
 	agenttesting "github.com/codefly-dev/core/agents/testing"
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	"github.com/codefly-dev/core/resources"
 )
 
 func TestDeploymentTemplatesWithMigration(t *testing.T) {
@@ -22,6 +27,108 @@ func TestDeploymentTemplatesWithoutBootstrap(t *testing.T) {
 		ManagedImage: image.FullName(),
 	})
 	assertMigrationResource(t, dir, false)
+}
+
+func TestPromotableDeploymentUsesTypedSecretReferencesWithoutValues(t *testing.T) {
+	ctx := context.Background()
+	builder := NewBuilder()
+	identity := &basev0.ServiceIdentity{
+		Workspace: "workspace",
+		Module:    "module",
+		Name:      "store",
+		Version:   "1.2.3",
+	}
+	if err := builder.HeadlessLoad(ctx, identity); err != nil {
+		t.Fatal(err)
+	}
+	builder.DatabaseName = "users"
+	builder.Information = &services.Information{
+		Service: resources.ToServiceWithCase(builder.Identity),
+		Module:  resources.ToModuleWithCase(builder.Identity),
+	}
+	builder.TcpEndpoint = &basev0.Endpoint{
+		Name:    "tcp",
+		Module:  identity.Module,
+		Service: identity.Name,
+		Api:     "tcp",
+	}
+	instance := resources.NewNetworkInstance("store.platform.svc.cluster.local", 5432)
+	instance.Access = resources.NewPublicNetworkAccess()
+	secretReferences := make(map[string]*builderv0.KubernetesSecretKeyReference)
+	for _, key := range []string{
+		"POSTGRES_USER",
+		"POSTGRES_PASSWORD",
+		"POSTGRES_READ_ONLY_PASSWORD",
+		"POSTGRES_READ_WRITE_PASSWORD",
+	} {
+		configurationKey := resources.ServiceSecretConfigurationKeyFromUnique(builder.Unique(), "postgres", key)
+		secretReferences[configurationKey] = &builderv0.KubernetesSecretKeyReference{
+			Name: "store-secrets",
+			Key:  configurationKey,
+		}
+	}
+	destination := t.TempDir()
+
+	response, err := builder.Deploy(ctx, &builderv0.DeploymentRequest{
+		Environment: &basev0.Environment{Name: "local"},
+		NetworkMappings: []*basev0.NetworkMapping{{
+			Endpoint:  builder.TcpEndpoint,
+			Instances: []*basev0.NetworkInstance{instance},
+		}},
+		Deployment: &builderv0.Deployment{Kind: &builderv0.Deployment_Kubernetes{
+			Kubernetes: &builderv0.KubernetesDeployment{
+				Namespace:        "platform",
+				Destination:      destination,
+				Profile:          builderv0.KubernetesOutputProfile_KUBERNETES_OUTPUT_PROFILE_PROMOTABLE_GITOPS_V1,
+				SecretReferences: secretReferences,
+				BuildContext: &builderv0.DockerBuildContext{
+					DockerRepository: "registry.example.com",
+					ImageDigest:      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				},
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.GetState().GetState() != builderv0.DeploymentStatus_SUCCESS {
+		t.Fatalf("deployment failed: %s", response.GetState().GetMessage())
+	}
+	if !response.GetDeployment().GetKubernetes().GetValidation().GetPromotable() {
+		t.Fatal("deployment is not promotable")
+	}
+	for _, value := range response.GetConfiguration().GetInfos()[0].GetConfigurationValues() {
+		if !value.GetSecret() || value.GetValue() != "" {
+			t.Fatalf("exported connection contains a value: %+v", value)
+		}
+	}
+
+	tree := ""
+	for _, file := range []string{"stateful-set.yaml", "job.yaml"} {
+		content, readErr := os.ReadFile(filepath.Join(destination, "base", file))
+		if readErr != nil {
+			t.Fatal(readErr)
+		}
+		tree += string(content)
+	}
+	for _, expected := range []string{
+		"name: POSTGRES_USER",
+		"name: POSTGRES_PASSWORD",
+		"name: POSTGRES_READ_ONLY_PASSWORD",
+		"name: POSTGRES_READ_WRITE_PASSWORD",
+		"name: CODEFLY_POSTGRES_MIGRATION_CONNECTION",
+		"name: store-secrets",
+		`value: "users"`,
+	} {
+		if !strings.Contains(tree, expected) {
+			t.Errorf("manifest tree missing %q:\n%s", expected, tree)
+		}
+	}
+	for configurationKey := range secretReferences {
+		if strings.Contains(tree, "name: "+configurationKey) {
+			t.Errorf("manifest exposed configuration key %q as a runtime variable", configurationKey)
+		}
+	}
 }
 
 func assertMigrationResource(t *testing.T, dir string, expected bool) {

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.12
 toolchain go1.26.4
 
 require (
-	github.com/codefly-dev/core v0.2.51
+	github.com/codefly-dev/core v0.2.52
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.12.3

--- a/go.sum
+++ b/go.sum
@@ -34,8 +34,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.51 h1:DheTksUA9gqjipzAEoeBaV2LlR/IVHjfxzxXIAMm+bU=
-github.com/codefly-dev/core v0.2.51/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
+github.com/codefly-dev/core v0.2.52 h1:bHudneVK/yLMxEc163v9Hm590E1Z6x7HWkZVdoA3CIA=
+github.com/codefly-dev/core v0.2.52/go.mod h1:hHJm+wOsHxpxKn4UMiFqBrGy0BE56iby9yptfygbdR4=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/main.go
+++ b/main.go
@@ -141,6 +141,7 @@ func parseRuntimeImageLock(content []byte) (*resources.DockerImage, error) {
 type DeploymentTemplateParameters struct {
 	WithBootstrap bool
 	ManagedImage  string
+	DatabaseName  string
 }
 
 // defaultExtensions are CREATE EXTENSION'd on every start (best-effort). They
@@ -288,6 +289,21 @@ func (s *Service) CreateConnectionConfiguration(ctx context.Context, conf *basev
 		},
 	}
 	return outputConf, nil
+}
+
+func (s *Service) promotableConnectionConfiguration(instance *basev0.NetworkInstance) *basev0.Configuration {
+	return &basev0.Configuration{
+		Origin:         s.Base.Unique(),
+		RuntimeContext: resources.RuntimeContextFromInstance(instance),
+		Infos: []*basev0.ConfigurationInformation{{
+			Name: "postgres",
+			ConfigurationValues: []*basev0.ConfigurationValue{
+				{Key: ownerConnectionKey, Secret: true},
+				{Key: readOnlyConnectionKey, Secret: true},
+				{Key: readWriteConnectionKey, Secret: true},
+			},
+		}},
+	}
 }
 
 func postgresConnectionString(address, database, user, password string, withSSL bool) string {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/codefly-dev/core/builders"
 	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
 	agentv0 "github.com/codefly-dev/core/generated/go/codefly/services/agent/v0"
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
 	"github.com/codefly-dev/core/resources"
 	runnersbase "github.com/codefly-dev/core/runners/base"
 	"github.com/codefly-dev/core/shared"
@@ -139,8 +140,10 @@ func parseRuntimeImageLock(content []byte) (*resources.DockerImage, error) {
 }
 
 type DeploymentTemplateParameters struct {
-	WithBootstrap bool
-	ManagedImage  string
+	WithBootstrap                bool
+	ManagedImage                 string
+	StatefulSetSecretReferences  map[string]*builderv0.KubernetesSecretKeyReference
+	BootstrapJobSecretReferences map[string]*builderv0.KubernetesSecretKeyReference
 }
 
 // defaultExtensions are CREATE EXTENSION'd on every start (best-effort). They
@@ -275,7 +278,7 @@ func (s *Service) CreateConnectionConfiguration(ctx context.Context, conf *basev
 	readWriteConnection := postgresConnectionString(instance.Address, s.DatabaseName, readWriteRole, s.readWritePassword, withSSL)
 
 	outputConf := &basev0.Configuration{
-		Origin:         s.Base.Unique(),
+		Origin:         s.Unique(),
 		RuntimeContext: resources.RuntimeContextFromInstance(instance),
 		Infos: []*basev0.ConfigurationInformation{
 			{Name: "postgres",
@@ -288,6 +291,25 @@ func (s *Service) CreateConnectionConfiguration(ctx context.Context, conf *basev
 		},
 	}
 	return outputConf, nil
+}
+
+// promotableConnectionConfiguration describes the capability-scoped handoff
+// without embedding credentials. The migration owner remains private to the
+// bootstrap Job and is never advertised to dependent workloads.
+func (s *Service) promotableConnectionConfiguration(instance *basev0.NetworkInstance) *basev0.Configuration {
+	return &basev0.Configuration{
+		Origin:         s.Unique(),
+		RuntimeContext: resources.RuntimeContextFromInstance(instance),
+		Infos: []*basev0.ConfigurationInformation{
+			{
+				Name: "postgres",
+				ConfigurationValues: []*basev0.ConfigurationValue{
+					{Key: readOnlyConnectionKey, Secret: true},
+					{Key: readWriteConnectionKey, Secret: true},
+				},
+			},
+		},
+	}
 }
 
 func postgresConnectionString(address, database, user, password string, withSSL bool) string {

--- a/templates/deployment/kustomize/base/job.yaml.tmpl
+++ b/templates/deployment/kustomize/base/job.yaml.tmpl
@@ -34,15 +34,15 @@ spec:
           envFrom:
             - secretRef:
                 name: secret-{{ .Service.Name.DNSCase }}
-{{- end }}
-{{- if .GitOps }}
+{{- else }}
           env:
-{{- range $key, $reference := .SecretReferences }}
-            - name: {{ $key }}
+{{- range $environmentVariable, $reference := .Deployment.Parameters.BootstrapJobSecretReferences }}
+            - name: {{ $environmentVariable }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $reference.Name }}
                   key: {{ $reference.Key }}
+                  optional: {{ $reference.Optional }}
 {{- end }}
 {{- end }}
           resources:

--- a/templates/deployment/kustomize/base/job.yaml.tmpl
+++ b/templates/deployment/kustomize/base/job.yaml.tmpl
@@ -37,6 +37,8 @@ spec:
 {{- end }}
 {{- if .GitOps }}
           env:
+            - name: POSTGRES_DB
+              value: "{{ .Deployment.Parameters.DatabaseName }}"
 {{- range $key, $reference := .SecretReferences }}
             - name: {{ $key }}
               valueFrom:

--- a/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
+++ b/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
@@ -63,15 +63,15 @@ spec:
           envFrom:
             - secretRef:
                 name: secret-{{ .Service.Name.DNSCase }}
-{{- end }}
-{{- if .GitOps }}
+{{- else }}
           env:
-{{- range $key, $reference := .SecretReferences }}
-            - name: {{ $key }}
+{{- range $environmentVariable, $reference := .Deployment.Parameters.StatefulSetSecretReferences }}
+            - name: {{ $environmentVariable }}
               valueFrom:
                 secretKeyRef:
                   name: {{ $reference.Name }}
                   key: {{ $reference.Key }}
+                  optional: {{ $reference.Optional }}
 {{- end }}
 {{- end }}
           # Modest defaults — tune in overlay per-tenant. The PSS

--- a/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
+++ b/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
@@ -66,6 +66,8 @@ spec:
 {{- end }}
 {{- if .GitOps }}
           env:
+            - name: POSTGRES_DB
+              value: "{{ .Deployment.Parameters.DatabaseName }}"
 {{- range $key, $reference := .SecretReferences }}
             - name: {{ $key }}
               valueFrom:


### PR DESCRIPTION
Closes #21.

## Summary

- render promotable Postgres workloads from typed Kubernetes Secret references without receiving credential values
- keep the ephemeral local value-backed path unchanged and publish the corrected contract as v0.0.110

## Test plan

- [x] `go test ./... -count=1`
- [x] real promotable deploy boundary with value-free inputs
- [x] runtime image build, smoke test, publish, and verification gate