### PR TITLE
feat: expose managed WAL budget (#59)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
           go-version-file: go.mod
 
       - name: Run unit tests
-        run: go test ./... -skip '^TestCreateToRunDocker$'
+        run: go test ./... -skip '^(TestCreateToRunDocker|TestSustainedWALBudgetDocker)$'
+
+      - name: Qualify sustained WAL budget
+        run: go test . -run '^TestSustainedWALBudgetDocker$' -count=1 -timeout=3m
 
       - name: Build runtime image
         run: docker build --build-arg SOURCE_DATE_EPOCH=0 --tag service-postgres:test .

--- a/builder.go
+++ b/builder.go
@@ -181,11 +181,17 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
+	walBudget, err := s.Settings.effectiveWALBudget()
+	if err != nil {
+		return s.Builder.DeployError(err)
+	}
+	reportWALBudget(s.Wool.In("builder::deploy"), walBudget)
 
 	parameters := &DeploymentTemplateParameters{
-		WithBootstrap: true,
-		ManagedImage:  s.dockerImage().FullName(),
-		DatabaseName:  s.DatabaseName,
+		WithBootstrap:     true,
+		ManagedImage:      s.dockerImage().FullName(),
+		PostgresArguments: append([]string{"postgres"}, walBudget.postgresArguments()...),
+		DatabaseName:      s.DatabaseName,
 	}
 	var restrictedConfiguration *v0.Configuration
 	response, err := s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{

--- a/builder.go
+++ b/builder.go
@@ -181,17 +181,23 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
-	walBudget, err := s.Settings.effectiveWALBudget()
+	walBudget, err := s.effectiveWALBudget()
 	if err != nil {
+		return s.Builder.DeployError(err)
+	}
+	if err = validateWALBudgetStorage(walBudget, managedPostgresStorage()); err != nil {
 		return s.Builder.DeployError(err)
 	}
 	reportWALBudget(s.Wool.In("builder::deploy"), walBudget)
 
 	parameters := &DeploymentTemplateParameters{
-		WithBootstrap:     true,
-		ManagedImage:      s.dockerImage().FullName(),
-		PostgresArguments: append([]string{"postgres"}, walBudget.postgresArguments()...),
-		DatabaseName:      s.DatabaseName,
+		WithBootstrap:         true,
+		ManagedImage:          s.dockerImage().FullName(),
+		PostgresArguments:     append([]string{"postgres"}, walBudget.postgresArguments()...),
+		WALBudgetMaxSizeMB:    walBudget.maxSizeMB,
+		WALStoragePercent:     maximumWALStoragePercent,
+		ManagedStorageSizeGiB: managedPostgresStorageMB / 1024,
+		DatabaseName:          s.DatabaseName,
 	}
 	var restrictedConfiguration *v0.Configuration
 	response, err := s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{

--- a/composition_test.go
+++ b/composition_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"math"
 	"slices"
 	"strings"
 	"testing"
 
 	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
+	"github.com/codefly-dev/core/resources"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,25 +87,25 @@ func TestEffectiveWALBudget(t *testing.T) {
 	})
 
 	t.Run("explicit", func(t *testing.T) {
-		settings := &Settings{WALBudget: WALBudgetSettings{MaxSizeMB: 2048, CheckpointTimeoutSeconds: 600}}
+		settings := &Settings{WALBudget: WALBudgetSettings{MaxSizeMB: 8192, CheckpointTimeoutSeconds: 600}}
 		budget, err := settings.effectiveWALBudget()
 		if err != nil {
 			t.Fatal(err)
 		}
-		if budget.maxSizeMB != 2048 || budget.checkpointTimeoutSeconds != 600 {
+		if budget.maxSizeMB != 8192 || budget.checkpointTimeoutSeconds != 600 {
 			t.Fatalf("explicit budget = %+v", budget)
 		}
 	})
 }
 
-func TestEffectiveWALBudgetRejectsInvalidAndStorageUnsafeValues(t *testing.T) {
+func TestEffectiveWALBudgetRejectsInvalidValues(t *testing.T) {
 	tests := []struct {
 		name     string
 		settings WALBudgetSettings
 		want     string
 	}{
 		{name: "max size below supported minimum", settings: WALBudgetSettings{MaxSizeMB: 79}, want: "must be at least 80"},
-		{name: "max size exceeds managed storage ceiling", settings: WALBudgetSettings{MaxSizeMB: 4097}, want: "exceeds the storage-safe limit 4096"},
+		{name: "max size cannot convert to bytes", settings: WALBudgetSettings{MaxSizeMB: int(math.MaxUint64/bytesPerMiB) + 1}, want: "cannot be represented as bytes"},
 		{name: "checkpoint timeout too short", settings: WALBudgetSettings{CheckpointTimeoutSeconds: 29}, want: "must be between 30 and 86400"},
 		{name: "checkpoint timeout too long", settings: WALBudgetSettings{CheckpointTimeoutSeconds: 86401}, want: "must be between 30 and 86400"},
 	}
@@ -112,6 +114,37 @@ func TestEffectiveWALBudgetRejectsInvalidAndStorageUnsafeValues(t *testing.T) {
 			_, err := (&Settings{WALBudget: test.settings}).effectiveWALBudget()
 			if err == nil || !strings.Contains(err.Error(), test.want) {
 				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateWALBudgetStorageUsesLiveCapacityAndAvailability(t *testing.T) {
+	tests := []struct {
+		name      string
+		budgetMB  int
+		totalMB   uint64
+		freeMB    uint64
+		wantError string
+	}{
+		{name: "larger filesystem admits larger budget", budgetMB: 8192, totalMB: 32 * 1024, freeMB: 20 * 1024},
+		{name: "capacity reserve rejects oversized budget", budgetMB: 8192, totalMB: 16 * 1024, freeMB: 12 * 1024, wantError: "exceeds 40% of storage capacity"},
+		{name: "current usage rejects unavailable budget", budgetMB: 4096, totalMB: 32 * 1024, freeMB: 4095, wantError: "exceeds currently available storage 4095MB"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := validateWALBudgetStorage(
+				postgresWALBudget{maxSizeMB: test.budgetMB},
+				resources.StorageFilesystem{
+					TotalBytes:     test.totalMB * bytesPerMiB,
+					AvailableBytes: test.freeMB * bytesPerMiB,
+				},
+			)
+			if test.wantError == "" && err != nil {
+				t.Fatalf("validate storage: %v", err)
+			}
+			if test.wantError != "" && (err == nil || !strings.Contains(err.Error(), test.wantError)) {
+				t.Fatalf("error = %v, want containing %q", err, test.wantError)
 			}
 		})
 	}
@@ -151,9 +184,9 @@ func TestWALBudgetEvidenceReportsEffectiveValues(t *testing.T) {
 	}
 }
 
-func TestRuntimeInitRejectsUnsafeWALBudgetBeforeResolvingStartupInputs(t *testing.T) {
+func TestRuntimeInitRejectsInvalidWALBudgetBeforeResolvingStartupInputs(t *testing.T) {
 	runtime := NewRuntime()
-	runtime.WALBudget.MaxSizeMB = 4097
+	runtime.WALBudget.MaxSizeMB = 79
 	response, err := runtime.Init(context.Background(), &runtimev0.InitRequest{})
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +194,7 @@ func TestRuntimeInitRejectsUnsafeWALBudgetBeforeResolvingStartupInputs(t *testin
 	if response.GetStatus().GetState() != runtimev0.InitStatus_ERROR {
 		t.Fatalf("init status = %s", response.GetStatus().GetState())
 	}
-	if !strings.Contains(response.GetStatus().GetMessage(), "exceeds the storage-safe limit 4096") {
+	if !strings.Contains(response.GetStatus().GetMessage(), "must be at least 80") {
 		t.Fatalf("init message = %q", response.GetStatus().GetMessage())
 	}
 }

--- a/composition_test.go
+++ b/composition_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"context"
+	"slices"
+	"strings"
 	"testing"
 
+	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
 	"gopkg.in/yaml.v3"
 )
 
@@ -38,6 +42,9 @@ runtime-schemas:
 runtime-read-write-roles:
   - app_tenant
   - app_worker
+wal-budget:
+  max-size-mb: 2048
+  checkpoint-timeout-seconds: 600
 `)
 	var s Settings
 	if err := yaml.Unmarshal(src, &s); err != nil {
@@ -60,5 +67,101 @@ runtime-read-write-roles:
 	}
 	if len(s.RuntimeReadWriteRoles) != 2 || s.RuntimeReadWriteRoles[0] != "app_tenant" || s.RuntimeReadWriteRoles[1] != "app_worker" {
 		t.Errorf("RuntimeReadWriteRoles: got %v", s.RuntimeReadWriteRoles)
+	}
+	if s.WALBudget.MaxSizeMB != 2048 || s.WALBudget.CheckpointTimeoutSeconds != 600 {
+		t.Errorf("WALBudget: got %+v", s.WALBudget)
+	}
+}
+
+func TestEffectiveWALBudget(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		budget, err := (&Settings{}).effectiveWALBudget()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if budget.maxSizeMB != 4096 || budget.checkpointTimeoutSeconds != 900 {
+			t.Fatalf("default budget = %+v", budget)
+		}
+	})
+
+	t.Run("explicit", func(t *testing.T) {
+		settings := &Settings{WALBudget: WALBudgetSettings{MaxSizeMB: 2048, CheckpointTimeoutSeconds: 600}}
+		budget, err := settings.effectiveWALBudget()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if budget.maxSizeMB != 2048 || budget.checkpointTimeoutSeconds != 600 {
+			t.Fatalf("explicit budget = %+v", budget)
+		}
+	})
+}
+
+func TestEffectiveWALBudgetRejectsInvalidAndStorageUnsafeValues(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings WALBudgetSettings
+		want     string
+	}{
+		{name: "max size below supported minimum", settings: WALBudgetSettings{MaxSizeMB: 79}, want: "must be at least 80"},
+		{name: "max size exceeds managed storage ceiling", settings: WALBudgetSettings{MaxSizeMB: 4097}, want: "exceeds the storage-safe limit 4096"},
+		{name: "checkpoint timeout too short", settings: WALBudgetSettings{CheckpointTimeoutSeconds: 29}, want: "must be between 30 and 86400"},
+		{name: "checkpoint timeout too long", settings: WALBudgetSettings{CheckpointTimeoutSeconds: 86401}, want: "must be between 30 and 86400"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := (&Settings{WALBudget: test.settings}).effectiveWALBudget()
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want containing %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestPostgresCommandCarriesWALBudgetAndLogSettings(t *testing.T) {
+	budget := postgresWALBudget{maxSizeMB: 2048, checkpointTimeoutSeconds: 600}
+	got := postgresCommand(budget, "NOTICE")
+	want := []string{
+		"postgres",
+		"-c", "max_wal_size=2048MB",
+		"-c", "checkpoint_timeout=600s",
+		"-c", "log_min_messages=notice",
+		"-c", "log_statement=none",
+		"-c", "log_connections=off",
+		"-c", "log_disconnections=off",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("postgres command = %q, want %q", got, want)
+	}
+}
+
+func TestWALBudgetEvidenceReportsEffectiveValues(t *testing.T) {
+	w, captured := newCaptureWool()
+	reportWALBudget(w, postgresWALBudget{maxSizeMB: 4096, checkpointTimeoutSeconds: 900})
+	if len(captured.logs) != 1 {
+		t.Fatalf("evidence logs = %d, want 1", len(captured.logs))
+	}
+	if captured.logs[0].Message != "effective postgres WAL budget" {
+		t.Fatalf("evidence message = %q", captured.logs[0].Message)
+	}
+	if value, ok := fieldValue(captured.logs[0], "max_wal_size_mb"); !ok || value != 4096 {
+		t.Fatalf("max_wal_size_mb = %v, present = %t", value, ok)
+	}
+	if value, ok := fieldValue(captured.logs[0], "checkpoint_timeout_seconds"); !ok || value != 900 {
+		t.Fatalf("checkpoint_timeout_seconds = %v, present = %t", value, ok)
+	}
+}
+
+func TestRuntimeInitRejectsUnsafeWALBudgetBeforeResolvingStartupInputs(t *testing.T) {
+	runtime := NewRuntime()
+	runtime.WALBudget.MaxSizeMB = 4097
+	response, err := runtime.Init(context.Background(), &runtimev0.InitRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.GetStatus().GetState() != runtimev0.InitStatus_ERROR {
+		t.Fatalf("init status = %s", response.GetStatus().GetState())
+	}
+	if !strings.Contains(response.GetStatus().GetMessage(), "exceeds the storage-safe limit 4096") {
+		t.Fatalf("init message = %q", response.GetStatus().GetMessage())
 	}
 }

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -18,10 +18,13 @@ import (
 
 func TestDeploymentTemplatesWithMigration(t *testing.T) {
 	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentTemplateParameters{
-		WithBootstrap:     true,
-		ManagedImage:      image.FullName(),
-		PostgresArguments: []string{"postgres", "-c", "max_wal_size=4096MB", "-c", "checkpoint_timeout=900s"},
-		BootstrapJobName:  "postgres-aaaaaaaaaaaa",
+		WithBootstrap:         true,
+		ManagedImage:          image.FullName(),
+		PostgresArguments:     []string{"postgres", "-c", "max_wal_size=4096MB", "-c", "checkpoint_timeout=900s"},
+		WALBudgetMaxSizeMB:    4096,
+		WALStoragePercent:     40,
+		ManagedStorageSizeGiB: 10,
+		BootstrapJobName:      "postgres-aaaaaaaaaaaa",
 	})
 	assertMigrationResource(t, dir, true)
 	assertEphemeralSecret(t, dir)
@@ -29,9 +32,12 @@ func TestDeploymentTemplatesWithMigration(t *testing.T) {
 
 func TestDeploymentTemplatesWithoutBootstrap(t *testing.T) {
 	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentTemplateParameters{
-		ManagedImage:      image.FullName(),
-		PostgresArguments: []string{"postgres", "-c", "max_wal_size=4096MB", "-c", "checkpoint_timeout=900s"},
-		BootstrapJobName:  "postgres-aaaaaaaaaaaa",
+		ManagedImage:          image.FullName(),
+		PostgresArguments:     []string{"postgres", "-c", "max_wal_size=4096MB", "-c", "checkpoint_timeout=900s"},
+		WALBudgetMaxSizeMB:    4096,
+		WALStoragePercent:     40,
+		ManagedStorageSizeGiB: 10,
+		BootstrapJobName:      "postgres-aaaaaaaaaaaa",
 	})
 	assertMigrationResource(t, dir, false)
 }
@@ -226,6 +232,11 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 		image.FullName(),
 		`- "max_wal_size=4096MB"`,
 		`- "checkpoint_timeout=900s"`,
+		"name: validate-wal-storage",
+		"wal_kb=$((4096 * 1024))",
+		"storage_safe_kb=$((total_kb * 40 / 100))",
+		"storage: 10Gi",
+		"exceeds currently available mounted storage",
 		"name: PGDATA",
 		"value: /var/lib/postgresql/data/pgdata",
 		"name: POSTGRES_USER",
@@ -289,7 +300,7 @@ func TestDeploymentRejectsStorageUnsafeWALBudget(t *testing.T) {
 	))
 	require.NoError(t, err)
 	require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
-	require.Contains(t, response.GetState().GetMessage(), "exceeds the storage-safe limit 4096")
+	require.Contains(t, response.GetState().GetMessage(), "exceeds 40% of storage capacity (4096MB of 10240MB)")
 }
 
 func TestPromotableBootstrapJobIdentityChangesWithImageDigest(t *testing.T) {

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -18,9 +18,10 @@ import (
 
 func TestDeploymentTemplatesWithMigration(t *testing.T) {
 	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentTemplateParameters{
-		WithBootstrap:    true,
-		ManagedImage:     image.FullName(),
-		BootstrapJobName: "postgres-aaaaaaaaaaaa",
+		WithBootstrap:     true,
+		ManagedImage:      image.FullName(),
+		PostgresArguments: []string{"postgres", "-c", "max_wal_size=4096MB", "-c", "checkpoint_timeout=900s"},
+		BootstrapJobName:  "postgres-aaaaaaaaaaaa",
 	})
 	assertMigrationResource(t, dir, true)
 	assertEphemeralSecret(t, dir)
@@ -28,8 +29,9 @@ func TestDeploymentTemplatesWithMigration(t *testing.T) {
 
 func TestDeploymentTemplatesWithoutBootstrap(t *testing.T) {
 	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentTemplateParameters{
-		ManagedImage:     image.FullName(),
-		BootstrapJobName: "postgres-aaaaaaaaaaaa",
+		ManagedImage:      image.FullName(),
+		PostgresArguments: []string{"postgres", "-c", "max_wal_size=4096MB", "-c", "checkpoint_timeout=900s"},
+		BootstrapJobName:  "postgres-aaaaaaaaaaaa",
 	})
 	assertMigrationResource(t, dir, false)
 }
@@ -222,6 +224,8 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 	statefulSet := readDeploymentFile(t, destination, "base", "stateful-set.yaml")
 	for _, expected := range []string{
 		image.FullName(),
+		`- "max_wal_size=4096MB"`,
+		`- "checkpoint_timeout=900s"`,
 		"name: PGDATA",
 		"value: /var/lib/postgresql/data/pgdata",
 		"name: POSTGRES_USER",
@@ -271,6 +275,21 @@ func TestPromotableGitOpsDeploymentReturnsReferenceOnlyConfigurationAndScopesSec
 		require.NotContains(t, job, unexpected)
 	}
 	require.Regexp(t, `^postgres-[0-9a-f]{12}$`, bootstrapJobResourceName(t, job))
+}
+
+func TestDeploymentRejectsStorageUnsafeWALBudget(t *testing.T) {
+	builder, networkMappings := newDeploymentTestBuilder(t)
+	builder.WALBudget.MaxSizeMB = 4097
+	destination := t.TempDir()
+
+	response, err := builder.Deploy(context.Background(), promotableDeploymentRequest(
+		destination,
+		networkMappings,
+		promotablePostgresSecretReferences(),
+	))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.DeploymentStatus_ERROR, response.GetState().GetState())
+	require.Contains(t, response.GetState().GetMessage(), "exceeds the storage-safe limit 4096")
 }
 
 func TestPromotableBootstrapJobIdentityChangesWithImageDigest(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -56,6 +56,10 @@ type Settings struct {
 	// default (warning, but image emits a lot of startup chatter).
 	LogLevel string `yaml:"log-level"`
 
+	// WALBudget sets the target WAL retained between checkpoints. Numeric units
+	// keep the service declaration portable across Docker, Nix, and Kubernetes.
+	WALBudget WALBudgetSettings `yaml:"wal-budget"`
+
 	// Image overrides the default postgres image — bring your own extensions.
 	// e.g. "postgis/postgis:17-3.5" for PostGIS, or any image that ships the
 	// .so files the extensions you list below need. Format "name:tag". Empty =
@@ -97,6 +101,66 @@ type Settings struct {
 	// Paths are relative to this service's directory (or absolute). A source
 	// whose directory is missing is skipped with a warning.
 	MigrationSources []MigrationSource `yaml:"migration-sources"`
+}
+
+type WALBudgetSettings struct {
+	MaxSizeMB                int `yaml:"max-size-mb"`
+	CheckpointTimeoutSeconds int `yaml:"checkpoint-timeout-seconds"`
+}
+
+type postgresWALBudget struct {
+	maxSizeMB                int
+	checkpointTimeoutSeconds int
+}
+
+const (
+	defaultMaxWALSizeMB             = 4 * 1024
+	defaultCheckpointTimeoutSeconds = 15 * 60
+	minimumMaxWALSizeMB             = 80
+	minimumCheckpointTimeoutSeconds = 30
+	maximumCheckpointTimeoutSeconds = 24 * 60 * 60
+	managedPostgresStorageMB        = 10 * 1024
+	maximumStorageSafeWALSizeMB     = 4 * 1024
+)
+
+func (s *Settings) effectiveWALBudget() (postgresWALBudget, error) {
+	budget := postgresWALBudget{
+		maxSizeMB:                s.WALBudget.MaxSizeMB,
+		checkpointTimeoutSeconds: s.WALBudget.CheckpointTimeoutSeconds,
+	}
+	if budget.maxSizeMB == 0 {
+		budget.maxSizeMB = defaultMaxWALSizeMB
+	}
+	if budget.checkpointTimeoutSeconds == 0 {
+		budget.checkpointTimeoutSeconds = defaultCheckpointTimeoutSeconds
+	}
+	if budget.maxSizeMB < minimumMaxWALSizeMB {
+		return postgresWALBudget{}, fmt.Errorf("wal-budget.max-size-mb must be at least %d", minimumMaxWALSizeMB)
+	}
+	if budget.maxSizeMB > maximumStorageSafeWALSizeMB {
+		return postgresWALBudget{}, fmt.Errorf(
+			"wal-budget.max-size-mb %d exceeds the storage-safe limit %d for the managed %dMB volume",
+			budget.maxSizeMB,
+			maximumStorageSafeWALSizeMB,
+			managedPostgresStorageMB,
+		)
+	}
+	if budget.checkpointTimeoutSeconds < minimumCheckpointTimeoutSeconds ||
+		budget.checkpointTimeoutSeconds > maximumCheckpointTimeoutSeconds {
+		return postgresWALBudget{}, fmt.Errorf(
+			"wal-budget.checkpoint-timeout-seconds must be between %d and %d",
+			minimumCheckpointTimeoutSeconds,
+			maximumCheckpointTimeoutSeconds,
+		)
+	}
+	return budget, nil
+}
+
+func (b postgresWALBudget) postgresArguments() []string {
+	return []string{
+		"-c", fmt.Sprintf("max_wal_size=%dMB", b.maxSizeMB),
+		"-c", fmt.Sprintf("checkpoint_timeout=%ds", b.checkpointTimeoutSeconds),
+	}
 }
 
 // MigrationSource declares one additional service contributing migrations to
@@ -154,6 +218,7 @@ func parseRuntimeImageLock(content []byte) (*resources.DockerImage, error) {
 type DeploymentTemplateParameters struct {
 	WithBootstrap                bool
 	ManagedImage                 string
+	PostgresArguments            []string
 	BootstrapJobName             string
 	DatabaseName                 string
 	StatefulSetSecretReferences  map[string]*builderv0.KubernetesSecretKeyReference

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/url"
 	"strings"
 
@@ -61,9 +62,10 @@ type Settings struct {
 	WALBudget WALBudgetSettings `yaml:"wal-budget"`
 
 	// Image overrides the default postgres image — bring your own extensions.
-	// e.g. "postgis/postgis:17-3.5" for PostGIS, or any image that ships the
-	// .so files the extensions you list below need. Format "name:tag". Empty =
-	// the default pgvector image (see the `image` var).
+	// The image must retain the official PostgreSQL entrypoint contract so the
+	// agent can own the postgres server command and its configuration arguments.
+	// e.g. "postgis/postgis:17-3.5" for PostGIS. Format "name:tag". Empty = the
+	// default pgvector image (see the `image` var).
 	Image string `yaml:"docker-image"`
 
 	// Extensions are CREATE EXTENSION IF NOT EXISTS'd at startup, on top of the
@@ -120,7 +122,8 @@ const (
 	minimumCheckpointTimeoutSeconds = 30
 	maximumCheckpointTimeoutSeconds = 24 * 60 * 60
 	managedPostgresStorageMB        = 10 * 1024
-	maximumStorageSafeWALSizeMB     = 4 * 1024
+	maximumWALStoragePercent        = 40
+	bytesPerMiB                     = 1024 * 1024
 )
 
 func (s *Settings) effectiveWALBudget() (postgresWALBudget, error) {
@@ -137,13 +140,8 @@ func (s *Settings) effectiveWALBudget() (postgresWALBudget, error) {
 	if budget.maxSizeMB < minimumMaxWALSizeMB {
 		return postgresWALBudget{}, fmt.Errorf("wal-budget.max-size-mb must be at least %d", minimumMaxWALSizeMB)
 	}
-	if budget.maxSizeMB > maximumStorageSafeWALSizeMB {
-		return postgresWALBudget{}, fmt.Errorf(
-			"wal-budget.max-size-mb %d exceeds the storage-safe limit %d for the managed %dMB volume",
-			budget.maxSizeMB,
-			maximumStorageSafeWALSizeMB,
-			managedPostgresStorageMB,
-		)
+	if uint64(budget.maxSizeMB) > math.MaxUint64/bytesPerMiB {
+		return postgresWALBudget{}, fmt.Errorf("wal-budget.max-size-mb %d cannot be represented as bytes", budget.maxSizeMB)
 	}
 	if budget.checkpointTimeoutSeconds < minimumCheckpointTimeoutSeconds ||
 		budget.checkpointTimeoutSeconds > maximumCheckpointTimeoutSeconds {
@@ -154,6 +152,38 @@ func (s *Settings) effectiveWALBudget() (postgresWALBudget, error) {
 		)
 	}
 	return budget, nil
+}
+
+func validateWALBudgetStorage(budget postgresWALBudget, storage resources.StorageFilesystem) error {
+	if storage.TotalBytes == 0 {
+		return fmt.Errorf("cannot validate WAL budget against zero storage capacity")
+	}
+	totalMB := storage.TotalBytes / bytesPerMiB
+	availableMB := storage.AvailableBytes / bytesPerMiB
+	storageSafeMB := totalMB * maximumWALStoragePercent / 100
+	requestedMB := uint64(budget.maxSizeMB)
+	if requestedMB > storageSafeMB {
+		return fmt.Errorf(
+			"wal-budget.max-size-mb %d exceeds %d%% of storage capacity (%dMB of %dMB)",
+			budget.maxSizeMB,
+			maximumWALStoragePercent,
+			storageSafeMB,
+			totalMB,
+		)
+	}
+	if requestedMB > availableMB {
+		return fmt.Errorf(
+			"wal-budget.max-size-mb %d exceeds currently available storage %dMB",
+			budget.maxSizeMB,
+			availableMB,
+		)
+	}
+	return nil
+}
+
+func managedPostgresStorage() resources.StorageFilesystem {
+	capacity := uint64(managedPostgresStorageMB) * bytesPerMiB
+	return resources.StorageFilesystem{TotalBytes: capacity, AvailableBytes: capacity}
 }
 
 func (b postgresWALBudget) postgresArguments() []string {
@@ -219,6 +249,9 @@ type DeploymentTemplateParameters struct {
 	WithBootstrap                bool
 	ManagedImage                 string
 	PostgresArguments            []string
+	WALBudgetMaxSizeMB           int
+	WALStoragePercent            int
+	ManagedStorageSizeGiB        int
 	BootstrapJobName             string
 	DatabaseName                 string
 	StatefulSetSecretReferences  map[string]*builderv0.KubernetesSecretKeyReference

--- a/main_test.go
+++ b/main_test.go
@@ -173,9 +173,6 @@ func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext) {
 	owner, err := openPostgresCapabilityProbe(ctx, runtime.connection)
 	require.NoError(t, err)
 	defer owner.Close()
-	if runtimeContext.Kind == resources.RuntimeContextContainer {
-		assertSustainedWALBudget(t, ctx, runtime)
-	}
 	// The reusable migration control plane is exercised against this actual
 	// plugin instance, including isolated database lifecycle, runtime-access
 	// reconciliation, physical cloning, and reversible transactional DDL.
@@ -317,49 +314,6 @@ func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext) {
 			fixtureID,
 		)
 	}
-}
-
-func assertSustainedWALBudget(t *testing.T, ctx context.Context, runtime *Runtime) {
-	t.Helper()
-	db, err := sql.Open("postgres", runtime.connection)
-	require.NoError(t, err)
-	defer db.Close()
-
-	var maxWALSize, checkpointTimeout, checkpointWarning string
-	require.NoError(t, db.QueryRowContext(ctx, "SHOW max_wal_size").Scan(&maxWALSize))
-	require.NoError(t, db.QueryRowContext(ctx, "SHOW checkpoint_timeout").Scan(&checkpointTimeout))
-	require.NoError(t, db.QueryRowContext(ctx, "SHOW checkpoint_warning").Scan(&checkpointWarning))
-	require.Equal(t, "4GB", maxWALSize)
-	require.Equal(t, "15min", checkpointTimeout)
-	require.Equal(t, "30s", checkpointWarning)
-
-	_, err = db.ExecContext(ctx, "CHECKPOINT")
-	require.NoError(t, err)
-	var requestedBefore int64
-	require.NoError(t, db.QueryRowContext(ctx, "SELECT num_requested FROM pg_stat_checkpointer").Scan(&requestedBefore))
-	_, err = db.ExecContext(ctx, "CREATE TABLE wal_budget_qualification (id bigint)")
-	require.NoError(t, err)
-	started := time.Now()
-	_, err = db.ExecContext(ctx, `
-		DO $$
-		BEGIN
-			FOR i IN 1..96 LOOP
-				INSERT INTO wal_budget_qualification VALUES (i);
-				PERFORM pg_switch_wal();
-			END LOOP;
-		END
-		$$
-	`)
-	require.NoError(t, err)
-	require.Less(t, time.Since(started), 30*time.Second, "qualification must cross the former 1GB WAL boundary inside checkpoint_warning")
-	time.Sleep(2 * time.Second)
-
-	var requestedAfter int64
-	require.NoError(t, db.QueryRowContext(ctx, "SELECT num_requested FROM pg_stat_checkpointer").Scan(&requestedAfter))
-	require.Equal(t, requestedBefore, requestedAfter, "production WAL profile requested an early checkpoint")
-	require.NotContains(t, runtime.runnerEnvironment.TailLogs(ctx, 2000), "checkpoints are occurring too frequently")
-	_, err = db.ExecContext(ctx, "DROP TABLE wal_budget_qualification")
-	require.NoError(t, err)
 }
 
 // assertMigrationConnectionsAreOwned proves the real golang-migrate boundary

--- a/main_test.go
+++ b/main_test.go
@@ -173,6 +173,9 @@ func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext) {
 	owner, err := openPostgresCapabilityProbe(ctx, runtime.connection)
 	require.NoError(t, err)
 	defer owner.Close()
+	if runtimeContext.Kind == resources.RuntimeContextContainer {
+		assertSustainedWALBudget(t, ctx, runtime)
+	}
 	// The reusable migration control plane is exercised against this actual
 	// plugin instance, including isolated database lifecycle, runtime-access
 	// reconciliation, physical cloning, and reversible transactional DDL.
@@ -314,6 +317,49 @@ func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext) {
 			fixtureID,
 		)
 	}
+}
+
+func assertSustainedWALBudget(t *testing.T, ctx context.Context, runtime *Runtime) {
+	t.Helper()
+	db, err := sql.Open("postgres", runtime.connection)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var maxWALSize, checkpointTimeout, checkpointWarning string
+	require.NoError(t, db.QueryRowContext(ctx, "SHOW max_wal_size").Scan(&maxWALSize))
+	require.NoError(t, db.QueryRowContext(ctx, "SHOW checkpoint_timeout").Scan(&checkpointTimeout))
+	require.NoError(t, db.QueryRowContext(ctx, "SHOW checkpoint_warning").Scan(&checkpointWarning))
+	require.Equal(t, "4GB", maxWALSize)
+	require.Equal(t, "15min", checkpointTimeout)
+	require.Equal(t, "30s", checkpointWarning)
+
+	_, err = db.ExecContext(ctx, "CHECKPOINT")
+	require.NoError(t, err)
+	var requestedBefore int64
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT num_requested FROM pg_stat_checkpointer").Scan(&requestedBefore))
+	_, err = db.ExecContext(ctx, "CREATE TABLE wal_budget_qualification (id bigint)")
+	require.NoError(t, err)
+	started := time.Now()
+	_, err = db.ExecContext(ctx, `
+		DO $$
+		BEGIN
+			FOR i IN 1..96 LOOP
+				INSERT INTO wal_budget_qualification VALUES (i);
+				PERFORM pg_switch_wal();
+			END LOOP;
+		END
+		$$
+	`)
+	require.NoError(t, err)
+	require.Less(t, time.Since(started), 30*time.Second, "qualification must cross the former 1GB WAL boundary inside checkpoint_warning")
+	time.Sleep(2 * time.Second)
+
+	var requestedAfter int64
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT num_requested FROM pg_stat_checkpointer").Scan(&requestedAfter))
+	require.Equal(t, requestedBefore, requestedAfter, "production WAL profile requested an early checkpoint")
+	require.NotContains(t, runtime.runnerEnvironment.TailLogs(ctx, 2000), "checkpoints are occurring too frequently")
+	_, err = db.ExecContext(ctx, "DROP TABLE wal_budget_qualification")
+	require.NoError(t, err)
 }
 
 // assertMigrationConnectionsAreOwned proves the real golang-migrate boundary

--- a/nixpg.go
+++ b/nixpg.go
@@ -52,6 +52,7 @@ type nixPostgres struct {
 	password  string
 	dbName    string
 	logLevel  string
+	walBudget postgresWALBudget
 	out       io.Writer
 	proc      runners.Proc
 	// serverCancel cancels serverCtx — the context the postgres process runs
@@ -80,7 +81,7 @@ type nixPostgres struct {
 // input, so runtime state cannot live below it. The scoped key also prevents
 // independent Codefly flows from sharing credentials or database contents,
 // while an unscoped restart retains the historical per-location cluster.
-func newNixPostgres(ctx context.Context, stateKey string, port uint16, user, password, dbName, logLevel string, out io.Writer) (*nixPostgres, error) {
+func newNixPostgres(ctx context.Context, stateKey string, port uint16, user, password, dbName, logLevel string, walBudget postgresWALBudget, out io.Writer) (*nixPostgres, error) {
 	if strings.TrimSpace(password) == "" {
 		return nil, fmt.Errorf("postgres password is required for the native runtime")
 	}
@@ -125,6 +126,7 @@ func newNixPostgres(ctx context.Context, stateKey string, port uint16, user, pas
 		password:  password,
 		dbName:    dbName,
 		logLevel:  logLevel,
+		walBudget: walBudget,
 		out:       out,
 	}, nil
 }
@@ -303,6 +305,7 @@ func (n *nixPostgres) startServer(ctx context.Context) error {
 		"-k", n.socketDir,
 		"-c", "listen_addresses=127.0.0.1",
 	}
+	args = append(args, n.walBudget.postgresArguments()...)
 	if lvl := strings.ToLower(strings.TrimSpace(n.logLevel)); lvl != "" {
 		args = append(args,
 			"-c", "log_min_messages="+lvl,

--- a/nixpg.go
+++ b/nixpg.go
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/codefly-dev/core/resources"
 	runners "github.com/codefly-dev/core/runners/base"
 	"github.com/codefly-dev/core/shared"
 	"github.com/lib/pq"
@@ -173,6 +174,13 @@ func (n *nixPostgres) Init(ctx context.Context) (initErr error) {
 	}()
 	if err := n.env.Init(ctx); err != nil {
 		return fmt.Errorf("materialize nix postgres env: %w", err)
+	}
+	storage, err := resources.InspectStorageFilesystem(n.dataDir)
+	if err != nil {
+		return fmt.Errorf("inspect nix postgres storage: %w", err)
+	}
+	if err := validateWALBudgetStorage(n.walBudget, storage); err != nil {
+		return err
 	}
 	if err := n.resolveBinDir(); err != nil {
 		return err

--- a/nixpg_auth_test.go
+++ b/nixpg_auth_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewNixPostgresRejectsEmptyPasswordBeforeProvisioning(t *testing.T) {
-	if _, err := newNixPostgres(context.Background(), t.TempDir(), 5432, "postgres", "", "postgres", "", nil); err == nil {
+	if _, err := newNixPostgres(context.Background(), t.TempDir(), 5432, "postgres", "", "postgres", "", postgresWALBudget{}, nil); err == nil {
 		t.Fatal("native postgres accepted an empty password")
 	}
 }

--- a/runtime.go
+++ b/runtime.go
@@ -28,9 +28,8 @@ type persistentCacheMounter interface {
 	WithPersistentCacheMount(context.Context, string, string) (string, error)
 }
 
-func mountPersistentPostgresData(ctx context.Context, runner persistentCacheMounter) error {
-	_, err := runner.WithPersistentCacheMount(ctx, postgresDataCacheKey, postgresDataDirectory)
-	return err
+func mountPersistentPostgresData(ctx context.Context, runner persistentCacheMounter) (string, error) {
+	return runner.WithPersistentCacheMount(ctx, postgresDataCacheKey, postgresDataDirectory)
 }
 
 type Runtime struct {
@@ -80,7 +79,7 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 	s.Runtime.WithContext(req.GetRuntimeContext())
 
 	w := s.Wool.In("runtime::init")
-	walBudget, err := s.Settings.effectiveWALBudget()
+	walBudget, err := s.effectiveWALBudget()
 	if err != nil {
 		return s.Runtime.InitError(err)
 	}
@@ -176,8 +175,16 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 	if err != nil {
 		return s.Runtime.InitError(err)
 	}
-	if err = mountPersistentPostgresData(ctx, runner); err != nil {
+	postgresDataPath, err := mountPersistentPostgresData(ctx, runner)
+	if err != nil {
 		return s.Runtime.InitError(s.Wool.Wrapf(err, "cannot configure persistent postgres data"))
+	}
+	storage, err := resources.InspectStorageFilesystem(postgresDataPath)
+	if err != nil {
+		return s.Runtime.InitError(s.Wool.Wrapf(err, "cannot inspect persistent postgres storage"))
+	}
+	if err = validateWALBudgetStorage(walBudget, storage); err != nil {
+		return s.Runtime.InitError(err)
 	}
 
 	runner.WithOutput(newPGLogWriter(s.Wool))

--- a/runtime.go
+++ b/runtime.go
@@ -80,6 +80,11 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 	s.Runtime.WithContext(req.GetRuntimeContext())
 
 	w := s.Wool.In("runtime::init")
+	walBudget, err := s.Settings.effectiveWALBudget()
+	if err != nil {
+		return s.Runtime.InitError(err)
+	}
+	reportWALBudget(w, walBudget)
 
 	s.NetworkMappings = req.ProposedNetworkMappings
 
@@ -151,7 +156,7 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 	if rc := req.GetRuntimeContext(); rc != nil && rc.Kind == resources.RuntimeContextNix {
 		w.Debug("using nix runtime for postgres", wool.Field("port", instance.Port))
 		nixpg, errNix := newNixPostgres(ctx, nixPostgresStateKey(s.Location, s.Environment.NamingScope), uint16(instance.Port),
-			s.postgresUser, s.postgresPassword, s.DatabaseName, s.LogLevel, newPGLogWriter(s.Wool))
+			s.postgresUser, s.postgresPassword, s.DatabaseName, s.LogLevel, walBudget, newPGLogWriter(s.Wool))
 		if errNix != nil {
 			return s.Runtime.InitError(errNix)
 		}
@@ -184,22 +189,7 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 		resources.Env("POSTGRES_PASSWORD", s.postgresPassword),
 		resources.Env("POSTGRES_DB", s.DatabaseName))
 
-	// Quieten the server when a log level is configured. The official
-	// postgres image's ENTRYPOINT is docker-entrypoint.sh and its
-	// default CMD is `postgres`. WithCommand only overrides CMD, so
-	// we provide just `postgres <flags>` — the entrypoint still runs
-	// initdb on first boot, then execs our postgres + flags. The
-	// `-c` args are passed straight to the server and override the
-	// equivalent postgresql.conf entries.
-	if lvl := strings.ToLower(strings.TrimSpace(s.LogLevel)); lvl != "" {
-		runner.WithCommand(
-			"postgres",
-			"-c", "log_min_messages="+lvl,
-			"-c", "log_statement=none",
-			"-c", "log_connections=off",
-			"-c", "log_disconnections=off",
-		)
-	}
+	runner.WithCommand(postgresCommand(walBudget, s.LogLevel)...)
 
 	s.runnerEnvironment = runner
 
@@ -214,6 +204,26 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 		return s.Runtime.InitError(err)
 	}
 	return s.Runtime.InitResponse()
+}
+
+func postgresCommand(walBudget postgresWALBudget, logLevel string) []string {
+	args := append([]string{"postgres"}, walBudget.postgresArguments()...)
+	if level := strings.ToLower(strings.TrimSpace(logLevel)); level != "" {
+		args = append(args,
+			"-c", "log_min_messages="+level,
+			"-c", "log_statement=none",
+			"-c", "log_connections=off",
+			"-c", "log_disconnections=off",
+		)
+	}
+	return args
+}
+
+func reportWALBudget(w *wool.Wool, budget postgresWALBudget) {
+	w.Info("effective postgres WAL budget",
+		wool.Field("max_wal_size_mb", budget.maxSizeMB),
+		wool.Field("checkpoint_timeout_seconds", budget.checkpointTimeoutSeconds),
+	)
 }
 
 // migrateOnInit applies schema migrations DURING Init — after the database is

--- a/runtime_persistence_test.go
+++ b/runtime_persistence_test.go
@@ -27,8 +27,12 @@ func (m *recordingPersistentCacheMounter) WithPersistentCacheMount(
 func TestMountPersistentPostgresDataUsesCodeflyOwnedScope(t *testing.T) {
 	mounter := &recordingPersistentCacheMounter{}
 
-	if err := mountPersistentPostgresData(context.Background(), mounter); err != nil {
+	path, err := mountPersistentPostgresData(context.Background(), mounter)
+	if err != nil {
 		t.Fatalf("mount persistent postgres data: %v", err)
+	}
+	if path != "/codefly/runtime-cache/test/postgres-data" {
+		t.Fatalf("cache path = %q", path)
 	}
 	if mounter.callCount != 1 {
 		t.Fatalf("mount calls = %d, want 1", mounter.callCount)
@@ -45,7 +49,7 @@ func TestMountPersistentPostgresDataPropagatesFailure(t *testing.T) {
 	want := errors.New("cache unavailable")
 	mounter := &recordingPersistentCacheMounter{err: want}
 
-	if err := mountPersistentPostgresData(context.Background(), mounter); !errors.Is(err, want) {
+	if _, err := mountPersistentPostgresData(context.Background(), mounter); !errors.Is(err, want) {
 		t.Fatalf("mount error = %v, want %v", err, want)
 	}
 }

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -13,9 +13,9 @@ Local database state survives ordinary stop/start and container recreation. In D
 
 ## WAL budget
 
-The agent starts local Docker, Nix, and generated Kubernetes Postgres instances with the same WAL/checkpoint budget. The deterministic default is `max_wal_size=4096MB` and `checkpoint_timeout=900s`; it is the production semantic-ingestion profile and needs no application-side command or `postgresql.conf` edit. The configured 4 GiB maximum is 40% of the managed 10 GiB volume, reserving a nominal 6 GiB for relation data and checkpoint headroom. PostgreSQL treats `max_wal_size` as a soft budget, so WAL can temporarily exceed it under heavy load.
+The agent starts local Docker, Nix, and generated Kubernetes Postgres instances with the same WAL/checkpoint budget. The deterministic default is `max_wal_size=4096MB` and `checkpoint_timeout=900s`; it is the production semantic-ingestion profile and needs no application-side command or `postgresql.conf` edit. PostgreSQL treats `max_wal_size` as a soft budget, so WAL can temporarily exceed it under heavy load.
 
-The agent-backed qualification drives 96 WAL segment switches (about 1.5 GiB) inside PostgreSQL's 30-second `checkpoint_warning` window. That crosses the former 1 GiB budget which reproduces the production warning, then asserts the production profile requests no early checkpoint and emits no warning.
+The agent-backed qualification generates three 16 MiB WAL segments per second, matching the fastest warning cadence observed in production. It continues until PostgreSQL records the production profile's WAL-requested checkpoint, then proves that checkpoint occurs outside the 30-second `checkpoint_warning` window and that Postgres emits no frequency warning.
 
 Override either numeric value in `service.codefly.yaml` when a smaller workload needs a smaller budget:
 
@@ -25,7 +25,9 @@ wal-budget:
   checkpoint-timeout-seconds: 600
 ```
 
-`max-size-mb` must be between 80 and 4096. `checkpoint-timeout-seconds` must be between 30 and 86400. Omitted or zero values select the defaults. The agent rejects invalid values and budgets above the managed-volume safety ceiling before Postgres starts, and reports the effective values in the `effective postgres WAL budget` lifecycle event.
+`max-size-mb` must be at least 80. `checkpoint-timeout-seconds` must be between 30 and 86400. Omitted or zero values select the defaults. For local Docker and Nix, the agent inspects the persistent filesystem immediately before database startup and requires the WAL budget to fit both the currently available space and 40% of total capacity. This allows larger budgets on larger stores while rejecting a default budget on a near-full store. Kubernetes keeps its managed 10 GiB claim, so render-time validation caps its WAL budget at 4096 MiB; an init container checks the mounted claim's live capacity and available space before Postgres starts. The agent reports the effective values in the `effective postgres WAL budget` lifecycle event.
+
+When `docker-image` is overridden, the image must preserve the official PostgreSQL entrypoint contract and accept `postgres` plus server arguments. The agent deliberately owns that command so the WAL settings are effective from first startup; images whose custom `CMD` is an independent wrapper are outside this interface. Official-derived extension images such as `postgis/postgis:17-3.5` retain the required contract.
 
 ## External-identity mode
 

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -11,6 +11,22 @@ The bootstrap job applies migrations and reconciles runtime roles and grants on 
 
 Local database state survives ordinary stop/start and container recreation. In Docker mode, the agent mounts the official image's data directory from a Codefly-owned persistent runtime directory scoped by workspace, service, and naming scope. Stable and development scopes therefore keep independent databases even when they run from the same checkout.
 
+## WAL budget
+
+The agent starts local Docker, Nix, and generated Kubernetes Postgres instances with the same WAL/checkpoint budget. The deterministic default is `max_wal_size=4096MB` and `checkpoint_timeout=900s`; it is the production semantic-ingestion profile and needs no application-side command or `postgresql.conf` edit. The configured 4 GiB maximum is 40% of the managed 10 GiB volume, reserving a nominal 6 GiB for relation data and checkpoint headroom. PostgreSQL treats `max_wal_size` as a soft budget, so WAL can temporarily exceed it under heavy load.
+
+The agent-backed qualification drives 96 WAL segment switches (about 1.5 GiB) inside PostgreSQL's 30-second `checkpoint_warning` window. That crosses the former 1 GiB budget which reproduces the production warning, then asserts the production profile requests no early checkpoint and emits no warning.
+
+Override either numeric value in `service.codefly.yaml` when a smaller workload needs a smaller budget:
+
+```yaml
+wal-budget:
+  max-size-mb: 2048
+  checkpoint-timeout-seconds: 600
+```
+
+`max-size-mb` must be between 80 and 4096. `checkpoint-timeout-seconds` must be between 30 and 86400. Omitted or zero values select the defaults. The agent rejects invalid values and budgets above the managed-volume safety ceiling before Postgres starts, and reports the effective values in the `effective postgres WAL budget` lifecycle event.
+
 ## External-identity mode
 
 Set `auth-mode: external-identity` for managed cloud Postgres with password authentication disabled. Login principals are created out-of-band by the cloud identity provider (Entra ID / Cloud SQL IAM); the service generates, requires, and exports no passwords. The deploy build promotes no credential `secretKeyRef`s, and the exported `owner-connection`, `read-only-connection`, and `read-write-connection` strings are passwordless DSNs (`postgresql://<principal>@host/db`) that carry the principal but no secret.

--- a/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
+++ b/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
@@ -40,6 +40,10 @@ spec:
           # dir is authoritative.
           image: {{ .Deployment.Parameters.ManagedImage }}
           imagePullPolicy: IfNotPresent
+          args:
+{{- range .Deployment.Parameters.PostgresArguments }}
+            - {{ printf "%q" . }}
+{{- end }}
           # Container-level security. Defense-in-depth on top of the
           # pod-level securityContext above. allowPrivilegeEscalation
           # = false stops setuid binaries from gaining root inside

--- a/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
+++ b/templates/deployment/kustomize/base/stateful-set.yaml.tmpl
@@ -30,6 +30,46 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       terminationGracePeriodSeconds: 60
+      initContainers:
+        - name: validate-wal-storage
+          image: {{ .Deployment.Parameters.ManagedImage }}
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/sh", "-ec"]
+          args:
+            - |
+              set -- $(df -Pk /var/lib/postgresql/data | awk 'NR == 2 { print $2, $4 }')
+              total_kb="$1"
+              available_kb="$2"
+              wal_kb=$(({{ .Deployment.Parameters.WALBudgetMaxSizeMB }} * 1024))
+              storage_safe_kb=$((total_kb * {{ .Deployment.Parameters.WALStoragePercent }} / 100))
+              if [ "$wal_kb" -gt "$storage_safe_kb" ]; then
+                echo "wal-budget.max-size-mb exceeds {{ .Deployment.Parameters.WALStoragePercent }}% of mounted storage capacity" >&2
+                exit 1
+              fi
+              if [ "$wal_kb" -gt "$available_kb" ]; then
+                echo "wal-budget.max-size-mb exceeds currently available mounted storage" >&2
+                exit 1
+              fi
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 70
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          resources:
+            requests:
+              cpu: 10m
+              memory: 16Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
       containers:
         - name: postgres
           # Supplied by main.go's managed-image declaration (or the service
@@ -137,4 +177,4 @@ spec:
         accessModes: ["ReadWriteOnce"]
         resources:
           requests:
-            storage: 10Gi
+            storage: {{ .Deployment.Parameters.ManagedStorageSizeGiB }}Gi

--- a/wal_qualification_test.go
+++ b/wal_qualification_test.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
+	"github.com/codefly-dev/core/network"
+	"github.com/codefly-dev/core/resources"
+	"github.com/codefly-dev/core/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSustainedWALBudgetDocker(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	cacheRoot := t.TempDir()
+	t.Setenv(resources.CodeflyHomeEnv, cacheRoot)
+	runtime := NewRuntime()
+	cleaned := false
+	t.Cleanup(func() {
+		if !cleaned {
+			if err := cleanupWALQualificationRuntime(runtime, cacheRoot); err != nil {
+				t.Errorf("cleanup WAL qualification runtime: %v", err)
+			}
+		}
+	})
+	startWALQualificationRuntime(t, ctx, runtime)
+
+	db, err := sql.Open("postgres", runtime.connection)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+	require.NoError(t, qualifySustainedWALBudget(ctx, db, runtime))
+	require.NoError(t, db.Close())
+
+	require.NoError(t, cleanupWALQualificationRuntime(runtime, cacheRoot))
+	cleaned = true
+	_, err = os.Stat(cacheRoot)
+	require.ErrorIs(t, err, os.ErrNotExist, "qualification must remove its persistent runtime cache")
+}
+
+func startWALQualificationRuntime(t *testing.T, ctx context.Context, runtime *Runtime) {
+	t.Helper()
+	workspace := &resources.Workspace{Name: "wal-qualification"}
+	workspacePath := t.TempDir()
+	service := resources.Service{
+		Name:    fmt.Sprintf("walq-%d", time.Now().UnixNano()),
+		Version: "test",
+	}
+	require.NoError(t, service.SaveAtDir(ctx, filepath.Join(workspacePath, "mod", service.Name)))
+	identity := &basev0.ServiceIdentity{
+		Name:                service.Name,
+		Module:              "mod",
+		Workspace:           workspace.Name,
+		WorkspacePath:       workspacePath,
+		RelativeToWorkspace: filepath.Join("mod", service.Name),
+	}
+	builder := NewBuilder()
+	_, err := builder.Load(ctx, &builderv0.LoadRequest{
+		DisableCatch: true,
+		Identity:     identity,
+		CreationMode: &builderv0.CreationMode{Communicate: false},
+	})
+	require.NoError(t, err)
+	_, err = builder.Create(ctx, &builderv0.CreateRequest{})
+	require.NoError(t, err)
+
+	environment := resources.LocalEnvironment()
+	load, err := runtime.Load(ctx, &runtimev0.LoadRequest{
+		Identity:     identity,
+		Environment:  shared.Must(environment.Proto()),
+		DisableCatch: true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, runtimev0.LoadStatus_READY, load.GetStatus().GetState(), load.GetStatus().GetMessage())
+	require.NotNil(t, runtime.TcpEndpoint)
+	runtime.NoMigration = true
+
+	networkManager, err := network.NewRuntimeManager(ctx, nil)
+	require.NoError(t, err)
+	networkManager.WithTemporaryPorts()
+	networkMappings, err := networkManager.GenerateNetworkMappings(
+		ctx,
+		environment,
+		workspace,
+		runtime.Identity,
+		runtime.Endpoints,
+		resources.NewRuntimeContextContainer(),
+	)
+	require.NoError(t, err)
+	configuration := &basev0.Configuration{
+		Origin:         identity.Module + "/" + identity.Name,
+		RuntimeContext: resources.NewRuntimeContextFree(),
+		Infos: []*basev0.ConfigurationInformation{{
+			Name: "postgres",
+			ConfigurationValues: []*basev0.ConfigurationValue{
+				{Key: "POSTGRES_USER", Value: "postgres"},
+				{Key: "POSTGRES_PASSWORD", Value: "owner-password"},
+				{Key: "POSTGRES_READ_ONLY_PASSWORD", Value: "read-only-password"},
+				{Key: "POSTGRES_READ_WRITE_PASSWORD", Value: "read-write-password"},
+			},
+		}},
+	}
+	init, err := runtime.Init(ctx, &runtimev0.InitRequest{
+		RuntimeContext:          resources.NewRuntimeContextContainer(),
+		Configuration:           configuration,
+		ProposedNetworkMappings: networkMappings,
+	})
+	require.NoError(t, err)
+	require.Equal(t, runtimev0.InitStatus_READY, init.GetStatus().GetState(), init.GetStatus().GetMessage())
+	start, err := runtime.Start(ctx, &runtimev0.StartRequest{})
+	require.NoError(t, err)
+	require.Equal(t, runtimev0.StartStatus_STARTED, start.GetStatus().GetState(), start.GetStatus().GetMessage())
+}
+
+func qualifySustainedWALBudget(ctx context.Context, db *sql.DB, runtime *Runtime) error {
+	var maxWALSize, checkpointTimeout, checkpointWarning, walSegmentSize string
+	if err := db.QueryRowContext(ctx, "SHOW max_wal_size").Scan(&maxWALSize); err != nil {
+		return err
+	}
+	if err := db.QueryRowContext(ctx, "SHOW checkpoint_timeout").Scan(&checkpointTimeout); err != nil {
+		return err
+	}
+	if err := db.QueryRowContext(ctx, "SHOW checkpoint_warning").Scan(&checkpointWarning); err != nil {
+		return err
+	}
+	if err := db.QueryRowContext(ctx, "SHOW wal_segment_size").Scan(&walSegmentSize); err != nil {
+		return err
+	}
+	if maxWALSize != "4GB" || checkpointTimeout != "15min" || checkpointWarning != "30s" || walSegmentSize != "16MB" {
+		return fmt.Errorf(
+			"effective WAL settings = max_wal_size %s, checkpoint_timeout %s, checkpoint_warning %s, wal_segment_size %s",
+			maxWALSize,
+			checkpointTimeout,
+			checkpointWarning,
+			walSegmentSize,
+		)
+	}
+	if _, err := db.ExecContext(ctx, "CREATE TABLE wal_budget_qualification (id bigint)"); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, "CHECKPOINT"); err != nil {
+		return err
+	}
+	var requestedBefore int64
+	if err := db.QueryRowContext(ctx, "SELECT num_requested FROM pg_stat_checkpointer").Scan(&requestedBefore); err != nil {
+		return err
+	}
+
+	const (
+		segmentsPerSecond = 3
+		maximumSegments   = 384
+	)
+	started := time.Now()
+	segmentsGenerated := 0
+	for segmentsGenerated < maximumSegments {
+		batch := segmentsGenerated/segmentsPerSecond + 1
+		target := started.Add(time.Duration(batch) * time.Second)
+		if wait := time.Until(target); wait > 0 {
+			timer := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+		}
+		if _, err := db.ExecContext(ctx, `
+			DO $$
+			BEGIN
+				FOR i IN 1..3 LOOP
+					INSERT INTO wal_budget_qualification VALUES (i);
+					PERFORM pg_switch_wal();
+				END LOOP;
+			END
+			$$
+		`); err != nil {
+			return err
+		}
+		segmentsGenerated += segmentsPerSecond
+		var requestedAfter int64
+		if err := db.QueryRowContext(ctx, "SELECT num_requested FROM pg_stat_checkpointer").Scan(&requestedAfter); err != nil {
+			return err
+		}
+		if requestedAfter > requestedBefore {
+			cadence := time.Since(started)
+			if cadence < 30*time.Second {
+				return fmt.Errorf("production WAL profile requested its checkpoint after %s", cadence.Round(time.Millisecond))
+			}
+			logs := runtime.runnerEnvironment.TailLogs(ctx, 10000)
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if containsCheckpointFrequencyWarning(logs) {
+				return errors.New("production WAL profile emitted the checkpoint-frequency warning")
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("production WAL profile did not request a WAL-budget checkpoint after %d segment switches", segmentsGenerated)
+}
+
+func containsCheckpointFrequencyWarning(logs string) bool {
+	return strings.Contains(logs, "checkpoints are occurring too frequently")
+}
+
+func cleanupWALQualificationRuntime(runtime *Runtime, cacheRoot string) error {
+	cleanupCtx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	var permissionErr, shutdownErr error
+	if runtime.runnerEnvironment != nil {
+		proc, err := runtime.runnerEnvironment.NewProcess("chmod", "-R", "a+rwX", postgresDataDirectory)
+		if err != nil {
+			permissionErr = err
+		} else {
+			permissionErr = proc.Run(cleanupCtx)
+		}
+		shutdownErr = runtime.runnerEnvironment.Shutdown(cleanupCtx)
+	}
+	removeErr := os.RemoveAll(cacheRoot)
+	return errors.Join(permissionErr, shutdownErr, removeErr)
+}

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -40,6 +40,10 @@ func TestCIWorkflowValidatesLockedImageForEveryPullRequest(t *testing.T) {
 
 	unitTests := findWorkflowStep(t, workflow.Jobs["image"], "Run unit tests")
 	require.Empty(t, unitTests.If)
+	qualification := findWorkflowStep(t, workflow.Jobs["image"], "Qualify sustained WAL budget")
+	require.Empty(t, qualification.If)
+	require.Contains(t, qualification.Run, "-run '^TestSustainedWALBudgetDocker$'")
+	require.Contains(t, qualification.Run, "-count=1")
 
 	smoke := findWorkflowStep(t, workflow.Jobs["image"], "Smoke test runtime image")
 	require.Contains(t, smoke.Run, "--read-only")


### PR DESCRIPTION
Closes #59.

## Summary
- Give agent-managed Postgres a deterministic 4 GiB WAL and 15-minute checkpoint budget so sustained semantic publication no longer inherits the undersized server default.
- Validate local budgets against live filesystem capacity and free space, and gate Kubernetes startup against both the managed 10 GiB claim and current PVC availability.
- Prove the production profile through an isolated agent-backed workload that runs to a real WAL-requested checkpoint at the observed production rate, with no application-side command or configuration-file edits.

## Test plan
- [x] `go test ./... -count=1 -timeout=10m`
- [x] `go vet ./...`
- [x] `golangci-lint run --new-from-rev=origin/main ./...`
- [x] Render and validate the generated Kustomize manifests, including the pre-start storage check and effective PostgreSQL arguments.
- [x] Generate three 16 MiB WAL segments per second through the real Docker-backed agent until PostgreSQL records a requested checkpoint; verify cadence exceeds 30 seconds, logs contain no frequent-checkpoint warning, and the isolated cache is removed.

## Risk
- Custom `docker-image` overrides must preserve the official PostgreSQL entrypoint contract because the agent owns the server command and WAL arguments; independent wrapper `CMD`s are not supported.