### PR TITLE
Release Postgres agent v0.0.114 (#32)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.113
+version: 0.0.114


### PR DESCRIPTION
## Summary

- Publishes the migration Job endpoint-separation fix as an immutable Postgres agent release.
- Lets GitOps consumers bind bootstrap policy without adding migration pods to database Service endpoints.

## Test plan

- [x] `go test ./...`
- [x] `git diff --check`
- [x] Signed release commit verified with `git verify-commit HEAD`
