### PR TITLE
Separate Postgres bootstrap identity (#32)

### DIFF
--- a/deployment_test.go
+++ b/deployment_test.go
@@ -252,7 +252,8 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	} {
 		require.Contains(t, job, expected)
 	}
-	require.Equal(t, 2, strings.Count(job, "app: postgres"))
+	require.Equal(t, 2, strings.Count(job, "codefly.dev/bootstrap-service: postgres"))
+	require.NotContains(t, job, "app: postgres")
 	for _, unexpected := range []string{
 		"envFrom:",
 		"name: POSTGRES_PASSWORD",

--- a/templates/deployment/kustomize/base/job.yaml.tmpl
+++ b/templates/deployment/kustomize/base/job.yaml.tmpl
@@ -4,14 +4,14 @@ metadata:
   name: {{ .Service.Name.DNSCase }}
   namespace: {{ .Namespace }}
   labels:
-    app: {{ .Service.Name.DNSCase }}
+    codefly.dev/bootstrap-service: {{ .Service.Name.DNSCase }}
 spec:
   ttlSecondsAfterFinished: 0
   backoffLimit: 4
   template:
     metadata:
       labels:
-        app: {{ .Service.Name.DNSCase }}
+        codefly.dev/bootstrap-service: {{ .Service.Name.DNSCase }}
       annotations:
         sidecar.istio.io/inject: "false"
     spec:


### PR DESCRIPTION
Closes #32.

## Summary

- Prevents the migration Job from joining the headless Postgres Service endpoints.
- Exposes a dedicated bootstrap-service identity for least-privilege NetworkPolicy selection.

## Test plan

- [x] `go test ./...`
- [x] `git diff --check`
- [x] Signed commit verified with `git verify-commit HEAD`
