### PR TITLE
Initialize non-root Postgres data directory (#23)

### DIFF
--- a/deployment_test.go
+++ b/deployment_test.go
@@ -214,6 +214,8 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	statefulSet := readDeploymentFile(t, destination, "base", "stateful-set.yaml")
 	for _, expected := range []string{
 		image.FullName(),
+		"name: PGDATA",
+		"value: /var/lib/postgresql/data/pgdata",
 		"name: POSTGRES_USER",
 		"name: POSTGRES_PASSWORD",
 		"name: POSTGRES_DB",
@@ -224,6 +226,7 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	}
 	for _, unexpected := range []string{
 		"envFrom:",
+		"subPath: pgdata",
 		"name: POSTGRES_READ_ONLY_PASSWORD",
 		"name: POSTGRES_READ_WRITE_PASSWORD",
 		"name: " + migrationConnectionEnvironmentKey,

--- a/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
+++ b/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
@@ -59,12 +59,14 @@ spec:
           ports:
             - name: postgres
               containerPort: 5432
+          env:
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
 {{- if not .GitOps }}
           envFrom:
             - secretRef:
                 name: secret-{{ .Service.Name.DNSCase }}
 {{- else }}
-          env:
             - name: POSTGRES_DB
               value: "{{ .Deployment.Parameters.DatabaseName }}"
 {{- range $environmentVariable, $reference := .Deployment.Parameters.StatefulSetSecretReferences }}
@@ -114,10 +116,6 @@ spec:
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data
-              # subPath keeps init metadata out of the PV root — the
-              # official image refuses to start when /var/lib/postgresql/data
-              # contains a `lost+found` (which `ext4` PVs include).
-              subPath: pgdata
             - name: postgres-run
               mountPath: /var/run/postgresql
             - name: tmp


### PR DESCRIPTION
Closes #23.

## Summary

- Let the non-root PostgreSQL process create and own its `PGDATA` subdirectory on group-writable persistent volumes.
- Preserve restricted manifest conformance without a privileged volume-permission init container.

## Test plan

- [x] `go test ./...`
- [x] Verify promotable and ephemeral templates pass Kubernetes manifest conformance.
- [x] Lock `PGDATA` and absence of the root-created `subPath` in template tests.