### PR TITLE
Wait for Kubernetes Postgres readiness (#26)

### DIFF
--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -32,6 +32,12 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 			if !strings.Contains(dockerfile, "psql \"${"+migrationConnectionEnvironmentKey+"}\"") {
 				t.Fatal("bootstrap image does not always reconcile runtime roles")
 			}
+			if !strings.Contains(
+				dockerfile,
+				"until pg_isready -d \"${"+migrationConnectionEnvironmentKey+"}\" >/dev/null 2>&1; do sleep 2; done",
+			) {
+				t.Fatal("bootstrap image does not wait for Postgres readiness")
+			}
 			hasMigration := strings.Contains(dockerfile, "/usr/local/bin/migrate -path")
 			if hasMigration != test.withMigrations {
 				t.Fatalf("migration command present = %t, want %t", hasMigration, test.withMigrations)

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -234,6 +234,10 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	} {
 		require.NotContains(t, statefulSet, unexpected)
 	}
+	require.Equal(t, 3, strings.Count(
+		statefulSet,
+		`command: ["/bin/sh", "-ec", "exec pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]`,
+	))
 
 	job := readDeploymentFile(t, destination, "base", "job.yaml")
 	for _, expected := range []string{

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -14,5 +14,6 @@ COPY migrations /app/migrations
 COPY builder/runtime-access.sql /app/runtime-access.sql
 
 CMD set -eu; \
+    until pg_isready -d "${{.MigrationConnectionKeyHolder}}" >/dev/null 2>&1; do sleep 2; done; \
 {{ if .WithMigration }}    /usr/local/bin/migrate -path /app/migrations -database "${{.MigrationConnectionKeyHolder}}" up; \
 {{ end }}    psql "${{.MigrationConnectionKeyHolder}}" --no-psqlrc --set=ON_ERROR_STOP=1 --file=/app/runtime-access.sql

--- a/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
+++ b/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
@@ -89,8 +89,9 @@ spec:
               cpu: "1"
               memory: 1Gi
           # pg_isready is the canonical "is postgres accepting
-          # connections" check. Without -U the env-injected user
-          # is implied. Probes intentionally separated:
+          # connections" check. The shell resolves the secret-backed
+          # database owner and declared database at probe time.
+          # Probes intentionally separated:
           #   startup:    grants up to 60s for first-boot init
           #               (which can run schema migrations).
           #   readiness:  takes the pod out of the Service if
@@ -99,17 +100,17 @@ spec:
           #               momentary connection saturation.
           startupProbe:
             exec:
-              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+              command: ["/bin/sh", "-ec", "exec pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
             periodSeconds: 5
             failureThreshold: 12
           readinessProbe:
             exec:
-              command: ["pg_isready", "-U", "$(POSTGRES_USER)", "-d", "$(POSTGRES_DB)"]
+              command: ["/bin/sh", "-ec", "exec pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
             periodSeconds: 10
             timeoutSeconds: 3
           livenessProbe:
             exec:
-              command: ["pg_isready", "-U", "$(POSTGRES_USER)"]
+              command: ["/bin/sh", "-ec", "exec pg_isready -U \"$POSTGRES_USER\" -d \"$POSTGRES_DB\""]
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3


### PR DESCRIPTION
Closes #26.

## Summary

- Resolve secret-backed probe identities through a shell so non-default Postgres owners become Ready.
- Keep migration bootstrap pending until first-boot Postgres accepts connections instead of exhausting Job retries.

## Test plan

- [x] `go test ./...`
- [x] Generated promotable probes use the injected database owner and database.
- [x] Bootstrap Dockerfile waits before migrations and runtime-role reconciliation.