### PR TITLE
fix: isolate Nix Postgres state by naming scope

### DIFF
--- a/nixpg.go
+++ b/nixpg.go
@@ -75,19 +75,16 @@ type nixPostgres struct {
 // whose runtime state (data dir, nix cache, flake, unix socket) lives ENTIRELY
 // OUTSIDE the user's source tree.
 //
-// baseDir is the agent's service location, which normally sits inside the
-// workspace repo. That repo is later consumed as a nix flake `path:` input when
-// codefly builds dependent services — and a unix socket left under it aborts
-// the flake fetch ("file ... has an unsupported type"), while a churning data
-// dir busts the flake eval cache. So we root everything in a stable per-service
-// runtime dir under the user cache dir, keyed by a hash of baseDir so a restart
-// of the same service reuses the same cluster (data persists like a Docker
-// volume) without ever touching the source tree.
-func newNixPostgres(ctx context.Context, baseDir string, port uint16, user, password, dbName, logLevel string, out io.Writer) (*nixPostgres, error) {
+// stateKey is derived from the agent's service location and the authoritative
+// Codefly naming scope. The source repo is later consumed as a nix flake `path:`
+// input, so runtime state cannot live below it. The scoped key also prevents
+// independent Codefly flows from sharing credentials or database contents,
+// while an unscoped restart retains the historical per-location cluster.
+func newNixPostgres(ctx context.Context, stateKey string, port uint16, user, password, dbName, logLevel string, out io.Writer) (*nixPostgres, error) {
 	if strings.TrimSpace(password) == "" {
 		return nil, fmt.Errorf("postgres password is required for the native runtime")
 	}
-	runtimeRoot, err := nixRuntimeRoot(baseDir)
+	runtimeRoot, err := nixRuntimeRoot(stateKey)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +107,7 @@ func newNixPostgres(ctx context.Context, baseDir string, port uint16, user, pass
 	// The unix socket path has a ~104-char limit, so it cannot live under a deep
 	// cache path. Use an unpredictable, owner-only temporary directory: a stable
 	// /tmp name can be pre-created or symlinked by another local user.
-	socketDir, err := os.MkdirTemp("", "cfpg-"+serviceHash(baseDir)[:8]+"-")
+	socketDir, err := os.MkdirTemp("", "cfpg-"+serviceHash(stateKey)[:8]+"-")
 	if err != nil {
 		return nil, fmt.Errorf("create postgres socket dir: %w", err)
 	}
@@ -132,23 +129,33 @@ func newNixPostgres(ctx context.Context, baseDir string, port uint16, user, pass
 	}, nil
 }
 
-// serviceHash is the hex sha256 of a service's base dir — a stable key that
-// maps a service location to its out-of-tree runtime dirs.
-func serviceHash(baseDir string) string {
-	sum := sha256.Sum256([]byte(baseDir))
+// nixPostgresStateKey preserves the existing unscoped data location while
+// making Codefly's advanced naming-scope isolation apply equally to the Nix
+// and Docker Postgres runtimes. The separator is unambiguous and the resulting
+// value is hashed before it is used as a filesystem component.
+func nixPostgresStateKey(serviceLocation, namingScope string) string {
+	if namingScope == "" {
+		return serviceLocation
+	}
+	return serviceLocation + "\x00naming-scope\x00" + namingScope
+}
+
+// serviceHash is the hex sha256 of a service's scoped state key.
+func serviceHash(stateKey string) string {
+	sum := sha256.Sum256([]byte(stateKey))
 	return hex.EncodeToString(sum[:])
 }
 
 // nixRuntimeRoot is the stable, out-of-source runtime root for a postgres
-// service (data dir, nix cache, flake), keyed by a hash of its agent location
-// so restarts reuse the same cluster. Falls back to the OS temp dir if no user
-// cache dir is available.
-func nixRuntimeRoot(baseDir string) (string, error) {
+// service (data dir, nix cache, flake), keyed by its scoped state identity so
+// same-scope restarts reuse the cluster without crossing isolation scopes.
+// Falls back to the OS temp dir if no user cache dir is available.
+func nixRuntimeRoot(stateKey string) (string, error) {
 	cache, err := os.UserCacheDir()
 	if err != nil {
 		cache = os.TempDir()
 	}
-	return filepath.Join(cache, "codefly", "postgres", serviceHash(baseDir)[:16]), nil
+	return filepath.Join(cache, "codefly", "postgres", serviceHash(stateKey)[:16]), nil
 }
 
 // Init materializes the nix env, initdb's the cluster on first boot, launches

--- a/nixpg_scope_test.go
+++ b/nixpg_scope_test.go
@@ -1,0 +1,27 @@
+package main
+
+import "testing"
+
+func TestNixPostgresStateKeyPreservesUnscopedIdentity(t *testing.T) {
+	const location = "/workspace/modules/infra/services/postgres"
+	if got := nixPostgresStateKey(location, ""); got != location {
+		t.Fatalf("unscoped state key = %q, want existing location %q", got, location)
+	}
+}
+
+func TestNixPostgresStateKeySeparatesNamingScopes(t *testing.T) {
+	const location = "/workspace/modules/infra/services/postgres"
+	first := nixPostgresStateKey(location, "qualification-a")
+	repeated := nixPostgresStateKey(location, "qualification-a")
+	second := nixPostgresStateKey(location, "qualification-b")
+
+	if first != repeated {
+		t.Fatalf("same naming scope produced unstable keys %q and %q", first, repeated)
+	}
+	if first == second {
+		t.Fatalf("different naming scopes shared state key %q", first)
+	}
+	if serviceHash(first) == serviceHash(second) {
+		t.Fatal("different naming scopes shared the same runtime-root hash")
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -150,7 +150,7 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 	// database as the Docker path, so the rest of the agent is unchanged.
 	if rc := req.GetRuntimeContext(); rc != nil && rc.Kind == resources.RuntimeContextNix {
 		w.Debug("using nix runtime for postgres", wool.Field("port", instance.Port))
-		nixpg, errNix := newNixPostgres(ctx, s.Location, uint16(instance.Port),
+		nixpg, errNix := newNixPostgres(ctx, nixPostgresStateKey(s.Location, s.Environment.NamingScope), uint16(instance.Port),
 			s.postgresUser, s.postgresPassword, s.DatabaseName, s.LogLevel, newPGLogWriter(s.Wool))
 		if errNix != nil {
 			return s.Runtime.InitError(errNix)


### PR DESCRIPTION
## Outcome

Nix Postgres now applies the same Codefly naming-scope isolation contract as Docker persistent mounts. Unscoped runs retain their existing state root; same-scope restarts remain stable; different scopes cannot share pgdata, flake/Nix cache, or socket identity.

Closes #44.

## Production evidence

The Mind production headless workflow exposed the defect: a new scoped flow reused an old Nix cluster and failed readiness for 30 seconds with password authentication errors.

With this candidate installed through codefly agent build:

- issue44-scope-a initialized and ran from root hash 54dcb27108ae2e69;
- issue44-scope-b initialized and ran independently from 6f76304d680c58f1;
- restarting issue44-scope-a reused 54dcb27108ae2e69 and reached Running in 700 ms without initdb.

## Verification

- codefly agent ci --dir . --native-only --skip-audit: 5 passed, 0 failed
- codefly agent build --dir . --native-only --skip-audit
- exact standalone Nix Codefly flows above with temporary ports and real migrations

No Mind workaround, credential copy, destructive cache cleanup, or compatibility branch was added.