### PR TITLE
Label migration Jobs for network policies (#29)

### DIFF
--- a/deployment_test.go
+++ b/deployment_test.go
@@ -252,6 +252,7 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	} {
 		require.Contains(t, job, expected)
 	}
+	require.Equal(t, 2, strings.Count(job, "app: postgres"))
 	for _, unexpected := range []string{
 		"envFrom:",
 		"name: POSTGRES_PASSWORD",

--- a/templates/deployment/kustomize/base/job.yaml.tmpl
+++ b/templates/deployment/kustomize/base/job.yaml.tmpl
@@ -3,11 +3,15 @@ kind: Job
 metadata:
   name: {{ .Service.Name.DNSCase }}
   namespace: {{ .Namespace }}
+  labels:
+    app: {{ .Service.Name.DNSCase }}
 spec:
   ttlSecondsAfterFinished: 0
   backoffLimit: 4
   template:
     metadata:
+      labels:
+        app: {{ .Service.Name.DNSCase }}
       annotations:
         sidecar.istio.io/inject: "false"
     spec:


### PR DESCRIPTION
Closes #29.

## Summary
- Give migration Jobs the same stable service identity as their database so default-deny consumers can authorize the bootstrap path exactly.
- Cover both Job and pod-template labels in generated deployment tests.

## Test plan
- [x] `go test ./...`
- [x] `git diff --check`