### PR TITLE
test: assert restricted deployment omits empty manifests (#60)

### DIFF
--- a/deployment_test.go
+++ b/deployment_test.go
@@ -216,8 +216,8 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	require.NotContains(t, baseKustomization, "namespace.yaml")
 	overlayKustomization := readDeploymentFile(t, destination, "overlays", "test", "kustomization.yaml")
 	require.NotContains(t, overlayKustomization, "secret.yaml")
-	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "base", "namespace.yaml")))
-	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "overlays", "test", "secret.yaml")))
+	requireNoDeploymentFile(t, destination, "base", "namespace.yaml")
+	requireNoDeploymentFile(t, destination, "overlays", "test", "secret.yaml")
 
 	statefulSet := readDeploymentFile(t, destination, "base", "stateful-set.yaml")
 	for _, expected := range []string{
@@ -440,7 +440,7 @@ func TestPromotableExternalIdentityDeploymentPromotesNoCredentialSecrets(t *test
 			require.NotContains(t, manifest, "name: "+credential)
 		}
 	}
-	require.Empty(t, strings.TrimSpace(readDeploymentFile(t, destination, "overlays", "test", "secret.yaml")))
+	requireNoDeploymentFile(t, destination, "overlays", "test", "secret.yaml")
 }
 
 func TestPromotableDeploymentRejectsUnsupportedAuthMode(t *testing.T) {
@@ -570,4 +570,10 @@ func readDeploymentFile(t *testing.T, directory string, elements ...string) stri
 	content, err := os.ReadFile(filepath.Join(append([]string{directory}, elements...)...))
 	require.NoError(t, err)
 	return string(content)
+}
+
+func requireNoDeploymentFile(t *testing.T, directory string, elements ...string) {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(append([]string{directory}, elements...)...))
+	require.ErrorIs(t, err, os.ErrNotExist)
 }


### PR DESCRIPTION
Closes #60.

## Summary
- Core v0.3.0's `services.WithDeployment` now sets `SkipEmptyRender: true`: a kustomize template that renders blank under the `RESTRICTED_PORTABLE` profile — `namespace.yaml` and `secret.yaml`, both guarded by `{{- if not .Restricted }}` — is no longer written to disk, so empty stubs aren't inventoried/digested into the signed promotion bundle. The promotable deployment tests still asserted those files existed-and-were-empty, so the core bump (`chore: update core to v0.3.0`) broke them with `no such file`. This was the actual CI failure on `main` (the two tests below, ~5.7s — not a timeout).
- The assertions now check the files are **absent** via a `requireNoDeploymentFile` helper. `os.Stat` + `ErrorIs(os.ErrNotExist)` is deliberately tighter than testify's `require.NoFileExists` (which also passes for a directory at the path, or any `Lstat` error) — true absence is the exact contract for "core wrote no manifest here", so a stray directory or masking error should fail rather than pass silently.

## Test plan
- [x] `go test ./... -skip '^TestCreateToRunDocker$'` (the CI gate) — green in ~48s
- [x] `TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSecrets` and `TestPromotableExternalIdentityDeploymentPromotesNoCredentialSecrets` pass
- [x] `go build ./...` and `go vet ./...` clean

## Notes
- No production code changed; the core `SkipEmptyRender` behavior is correct and this only realigns the tests to it.
- The full unskipped `go test ./...` can hit the default 600s timeout **locally** because `TestCreateToRunNix` runs (it self-skips when nix is absent, as on `ubuntu-latest`) alongside Docker-on-Mac VM overhead. On CI/release infra the identical `go test -v ./...` runs green (prior `main` runs passed it, including `TestCreateToRunDocker`), so there is no release-path timeout to address here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)