### PR TITLE
Keep GitOps migration jobs observable (#37)

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.115
+version: 0.0.116

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -254,6 +254,7 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	}
 	require.Equal(t, 2, strings.Count(job, "codefly.dev/bootstrap-service: postgres"))
 	require.NotContains(t, job, "app: postgres")
+	require.NotContains(t, job, "ttlSecondsAfterFinished")
 	for _, unexpected := range []string{
 		"envFrom:",
 		"name: POSTGRES_PASSWORD",

--- a/templates/deployment/kustomize/base/job.yaml.tmpl
+++ b/templates/deployment/kustomize/base/job.yaml.tmpl
@@ -6,7 +6,6 @@ metadata:
   labels:
     codefly.dev/bootstrap-service: {{ .Service.Name.DNSCase }}
 spec:
-  ttlSecondsAfterFinished: 0
   backoffLimit: 4
   template:
     metadata:


### PR DESCRIPTION
Closes #37.

## Summary

- Keep completed migration Jobs available so Argo CD can retain durable health evidence.
- Release the corrected template as Postgres agent 0.0.116.

## Test plan

- [x] `GOWORK=off go test ./...`
- [x] Verify the rendered GitOps Job omits immediate TTL cleanup.