### PR TITLE
feat: add scoped temporary bulk copy

### DIFF
--- a/libs/go/store.go
+++ b/libs/go/store.go
@@ -139,6 +139,12 @@ type ReadTx interface {
 type WriteTx interface {
 	ReadTx
 	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	// CopyIntoTemporaryTable streams rows into a transaction-local staging
+	// table. The destination is always resolved through pg_temp, so bulk
+	// loading cannot bypass the scoped transaction's RLS-protected durable
+	// writes. Applications create the temporary table with Exec, stream into
+	// it here, then publish with an ordinary INSERT ... SELECT.
+	CopyIntoTemporaryTable(context.Context, string, []string, pgx.CopyFromSource) (int64, error)
 	ScopedAdvisoryLock(context.Context, string, ...string) error
 }
 
@@ -358,6 +364,7 @@ type transaction interface {
 	Query(context.Context, string, ...any) (pgx.Rows, error)
 	QueryRow(context.Context, string, ...any) pgx.Row
 	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	CopyFrom(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error)
 	Commit(context.Context) error
 	Rollback(context.Context) error
 }
@@ -397,6 +404,27 @@ func (w writeTx) QueryRow(ctx context.Context, sql string, arguments ...any) pgx
 
 func (w writeTx) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
 	return w.tx.Exec(ctx, sql, arguments...)
+}
+
+// CopyIntoTemporaryTable exposes pgx's bounded streaming copy path without
+// exposing arbitrary COPY destinations. pg_temp is connection-local, and the
+// surrounding transaction remains the only route from staging data into a
+// durable, tenant-scoped relation.
+func (w writeTx) CopyIntoTemporaryTable(ctx context.Context, table string, columns []string, source pgx.CopyFromSource) (int64, error) {
+	table = strings.TrimSpace(table)
+	if ctx == nil || w.tx == nil || table == "" || len(columns) == 0 || source == nil {
+		return 0, errors.New("scoped Postgres temporary copy requires a transaction, context, table, columns, and source")
+	}
+	for _, column := range columns {
+		if strings.TrimSpace(column) == "" {
+			return 0, errors.New("scoped Postgres temporary copy columns cannot be empty")
+		}
+	}
+	rows, err := w.tx.CopyFrom(ctx, pgx.Identifier{"pg_temp", table}, columns, source)
+	if err != nil {
+		return rows, fmt.Errorf("copy into scoped Postgres temporary table %q: %w", table, err)
+	}
+	return rows, nil
 }
 
 // ScopedAdvisoryLock serializes a logical resource inside the authenticated

--- a/libs/go/store_test.go
+++ b/libs/go/store_test.go
@@ -84,6 +84,64 @@ func TestWriterBindsScopeAndExposesMutation(t *testing.T) {
 	}
 }
 
