### PR TITLE
release: v0.0.119

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.118
+version: 0.0.119


### PR DESCRIPTION
Publishes the Nix naming-scope isolation fix from #45 as the next immutable Codefly Postgres agent version.

- `codefly agent build --dir . --native-only --skip-audit` passed
- candidate two-scope and same-scope production flows passed

After merge, tag `v0.0.119` will publish the reviewed agent for Mind to pin.