### PR TITLE
Release Postgres agent v0.0.111

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.110
+version: 0.0.111


### PR DESCRIPTION
## Summary

- Publish the non-root persistent-volume initialization fix for promotable Kubernetes workloads.
- Make the corrected template available to Mind local GitOps qualification.

## Test plan

- [x] `go test ./...`
- [x] Verify the release commit signature.