+func TestWriterStreamsBulkRowsOnlyIntoTemporarySchema(t *testing.T) {
+	writeBackend := &fakeBeginner{tx: &fakeTransaction{}}
+	factory := newTestFactory(t, &fakeBeginner{tx: &fakeTransaction{}}, writeBackend, fakeAuthenticator{
+		principal: testPrincipal{tenant: "tenant-b", user: "user-b"},
+	})
+
+	writer, err := factory.Writer(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	rows := [][]any{{"one", int64(1)}, {"two", int64(2)}}
+	if err := writer.InTransaction(context.Background(), func(ctx context.Context, tx WriteTx) error {
+		copied, copyErr := tx.CopyIntoTemporaryTable(ctx, "publication_stage", []string{"id", "sequence"}, pgx.CopyFromRows(rows))
+		if copyErr != nil {
+			return copyErr
+		}
+		if copied != int64(len(rows)) {
+			t.Fatalf("copied rows = %d, want %d", copied, len(rows))
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	copy := writeBackend.tx.copies[0]
+	if got, want := copy.table.Sanitize(), `"pg_temp"."publication_stage"`; got != want {
+		t.Fatalf("copy destination = %s, want %s", got, want)
+	}
+	if !reflect.DeepEqual(copy.columns, []string{"id", "sequence"}) || !reflect.DeepEqual(copy.rows, rows) {
+		t.Fatalf("copy = %#v, want columns and rows %#v / %#v", copy, []string{"id", "sequence"}, rows)
+	}
+}
+
+func TestWriterRejectsIncompleteTemporaryCopy(t *testing.T) {
+	writeBackend := &fakeBeginner{tx: &fakeTransaction{}}
+	factory := newTestFactory(t, &fakeBeginner{tx: &fakeTransaction{}}, writeBackend, fakeAuthenticator{
+		principal: testPrincipal{tenant: "tenant-b", user: "user-b"},
+	})
+	writer, err := factory.Writer(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.InTransaction(context.Background(), func(ctx context.Context, tx WriteTx) error {
+		if _, copyErr := tx.CopyIntoTemporaryTable(ctx, "", []string{"id"}, pgx.CopyFromRows(nil)); copyErr == nil {
+			t.Fatal("temporary copy accepted an empty table")
+		}
+		if _, copyErr := tx.CopyIntoTemporaryTable(ctx, "stage", []string{""}, pgx.CopyFromRows(nil)); copyErr == nil {
+			t.Fatal("temporary copy accepted an empty column")
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(writeBackend.tx.copies) != 0 {
+		t.Fatal("invalid temporary copy reached Postgres")
+	}
+}
+
 func TestRequireTenantAndUserValidateArtifactScopeWithoutDatabaseAccess(t *testing.T) {
 	readerBackend := &fakeBeginner{tx: &fakeTransaction{}}
 	writerBackend := &fakeBeginner{tx: &fakeTransaction{}}
@@ -379,8 +437,15 @@ type execution struct {
 	arguments []any
 }
 
+type copiedRows struct {
+	table   pgx.Identifier
+	columns []string
+	rows    [][]any
+}
+
 type fakeTransaction struct {
 	executions    []execution
+	copies        []copiedRows
 	execError     error
 	committed     bool
 	commitError   error
@@ -398,6 +463,22 @@ func (t *fakeTransaction) QueryRow(context.Context, string, ...any) pgx.Row {
 func (t *fakeTransaction) Exec(_ context.Context, statement string, arguments ...any) (pgconn.CommandTag, error) {
 	t.executions = append(t.executions, execution{statement: statement, arguments: arguments})
 	return pgconn.CommandTag{}, t.execError
+}
+
+func (t *fakeTransaction) CopyFrom(_ context.Context, table pgx.Identifier, columns []string, source pgx.CopyFromSource) (int64, error) {
+	copy := copiedRows{table: append(pgx.Identifier(nil), table...), columns: append([]string(nil), columns...)}
+	for source.Next() {
+		values, err := source.Values()
+		if err != nil {
+			return 0, err
+		}
+		copy.rows = append(copy.rows, append([]any(nil), values...))
+	}
+	if err := source.Err(); err != nil {
+		return 0, err
+	}
+	t.copies = append(t.copies, copy)
+	return int64(len(copy.rows)), nil
 }
 
 func (t *fakeTransaction) Commit(context.Context) error {


### PR DESCRIPTION
## What changed

- expose pgx streaming COPY only to the transaction-local `pg_temp` schema
- preserve the authenticated scoped transaction as the only path into durable RLS relations
- validate incomplete bulk-copy requests before they reach Postgres

## Why

Mind's production semantic publisher currently converts tens of thousands of 1024-dimensional vectors into repository-sized JSON payloads before `jsonb_to_recordset`. A live Django harness run reached ~4.26 GB RSS while publishing 43,330 retrieval rows. This generic scoped primitive lets consumers stream into a temporary staging table, then publish with an ordinary tenant-checked `INSERT ... SELECT`.

## Verification

- `GOWORK=off go test ./libs/go/... -count=1`
- `GOWORK=off go vet ./libs/go/...`
- `git diff --check`
