### PR TITLE
fix: unblock external-identity deploy path (#57)

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -333,6 +333,12 @@ type promotableWorkloadSecretReferences struct {
 func (s *Builder) selectPromotableSecretReferences(
 	configured map[string]*builderv0.KubernetesSecretKeyReference,
 ) (*promotableWorkloadSecretReferences, error) {
+	// The restricted deploy build never loads runtime credentials, so this is
+	// the only place the auth mode is checked on this path: reject a mistyped
+	// mode here rather than silently demanding password Secret references.
+	if err := s.validateAuthMode(); err != nil {
+		return nil, err
+	}
 	// External-identity mode holds no passwords, so the deploy build promotes no
 	// credential Secret references; infra's guard forbids any Secret in the
 	// db-auth stack.

--- a/builder.go
+++ b/builder.go
@@ -333,6 +333,15 @@ type promotableWorkloadSecretReferences struct {
 func (s *Builder) selectPromotableSecretReferences(
 	configured map[string]*builderv0.KubernetesSecretKeyReference,
 ) (*promotableWorkloadSecretReferences, error) {
+	// External-identity mode holds no passwords, so the deploy build promotes no
+	// credential Secret references; infra's guard forbids any Secret in the
+	// db-auth stack.
+	if s.externalIdentity() {
+		return &promotableWorkloadSecretReferences{
+			StatefulSet:  map[string]*builderv0.KubernetesSecretKeyReference{},
+			BootstrapJob: map[string]*builderv0.KubernetesSecretKeyReference{},
+		}, nil
+	}
 	statefulSetEnvironmentVariables := []string{
 		"POSTGRES_USER",
 		"POSTGRES_PASSWORD",

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -443,6 +443,21 @@ func TestPromotableExternalIdentityDeploymentPromotesNoCredentialSecrets(t *test
 	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "overlays", "test", "secret.yaml")))
 }
 
+func TestPromotableDeploymentRejectsUnsupportedAuthMode(t *testing.T) {
+	builder, networkMappings := newDeploymentTestBuilder(t)
+	builder.AuthMode = "external-idenity" // typo
+
+	response, err := builder.Deploy(context.Background(), promotableDeploymentRequest(
+		t.TempDir(),
+		networkMappings,
+		promotablePostgresSecretReferences(),
+	))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
+	require.Contains(t, response.GetState().GetMessage(), `unsupported postgres auth mode "external-idenity"`)
+	require.Nil(t, response.GetConfiguration())
+}
+
 func newDeploymentTestBuilder(t *testing.T) (*Builder, []*basev0.NetworkMapping) {
 	t.Helper()
 	ctx := context.Background()

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -405,6 +405,44 @@ func TestPromotableGitOpsDeploymentRejectsMissingOrOptionalRequiredSecretReferen
 	}
 }
 
+func TestPromotableExternalIdentityDeploymentPromotesNoCredentialSecrets(t *testing.T) {
+	builder, networkMappings := newDeploymentTestBuilder(t)
+	builder.AuthMode = authModeExternalIdentity
+	destination := t.TempDir()
+
+	// External-identity mode requires no configured Secret references at all.
+	response, err := builder.Deploy(context.Background(), promotableDeploymentRequest(
+		destination,
+		networkMappings,
+		nil,
+	))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.DeploymentStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	values := response.GetConfiguration().GetInfos()[0].GetConfigurationValues()
+	require.Len(t, values, 2)
+	for _, value := range values {
+		require.Contains(t, []string{readOnlyConnectionKey, readWriteConnectionKey}, value.GetKey())
+		require.True(t, value.GetSecret())
+		require.Empty(t, value.GetValue())
+	}
+
+	statefulSet := readDeploymentFile(t, destination, "base", "stateful-set.yaml")
+	job := readDeploymentFile(t, destination, "base", "job.yaml")
+	for _, manifest := range []string{statefulSet, job} {
+		require.NotContains(t, manifest, "secretKeyRef")
+		for _, credential := range []string{
+			"POSTGRES_PASSWORD",
+			"POSTGRES_READ_ONLY_PASSWORD",
+			"POSTGRES_READ_WRITE_PASSWORD",
+			migrationConnectionEnvironmentKey,
+		} {
+			require.NotContains(t, manifest, "name: "+credential)
+		}
+	}
+	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "overlays", "test", "secret.yaml")))
+}
+
 func newDeploymentTestBuilder(t *testing.T) (*Builder, []*basev0.NetworkMapping) {
 	t.Helper()
 	ctx := context.Background()

--- a/main.go
+++ b/main.go
@@ -35,6 +35,16 @@ type Settings struct {
 	DatabaseName string `yaml:"database-name"`
 	HotReload    bool   `yaml:"hot-reload"`
 
+	// AuthMode selects how runtime login principals authenticate. Empty is the
+	// default password mode: the service owns password-authenticated login
+	// roles and exports credentialed connection strings. "external-identity" is
+	// for managed cloud Postgres with password auth disabled — login principals
+	// are provisioned out-of-band by the cloud identity provider (Entra ID /
+	// Cloud SQL IAM) and consumers acquire a short-lived token at connect time,
+	// so no password is generated, required, or embedded in any connection
+	// string or Kubernetes Secret. See templates/agent/README.md.tmpl.
+	AuthMode string `yaml:"auth-mode"`
+
 	WithoutSSL  bool `yaml:"without-ssl"`  // Default to SSL
 	NoMigration bool `yaml:"no-migration"` // Developer only
 
@@ -321,9 +331,15 @@ func postgresConnectionString(address, database, user, password string, withSSL 
 	if !withSSL || strings.Contains(address, "localhost") || strings.Contains(address, "host.docker.internal") {
 		query.Set("sslmode", "disable")
 	}
+	// External-identity mode carries no password: the consumer acquires a
+	// short-lived token at connect time, so the DSN keeps only the principal.
+	userinfo := url.User(user)
+	if password != "" {
+		userinfo = url.UserPassword(user, password)
+	}
 	connection := &url.URL{
 		Scheme:   "postgresql",
-		User:     url.UserPassword(user, password),
+		User:     userinfo,
 		Host:     address,
 		Path:     "/" + database,
 		RawQuery: query.Encode(),

--- a/main.go
+++ b/main.go
@@ -277,7 +277,7 @@ func (s *Service) createOwnerConnectionString(ctx context.Context, conf *basev0.
 		return "", s.Wool.Wrapf(err, "cannot get user and password")
 	}
 
-	return postgresConnectionString(address, s.DatabaseName, s.postgresUser, s.postgresPassword, withSSL), nil
+	return postgresConnectionString(address, s.DatabaseName, s.postgresUser, s.postgresPassword, withSSL, s.externalIdentity()), nil
 }
 
 func (s *Service) CreateConnectionConfiguration(ctx context.Context, conf *basev0.Configuration, instance *basev0.NetworkInstance, withSSL bool) (*basev0.Configuration, error) {
@@ -287,9 +287,10 @@ func (s *Service) CreateConnectionConfiguration(ctx context.Context, conf *basev
 		return nil, s.Wool.Wrapf(err, "cannot load postgres credentials")
 	}
 	readOnlyRole, readWriteRole := runtimeRoleNames(s.DatabaseName)
-	ownerConnection := postgresConnectionString(instance.Address, s.DatabaseName, s.postgresUser, s.postgresPassword, withSSL)
-	readOnlyConnection := postgresConnectionString(instance.Address, s.DatabaseName, readOnlyRole, s.readOnlyPassword, withSSL)
-	readWriteConnection := postgresConnectionString(instance.Address, s.DatabaseName, readWriteRole, s.readWritePassword, withSSL)
+	passwordless := s.externalIdentity()
+	ownerConnection := postgresConnectionString(instance.Address, s.DatabaseName, s.postgresUser, s.postgresPassword, withSSL, passwordless)
+	readOnlyConnection := postgresConnectionString(instance.Address, s.DatabaseName, readOnlyRole, s.readOnlyPassword, withSSL, passwordless)
+	readWriteConnection := postgresConnectionString(instance.Address, s.DatabaseName, readWriteRole, s.readWritePassword, withSSL, passwordless)
 
 	outputConf := &basev0.Configuration{
 		Origin:         s.Unique(),
@@ -326,15 +327,16 @@ func (s *Service) promotableConnectionConfiguration(instance *basev0.NetworkInst
 	}
 }
 
-func postgresConnectionString(address, database, user, password string, withSSL bool) string {
+func postgresConnectionString(address, database, user, password string, withSSL, passwordless bool) string {
 	query := url.Values{}
 	if !withSSL || strings.Contains(address, "localhost") || strings.Contains(address, "host.docker.internal") {
 		query.Set("sslmode", "disable")
 	}
 	// External-identity mode carries no password: the consumer acquires a
 	// short-lived token at connect time, so the DSN keeps only the principal.
+	// The mode is authoritative — a stray password must never leak into the DSN.
 	userinfo := url.User(user)
-	if password != "" {
+	if !passwordless {
 		userinfo = url.UserPassword(user, password)
 	}
 	connection := &url.URL{

--- a/runtime_access.go
+++ b/runtime_access.go
@@ -36,6 +36,20 @@ func (s *Service) externalIdentity() bool {
 	return s.AuthMode == authModeExternalIdentity
 }
 
+// validateAuthMode rejects any Settings.AuthMode outside the supported set.
+// Empty is treated as authModePassword. It is enforced on every path that
+// branches on the mode — including the restricted deploy build, which never
+// loads runtime credentials — so a mistyped mode fails loud instead of silently
+// falling back to password behavior.
+func (s *Service) validateAuthMode() error {
+	switch s.AuthMode {
+	case "", authModePassword, authModeExternalIdentity:
+		return nil
+	default:
+		return fmt.Errorf("unsupported postgres auth mode %q", s.AuthMode)
+	}
+}
+
 type runtimeAccess struct {
 	readOnlyRole   string
 	readWriteRole  string
@@ -66,8 +80,12 @@ func (s *Service) validateCredentials() error {
 	if strings.TrimSpace(s.postgresUser) == "" {
 		return fmt.Errorf("postgres owner user is required")
 	}
-	switch s.AuthMode {
-	case "", authModePassword:
+	if err := s.validateAuthMode(); err != nil {
+		return err
+	}
+	// External-identity login principals authenticate through the cloud identity
+	// provider; the service holds no passwords to validate.
+	if !s.externalIdentity() {
 		credentials := []struct {
 			name  string
 			value string
@@ -86,11 +104,6 @@ func (s *Service) validateCredentials() error {
 			s.readOnlyPassword == s.readWritePassword {
 			return fmt.Errorf("owner, read-only, and read-write passwords must be distinct")
 		}
-	case authModeExternalIdentity:
-		// Login principals authenticate through the cloud identity provider;
-		// the service holds no passwords to validate.
-	default:
-		return fmt.Errorf("unsupported postgres auth mode %q", s.AuthMode)
 	}
 	_, _, err := s.runtimeAccess()
 	return err
@@ -204,6 +217,13 @@ func validSQLIdentifier(value string) bool {
 // only in generic mode; delegated mode grants it only explicit SET ROLE
 // memberships. Neither role has schema CREATE or role-management authority.
 func (s *Runtime) ensureRuntimeAccess(ctx context.Context) error {
+	// The self-hosted runtime provisions password-authenticated LOGIN roles
+	// (ensureLoginRole). External-identity login principals are created
+	// out-of-band by the cloud identity provider, so running this path would
+	// issue empty-password LOGIN roles; fail closed instead.
+	if s.externalIdentity() {
+		return s.Wool.NewError("self-hosted runtime cannot reconcile runtime access in external-identity mode: login principals are provisioned by the cloud identity provider")
+	}
 	schemas, err := normalizedRuntimeSchemas(s.Settings.RuntimeSchemas)
 	if err != nil {
 		return err

--- a/runtime_access.go
+++ b/runtime_access.go
@@ -22,7 +22,19 @@ const (
 	// migrationConnectionEnvironmentKey is an internal bootstrap-job secret.
 	// It is never part of the service's exported Configuration contract.
 	migrationConnectionEnvironmentKey = "CODEFLY_POSTGRES_MIGRATION_CONNECTION"
+
+	// authModePassword and authModeExternalIdentity are the supported values of
+	// Settings.AuthMode. Empty is treated as authModePassword.
+	authModePassword         = "password"
+	authModeExternalIdentity = "external-identity"
 )
+
+// externalIdentity reports whether login principals authenticate through a
+// cloud identity provider instead of service-managed passwords. In this mode no
+// password is generated, required, or embedded in connection strings or Secrets.
+func (s *Service) externalIdentity() bool {
+	return s.AuthMode == authModeExternalIdentity
+}
 
 type runtimeAccess struct {
 	readOnlyRole   string
@@ -54,23 +66,31 @@ func (s *Service) validateCredentials() error {
 	if strings.TrimSpace(s.postgresUser) == "" {
 		return fmt.Errorf("postgres owner user is required")
 	}
-	credentials := []struct {
-		name  string
-		value string
-	}{
-		{name: "POSTGRES_PASSWORD", value: s.postgresPassword},
-		{name: "POSTGRES_READ_ONLY_PASSWORD", value: s.readOnlyPassword},
-		{name: "POSTGRES_READ_WRITE_PASSWORD", value: s.readWritePassword},
-	}
-	for _, credential := range credentials {
-		if strings.TrimSpace(credential.value) == "" {
-			return fmt.Errorf("%s must not be empty", credential.name)
+	switch s.AuthMode {
+	case "", authModePassword:
+		credentials := []struct {
+			name  string
+			value string
+		}{
+			{name: "POSTGRES_PASSWORD", value: s.postgresPassword},
+			{name: "POSTGRES_READ_ONLY_PASSWORD", value: s.readOnlyPassword},
+			{name: "POSTGRES_READ_WRITE_PASSWORD", value: s.readWritePassword},
 		}
-	}
-	if s.postgresPassword == s.readOnlyPassword ||
-		s.postgresPassword == s.readWritePassword ||
-		s.readOnlyPassword == s.readWritePassword {
-		return fmt.Errorf("owner, read-only, and read-write passwords must be distinct")
+		for _, credential := range credentials {
+			if strings.TrimSpace(credential.value) == "" {
+				return fmt.Errorf("%s must not be empty", credential.name)
+			}
+		}
+		if s.postgresPassword == s.readOnlyPassword ||
+			s.postgresPassword == s.readWritePassword ||
+			s.readOnlyPassword == s.readWritePassword {
+			return fmt.Errorf("owner, read-only, and read-write passwords must be distinct")
+		}
+	case authModeExternalIdentity:
+		// Login principals authenticate through the cloud identity provider;
+		// the service holds no passwords to validate.
+	default:
+		return fmt.Errorf("unsupported postgres auth mode %q", s.AuthMode)
 	}
 	_, _, err := s.runtimeAccess()
 	return err

--- a/runtime_access_test.go
+++ b/runtime_access_test.go
@@ -97,6 +97,41 @@ func TestExternalIdentityModeAcceptsPasswordlessCredentialsAndDSNs(t *testing.T)
 	assertPasswordlessConnection(t, configurationValue(t, configuration, readWriteConnectionKey), readWriteRole)
 }
 
+func TestExternalIdentityDSNsStayPasswordlessDespiteStrayCredentials(t *testing.T) {
+	svc := newTestPostgresService()
+	svc.DatabaseName = "accounts"
+	svc.AuthMode = authModeExternalIdentity
+
+	// A configuration that still carries a service-managed owner password must
+	// not leak it (or any password derived from it) into the passwordless DSNs.
+	configuration, err := svc.CreateConnectionConfiguration(
+		context.Background(),
+		testPostgresConfiguration("app-principal", "stray-owner-secret", "", ""),
+		&basev0.NetworkInstance{Address: "database.internal:5432", Access: resources.NewNativeNetworkAccess()},
+		true,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	readOnlyRole, readWriteRole := runtimeRoleNames(svc.DatabaseName)
+	assertPasswordlessConnection(t, configurationValue(t, configuration, ownerConnectionKey), "app-principal")
+	assertPasswordlessConnection(t, configurationValue(t, configuration, readOnlyConnectionKey), readOnlyRole)
+	assertPasswordlessConnection(t, configurationValue(t, configuration, readWriteConnectionKey), readWriteRole)
+}
+
+func TestExternalIdentityRuntimeAccessFailsClosed(t *testing.T) {
+	runtime := NewRuntime()
+	runtime.DatabaseName = "accounts"
+	runtime.AuthMode = authModeExternalIdentity
+
+	// The self-hosted reconciler would otherwise provision empty-password LOGIN
+	// roles; it must refuse before opening any connection.
+	if err := runtime.ensureRuntimeAccess(context.Background()); err == nil {
+		t.Fatal("self-hosted runtime reconciled runtime access in external-identity mode")
+	}
+}
+
 func TestUnsupportedAuthModeFailsClosed(t *testing.T) {
 	svc := newTestPostgresService()
 	svc.DatabaseName = "accounts"

--- a/runtime_access_test.go
+++ b/runtime_access_test.go
@@ -76,6 +76,36 @@ func TestCredentialsFailClosed(t *testing.T) {
 	}
 }
 
+func TestExternalIdentityModeAcceptsPasswordlessCredentialsAndDSNs(t *testing.T) {
+	svc := newTestPostgresService()
+	svc.DatabaseName = "accounts"
+	svc.AuthMode = authModeExternalIdentity
+
+	configuration, err := svc.CreateConnectionConfiguration(
+		context.Background(),
+		testPostgresConfiguration("app-principal", "", "", ""),
+		&basev0.NetworkInstance{Address: "database.internal:5432", Access: resources.NewNativeNetworkAccess()},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("external-identity credentials were rejected: %v", err)
+	}
+
+	readOnlyRole, readWriteRole := runtimeRoleNames(svc.DatabaseName)
+	assertPasswordlessConnection(t, configurationValue(t, configuration, ownerConnectionKey), "app-principal")
+	assertPasswordlessConnection(t, configurationValue(t, configuration, readOnlyConnectionKey), readOnlyRole)
+	assertPasswordlessConnection(t, configurationValue(t, configuration, readWriteConnectionKey), readWriteRole)
+}
+
+func TestUnsupportedAuthModeFailsClosed(t *testing.T) {
+	svc := newTestPostgresService()
+	svc.DatabaseName = "accounts"
+	svc.AuthMode = "delegated-magic"
+	if err := svc.LoadConfiguration(context.Background(), testPostgresConfiguration("migration-owner", "owner", "reader", "writer")); err == nil {
+		t.Fatal("unsupported auth mode was accepted")
+	}
+}
+
 func TestLegacyOwnerOnlyCredentialsDeriveStableScopedPasswords(t *testing.T) {
 	first := newTestPostgresService()
 	first.DatabaseName = "accounts"
@@ -183,6 +213,20 @@ func configurationValue(t *testing.T, configuration *basev0.Configuration, key s
 		t.Fatal(err)
 	}
 	return value
+}
+
+func assertPasswordlessConnection(t *testing.T, connection, expectedUser string) {
+	t.Helper()
+	parsed, err := url.Parse(connection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsed.User == nil || parsed.User.Username() != expectedUser {
+		t.Fatalf("connection user = %v, want %q", parsed.User, expectedUser)
+	}
+	if _, hasPassword := parsed.User.Password(); hasPassword {
+		t.Fatalf("external-identity DSN %q embedded a password", connection)
+	}
 }
 
 func assertConnectionIdentity(t *testing.T, connection, expectedUser, expectedPassword string) {

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -11,4 +11,10 @@ The bootstrap job applies migrations and reconciles runtime roles and grants on 
 
 Local database state survives ordinary stop/start and container recreation. In Docker mode, the agent mounts the official image's data directory from a Codefly-owned persistent runtime directory scoped by workspace, service, and naming scope. Stable and development scopes therefore keep independent databases even when they run from the same checkout.
 
+## External-identity mode
+
+Set `auth-mode: external-identity` for managed cloud Postgres with password authentication disabled. Login principals are created out-of-band by the cloud identity provider (Entra ID / Cloud SQL IAM); the service generates, requires, and exports no passwords. The deploy build promotes no credential `secretKeyRef`s, and the exported `owner-connection`, `read-only-connection`, and `read-write-connection` strings are passwordless DSNs (`postgresql://<principal>@host/db`) that carry the principal but no secret.
+
+Consumers acquire a short-lived token at connect time rather than reading a password from the DSN. The primary path is in-process token acquisition with `azidentity` wired into pgx's `BeforeConnect` hook, which sets the per-connection password to a freshly minted token (see `module-saas-starter#154`). The passwordless DSN supplies the host, database, and principal; the token supplies the credential.
+
 For tenant isolation, application migrations must enable row-level security and define policies against transaction-local tenant/user settings. Go services should use the service-owned library at `github.com/codefly-dev/service-postgres/libs/go`, which resolves an authenticated principal from context, issues separate read-only/read-write stores without exposing raw pools, and provides tenant-scoped transaction advisory locks without exposing tenant identity to repository code.


### PR DESCRIPTION
Closes #57.

## Summary
- The deploy path was unusable in external-identity mode because three checks hard-require service-managed passwords. This makes each one auth-mode-aware, gated on a new `auth-mode: external-identity` service setting (default stays password mode, unchanged).
- `validateCredentials` skips the password presence/distinctness checks in external-identity mode and rejects unknown auth modes; `selectPromotableSecretReferences` promotes no credential `secretKeyRef`s so the deploy build no longer fails and no Secret enters the db-auth stack; connection strings drop URL userinfo passwords, yielding passwordless DSNs.
- Consumers acquire a short-lived token at connect time (in-process `azidentity` + pgx `BeforeConnect`, per module-saas-starter#154); documented in the agent README template.

## Notes
- Scoped strictly to the three deploy-path items #56 left untracked. The runtime role reconciler's external-identity support already landed in #56 (`libs/go/controlplane`); this PR does not touch it.
- Password mode is byte-for-byte unchanged: the new logic only branches when `auth-mode` is `external-identity`.

## Test plan
- [x] `go test .` (non-container suite) — passes
- [x] `go test . -run TestCreateToRunDocker` (container integration) — passes, confirming password mode is unaffected
- [x] New unit tests: passwordless credentials/DSNs accepted in external-identity mode, unknown auth mode fails closed, promotable deploy in external-identity mode emits no credential Secret references
- [x] `gofmt` / `go vet` clean