### PR TITLE
fix: supervise nix postgres so a mid-run death fails codefly loudly (codefly-dev/cli#380)

### DIFF
--- a/nixpg.go
+++ b/nixpg.go
@@ -335,6 +335,45 @@ func (n *nixPostgres) startServer(ctx context.Context) error {
 	return nil
 }
 
+// Supervise watches the running postgres process after startup and invokes
+// onExit exactly once if the postmaster terminates for any reason OTHER than a
+// deliberate Stop. The Nix runtime is a host process the agent owns directly:
+// without this the postmaster can exit mid-run (crash, an external SIGTERM, an
+// invalidated data-directory lock) while the agent keeps reporting STARTED,
+// leaving codefly's Follow loop blind and every dependent wedged on connection
+// refused (codefly-dev/cli#380). This mirrors the user-binary supervision
+// service-go performs by feeding the exit into MarkRunnerExited.
+//
+// Call it once, after a successful Init/Start: startServer has populated
+// serverExit and serverCtx, and waitReady has finished observing serverExit, so
+// this goroutine is the sole remaining reader of the channel.
+func (n *nixPostgres) Supervise(onExit func(error)) {
+	exit := n.serverExit
+	if exit == nil {
+		return
+	}
+	// Stop cancels serverCtx before terminating the process, so a cancelled
+	// context is the authoritative "this shutdown was orderly" signal.
+	var stopped <-chan struct{}
+	if n.serverCtx != nil {
+		stopped = n.serverCtx.Done()
+	}
+	go func() {
+		err, ok := <-exit
+		if !ok {
+			return
+		}
+		if stopped != nil {
+			select {
+			case <-stopped:
+				return
+			default:
+			}
+		}
+		onExit(err)
+	}()
+}
+
 // adminDSN reaches this runtime's private Unix socket. Bootstrap work must not
 // use the public TCP mapping: another backend or stale process can still own
 // that port, and accepting its successful ping would authenticate, migrate,

--- a/nixpg_supervise_test.go
+++ b/nixpg_supervise_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"testing"
 	"time"
+
+	"github.com/codefly-dev/core/agents/services"
+	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
 )
 
 // awaitCallback returns the error Supervise reported, or (nil,false) if nothing
@@ -88,4 +91,91 @@ func TestSuperviseNilChannelIsNoop(t *testing.T) {
 	n := &nixPostgres{}
 	n.Supervise(func(error) { t.Fatal("callback fired with no server to watch") })
 	time.Sleep(50 * time.Millisecond)
+}
+
+// startStatusState reads the observable StartStatus the same way the
+// Information RPC does — through the RuntimeWrapper's lock.
+func startStatusState(rt *services.RuntimeWrapper) runtimev0.StartStatus_Status {
+	rt.RLock()
+	defer rt.RUnlock()
+	if rt.StartStatus == nil {
+		return runtimev0.StartStatus_UNKNOWN
+	}
+	return rt.StartStatus.State
+}
+
+// TestStartTailReportsDeathBufferedBeforeStartResponse pins the ordering fix in
+// (*Runtime).Start: the death-reporting supervisor must be armed only AFTER
+// StartResponse commits StartStatus=STARTED.
+//
+// The failure this guards against: the postmaster dies in the window between
+// waitReady succeeding (inside Init) and Start returning, so its exit is already
+// buffered in serverExit by the time Start runs. If Supervise is armed before
+// StartResponse (the original bug), the watcher goroutine flips StartStatus to
+// ERROR and StartResponse then clobbers it back to STARTED — the death is masked
+// and codefly's Follow loop never tears down (codefly-dev/cli#380).
+//
+// The two sub-cases run the same two operations in the two possible orders and
+// assert the observable final state, so the masking mechanism — and why the
+// production order is respond-then-arm — is locked in.
+func TestStartTailReportsDeathBufferedBeforeStartResponse(t *testing.T) {
+	crash := errors.New("postgres: terminated by signal 9")
+
+	// newDeadServer builds a nixPostgres whose postmaster has already exited:
+	// the exit sits in the buffered channel exactly as it would after a crash in
+	// the Init->Start window.
+	newDeadServer := func() *nixPostgres {
+		exit := make(chan error, 1)
+		exit <- crash
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		return &nixPostgres{serverExit: exit, serverCtx: ctx}
+	}
+
+	arm := func(rt *services.RuntimeWrapper, n *nixPostgres) <-chan struct{} {
+		done := make(chan struct{})
+		n.Supervise(func(err error) {
+			rt.MarkRunnerExited(err)
+			close(done)
+		})
+		return done
+	}
+
+	t.Run("respond then arm (production order) reports ERROR", func(t *testing.T) {
+		rt := &services.RuntimeWrapper{}
+		n := newDeadServer()
+
+		if _, err := rt.StartResponse(); err != nil {
+			t.Fatalf("StartResponse: %v", err)
+		}
+		done := arm(rt, n)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("supervisor never reported the buffered death")
+		}
+		if got := startStatusState(rt); got != runtimev0.StartStatus_ERROR {
+			t.Fatalf("final StartStatus = %v, want ERROR (buffered death must not be masked)", got)
+		}
+	})
+
+	t.Run("arm then respond (original bug) masks the death as STARTED", func(t *testing.T) {
+		rt := &services.RuntimeWrapper{}
+		n := newDeadServer()
+
+		done := arm(rt, n)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("supervisor never reported the buffered death")
+		}
+		// StartResponse running after the watcher has reported ERROR overwrites
+		// it with STARTED. This is the masking the production order avoids.
+		if _, err := rt.StartResponse(); err != nil {
+			t.Fatalf("StartResponse: %v", err)
+		}
+		if got := startStatusState(rt); got != runtimev0.StartStatus_STARTED {
+			t.Fatalf("final StartStatus = %v, want STARTED (demonstrates the masking)", got)
+		}
+	})
 }

