### PR TITLE
release: v0.0.121

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.120
+version: 0.0.121


### PR DESCRIPTION
Publishes the current Core process-record contract from #49 as the next immutable Codefly Postgres agent version.

- all service-postgres tests and vet passed on the dependency change
- canonical `codefly agent build` packaged `postgres:0.0.121`
- vulnerability audit reports only two already-tracked upstream Moby advisories with no available fix
- Mind's real Postgres-backed `TestCodeIntelTools_OverRealGraph` passed and left no stale process records

After merge, tag `v0.0.121` will publish the reviewed agent for Mind to pin.

