### PR TITLE
Release Postgres agent v0.0.112 (#26)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.111
+version: 0.0.112


### PR DESCRIPTION
Closes #26.

## Summary

- Publish the Kubernetes readiness fix as an exact agent version for downstream GitOps generation.

## Test plan

- [x] `go test ./...`
- [x] Upstream fix PR CI passed.