### PR TITLE
release: v0.0.123

### DIFF
--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.122
+version: 0.0.123

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,10 @@ module github.com/codefly-dev/service-postgres
 
 go 1.25.12
 
-toolchain go1.26.5
+toolchain go1.26.6
 
 require (
-	github.com/codefly-dev/core v0.2.107
+	github.com/codefly-dev/core v0.2.121
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.9.2
 	github.com/lib/pq v1.12.3

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.2.107 h1:ApD/FcSa+HGGol9jdXG841KXrkK6B2aUgSODk1x/0Ss=
-github.com/codefly-dev/core v0.2.107/go.mod h1:e3xNBpBgMOzraxGaFbbiYtMYyhLAEoP7Cy2yaMrvV5U=
+github.com/codefly-dev/core v0.2.121 h1:6eyWST/xrOKHHb+P/HRdeoBSkXNKWiktW9o4hPO7Upc=
+github.com/codefly-dev/core v0.2.121/go.mod h1:xW44cPm2/OYlmRWAN2+AjOzetJ1AFBjeupS5djsJbq4=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=


### PR DESCRIPTION
## Summary
- consume Core v0.2.121 so Postgres agent processes use the authenticated-v1 registry namespace
- move the agent toolchain to Go 1.26.6
- release Postgres agent v0.0.123

## Validation
- \`GOWORK=off go test ./... -count=1\`
- \`git diff --check\`