--- a/nixpg_supervise_test.go
+++ b/nixpg_supervise_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+// awaitCallback returns the error Supervise reported, or (nil,false) if nothing
+// fired within the timeout. Supervise runs its watch in a goroutine, so tests
+// synchronize through this channel rather than sleeping.
+func awaitCallback(t *testing.T, fired <-chan error, timeout time.Duration) (error, bool) {
+	t.Helper()
+	select {
+	case err := <-fired:
+		return err, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
+
+func TestSuperviseReportsCrash(t *testing.T) {
+	exit := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n := &nixPostgres{serverExit: exit, serverCtx: ctx}
+
+	fired := make(chan error, 1)
+	n.Supervise(func(err error) { fired <- err })
+
+	// The postmaster dies mid-run without anyone calling Stop.
+	crash := errors.New("postgres: terminated by signal 9")
+	exit <- crash
+
+	got, ok := awaitCallback(t, fired, 2*time.Second)
+	if !ok {
+		t.Fatal("Supervise did not report an unexpected exit")
+	}
+	if !errors.Is(got, crash) {
+		t.Fatalf("reported error = %v, want %v", got, crash)
+	}
+}
+
+func TestSuperviseReportsCleanExit(t *testing.T) {
+	exit := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	n := &nixPostgres{serverExit: exit, serverCtx: ctx}
+
+	fired := make(chan error, 1)
+	n.Supervise(func(err error) { fired <- err })
+
+	// A clean exit mid-run (nil error) is still unexpected: nobody asked
+	// postgres to stop, yet it is gone. It must be reported.
+	exit <- nil
+
+	got, ok := awaitCallback(t, fired, 2*time.Second)
+	if !ok {
+		t.Fatal("Supervise did not report a clean mid-run exit")
+	}
+	if got != nil {
+		t.Fatalf("reported error = %v, want nil", got)
+	}
+}
+
+func TestSuperviseIgnoresDeliberateStop(t *testing.T) {
+	exit := make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	n := &nixPostgres{serverExit: exit, serverCtx: ctx}
+
+	fired := make(chan error, 1)
+	n.Supervise(func(err error) { fired <- err })
+
+	// Stop cancels serverCtx BEFORE the process terminates, then the process
+	// exit lands on the channel. The cancelled context must suppress the report.
+	cancel()
+	exit <- errors.New("postgres: shutting down")
+
+	if _, ok := awaitCallback(t, fired, 500*time.Millisecond); ok {
+		t.Fatal("Supervise reported a deliberate Stop as an unexpected exit")
+	}
+}
+
+func TestSuperviseNilChannelIsNoop(t *testing.T) {
+	// Before startServer (e.g. Docker runtime) serverExit is nil. Supervise must
+	// not spawn a goroutine or panic.
+	n := &nixPostgres{}
+	n.Supervise(func(error) { t.Fatal("callback fired with no server to watch") })
+	time.Sleep(50 * time.Millisecond)
+}

--- a/runtime.go
+++ b/runtime.go
@@ -377,6 +377,19 @@ func (s *Runtime) Start(ctx context.Context, req *runtimev0.StartRequest) (*runt
 	if err := s.ensureRuntimeAccess(ctx); err != nil {
 		return s.Runtime.StartError(err)
 	}
+	s.Wool.Debug("start done")
+	// Commit StartStatus=STARTED BEFORE arming supervision. StartResponse and
+	// MarkRunnerExited both write StartStatus under the same lock, so ordering is
+	// by wall-clock, not data race: if Supervise were armed first, a postmaster
+	// death already buffered in serverExit (a crash in the Init->Start window)
+	// would let the watcher goroutine flip StartStatus to ERROR, and this
+	// StartResponse would then clobber it back to STARTED — masking the very
+	// death we exist to report (codefly-dev/cli#380). Arming after the commit
+	// guarantees any ERROR the watcher writes lands strictly after STARTED.
+	resp, err := s.Runtime.StartResponse()
+	if err != nil {
+		return resp, err
+	}
 	// Report a mid-run death of the managed postgres process so codefly's Follow
 	// loop observes StartStatus ERROR and tears down loudly instead of leaving
 	// dependents to spin on connection refused (codefly-dev/cli#380). Docker
@@ -392,8 +405,7 @@ func (s *Runtime) Start(ctx context.Context, req *runtimev0.StartRequest) (*runt
 			s.Runtime.MarkRunnerExited(err)
 		})
 	}
-	s.Wool.Debug("start done")
-	return s.Runtime.StartResponse()
+	return resp, nil
 }
 
 func (s *Runtime) Information(ctx context.Context, req *runtimev0.InformationRequest) (*runtimev0.InformationResponse, error) {

--- a/runtime.go
+++ b/runtime.go
@@ -377,6 +377,21 @@ func (s *Runtime) Start(ctx context.Context, req *runtimev0.StartRequest) (*runt
 	if err := s.ensureRuntimeAccess(ctx); err != nil {
 		return s.Runtime.StartError(err)
 	}
+	// Report a mid-run death of the managed postgres process so codefly's Follow
+	// loop observes StartStatus ERROR and tears down loudly instead of leaving
+	// dependents to spin on connection refused (codefly-dev/cli#380). Docker
+	// runtimes are supervised by the container engine and reported via the
+	// runner environment; the Nix host process has no such supervisor.
+	if s.nixRuntime != nil {
+		s.nixRuntime.Supervise(func(err error) {
+			if err != nil {
+				s.Wool.Error("nix postgres exited unexpectedly", wool.ErrField(err))
+			} else {
+				s.Wool.Error("nix postgres exited unexpectedly (clean exit, not stopped)")
+			}
+			s.Runtime.MarkRunnerExited(err)
+		})
+	}
 	s.Wool.Debug("start done")
 	return s.Runtime.StartResponse()
 }


### PR DESCRIPTION
Fixes codefly-dev/cli#380. (Cross-repo, so GitHub won't auto-close it — the root cause lives here, not in the CLI. Close cli#380 when this merges.)

## Problem
During a long `codefly run`, the embedded Nix postgres (`store`, `cfpg-*` on 127.0.0.1:49010) exited and was never restarted. Dependent `accounts` spammed `connection refused` for ~10 min while the `codefly run` parent stayed alive.

## Root cause (here, not in the CLI)
The Nix runtime launches the postmaster as a host process the agent owns directly, under a background-derived `serverCtx` that outlives Init. After startup **nothing watched that process**. `waitReady` observes `serverExit` only during the startup poll; once Start returns, a later exit (crash, external SIGTERM, invalidated data-directory lock) went unnoticed and the agent kept reporting `STARTED`.

codefly's `Runner.Follow` loop polls `Information` and only reacts to `StartStatus == ERROR` or an unreachable agent. A silent postmaster death is neither, so the whole fail-loud fabric never fired. This is exactly the wiring `service-go` already has for its user binary (`MarkRunnerExited`), and that `service-postgres` was missing.

## Fix
`nixPostgres.Supervise` watches `serverExit` after startup and calls `Runtime.MarkRunnerExited(err)` unless the exit followed a deliberate `Stop` — `Stop` cancels `serverCtx` *before* terminating the process, so a cancelled context is the authoritative orderly-shutdown signal. `MarkRunnerExited` flips `StartStatus` to `ERROR`, which the existing `Follow` fabric already turns into a loud teardown of the run.

No core change required: `MarkRunnerExited` and `InformationResponse` returning `StartStatus` have existed since core v0.2.0 and are present in the pinned v0.2.121.

## Tests
`nixpg_supervise_test.go`:
- crash mid-run → reported
- clean mid-run exit (nil) → reported (nobody asked it to stop)
- deliberate Stop (serverCtx cancelled) → **not** reported
- nil serverExit (pre-startup / Docker runtime) → no-op, no goroutine

## Note on the CLI PR
The earlier CLI-side liveness-probe PR (codefly-dev/cli#384) was a TCP-probe band-aid and is being closed in favor of this authoritative agent-side fix.