### PR TITLE
Refresh Postgres migration runtime (#35)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.114
+version: 0.0.115

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -38,6 +38,9 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 			) {
 				t.Fatal("bootstrap image does not wait for Postgres readiness")
 			}
+			if !strings.Contains(dockerfile, "/releases/download/v4.19.1/migrate.linux-amd64.tar.gz") {
+				t.Fatal("bootstrap image does not pin the supported migration runtime")
+			}
 			hasMigration := strings.Contains(dockerfile, "/usr/local/bin/migrate -path")
 			if hasMigration != test.withMigrations {
 				t.Fatalf("migration command present = %t, want %t", hasMigration, test.withMigrations)

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -3,7 +3,7 @@ FROM alpine:3.21
 WORKDIR /app
 
 RUN apk add --no-cache curl postgresql17-client
-RUN curl -L https://github.com/golang-migrate/migrate/releases/download/v4.15.0/migrate.linux-amd64.tar.gz | tar xvz
+RUN curl -L https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-amd64.tar.gz | tar xvz
 RUN mv migrate /usr/local/bin/migrate
 
 COPY . .


### PR DESCRIPTION
Closes #35.

## Summary

- Replaces the obsolete migration binary whose Go runtime crashes in supported k3d environments.
- Pins generated bootstrap images to the same current `golang-migrate` release used by the agent library.
- Publishes the fix as an immutable Postgres agent patch for downstream GitOps snapshots.

## Test plan

- [x] `go test ./...`
- [x] `git diff --check`
- [x] Signed release commit verified with `git verify-commit`
- [x] Live Mind k3d topology reproduced the v4.15.0 runtime crash after successful PostgreSQL connectivity
