### PR TITLE
feat: emit build recipe when CLI owns the docker build (#63)

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/codefly-dev/core/agents/services"
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	"github.com/codefly-dev/core/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// newBuildTestBuilder loads a builder whose Location points at a temporary
+// service directory seeded with a migrations tree, so Build can render its
+// recipe against a real filesystem.
+func newBuildTestBuilder(t *testing.T) *Builder {
+	t.Helper()
+	ctx := context.Background()
+	builder := NewBuilder()
+	identity := &basev0.ServiceIdentity{
+		Workspace: "workspace",
+		Module:    "module",
+		Name:      "postgres",
+		Version:   "1.2.3",
+	}
+	require.NoError(t, builder.HeadlessLoad(ctx, identity))
+	builder.Information = &services.Information{
+		Service: resources.ToServiceWithCase(builder.Identity),
+		Module:  resources.ToModuleWithCase(builder.Identity),
+	}
+	builder.DatabaseName = "test"
+
+	location := t.TempDir()
+	builder.Location = location
+	require.NoError(t, os.MkdirAll(filepath.Join(location, "migrations"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(location, "migrations", "1_create_table.up.sql"),
+		[]byte("CREATE TABLE example ();\n"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(location, "migrations", "1_create_table.down.sql"),
+		[]byte("DROP TABLE example;\n"), 0o644))
+	return builder
+}
+
+func buildRequest(outputDirectory string) *builderv0.BuildRequest {
+	return &builderv0.BuildRequest{
+		BuildContext: &builderv0.BuildContext{
+			Kind: &builderv0.BuildContext_DockerBuildContext{
+				DockerBuildContext: &builderv0.DockerBuildContext{DockerRepository: "registry.example.com"},
+			},
+		},
+		OutputDirectory: outputDirectory,
+	}
+}
+
+func TestBuildEmitsRecipeToOutputDirectory(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	plan := response.GetResult().GetDockerBuildPlan()
+	require.NotNil(t, plan, "recipe build must return a DockerBuildPlan, not a legacy DockerBuildResult")
+	require.Equal(t, services.DockerBuildRecipeContractVersion, plan.GetContractVersion())
+
+	require.Len(t, plan.GetRecipes(), 1)
+	recipe := plan.GetRecipes()[0]
+	require.Equal(t, "builder/Dockerfile", recipe.GetDockerfile())
+	require.Equal(t, ".", recipe.GetContext())
+	require.Equal(t, "registry.example.com/module/postgres", recipe.GetImage())
+	require.Equal(t, []string{"linux/amd64", "linux/arm64"}, recipe.GetPlatforms())
+
+	// The rendered tree is a self-contained context: a consumer with no codefly
+	// toolchain can build it from the emitted files alone.
+	require.FileExists(t, filepath.Join(outputDirectory, "builder", "Dockerfile"))
+	require.FileExists(t, filepath.Join(outputDirectory, "builder", "runtime-access.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "migrations", "1_create_table.up.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "migrations", "1_create_table.down.sql"))
+
+	// The plan the agent emits verifies against the tree it wrote, so the CLI
+	// builds it without the recipe drifting from the inventory.
+	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, plan))
+}
+
+func TestBuildRecipeOmitsMigrationsWhenDisabled(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	builder.Settings.NoMigration = true
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	require.NoDirExists(t, filepath.Join(outputDirectory, "migrations"))
+	require.NotNil(t, response.GetResult().GetDockerBuildPlan())
+	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
+}

--- a/build_test.go
+++ b/build_test.go
@@ -102,3 +102,53 @@ func TestBuildRecipeOmitsMigrationsWhenDisabled(t *testing.T) {
 	require.NotNil(t, response.GetResult().GetDockerBuildPlan())
 	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
 }
+
+// TestBuildRecipePurgesPreexistingOutputDirectory covers a caller that reuses or
+// pre-populates the output directory: stale and foreign content must not survive
+// into the emitted tree, the plan inventory, or (via COPY .) the image.
+func TestBuildRecipePurgesPreexistingOutputDirectory(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	outputDirectory := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(outputDirectory, "migrations"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDirectory, "migrations", "9_stale.up.sql"),
+		[]byte("SELECT 'stale';\n"), 0o644))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(outputDirectory, "stale-root.txt"),
+		[]byte("foreign\n"), 0o644))
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	require.NoFileExists(t, filepath.Join(outputDirectory, "stale-root.txt"))
+	require.NoFileExists(t, filepath.Join(outputDirectory, "migrations", "9_stale.up.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "migrations", "1_create_table.up.sql"))
+
+	plan := response.GetResult().GetDockerBuildPlan()
+	require.NotNil(t, plan)
+	for _, file := range plan.GetFiles() {
+		require.NotContains(t, file.GetPath(), "stale", "stale content leaked into the plan inventory")
+	}
+	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, plan))
+}
+
+// TestBuildRecipeCreatesEmptyMigrationsDirectory covers migrations enabled with
+// none authored yet: the recipe must still carry a migrations directory so the
+// Dockerfile's COPY migrations resolves, matching the legacy in-agent build.
+func TestBuildRecipeCreatesEmptyMigrationsDirectory(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	require.NoError(t, os.RemoveAll(builder.Local("migrations")))
+	require.NoError(t, os.MkdirAll(builder.Local("migrations"), 0o755))
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	require.DirExists(t, filepath.Join(outputDirectory, "migrations"))
+	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
+}

--- a/builder.go
+++ b/builder.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
 	"text/template"
 
@@ -150,6 +151,10 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 		ReadWriteRoles:               readWriteRoles,
 	}
 
+	if outputDirectory := req.GetOutputDirectory(); outputDirectory != "" {
+		return s.buildRecipe(ctx, outputDirectory, img, docker)
+	}
+
 	err = shared.DeleteFile(ctx, s.Local("builder/Dockerfile"))
 	if err != nil {
 		return s.Builder.BuildError(err)
@@ -177,6 +182,65 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 	s.Builder.WithDockerImages(img)
 
 	return s.Builder.BuildResponse()
+}
+
+// buildRecipe renders the bootstrap image's Dockerfile and build context into the
+// caller-owned output directory and returns a reproducible build plan instead of
+// running docker itself. The CLI builds the emitted recipe multi-arch and pushes
+// a manifest list, so a consumer can rebuild the image without the agent
+// toolchain. The context is the recipe tree itself: the rendered builder/ files
+// plus the migrations the image applies at bootstrap.
+func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *resources.DockerImage, docker DockerTemplating) (*builderv0.BuildResponse, error) {
+	builderDirectory := filepath.Join(outputDirectory, "builder")
+	if err := shared.EmptyDir(ctx, builderDirectory); err != nil {
+		return s.Builder.BuildError(err)
+	}
+	if err := s.Templates(ctx, docker, services.WithBuilder(builderFS).WithDestination("%s", builderDirectory)); err != nil {
+		return s.Builder.BuildError(err)
+	}
+
+	if s.WithMigration() {
+		migrationsDirectory := filepath.Join(outputDirectory, "migrations")
+		if err := shared.EmptyDir(ctx, migrationsDirectory); err != nil {
+			return s.Builder.BuildError(err)
+		}
+		if err := copyTree(ctx, s.Local("migrations"), migrationsDirectory); err != nil {
+			return s.Builder.BuildError(err)
+		}
+	}
+
+	plan, err := services.BuildDockerBuildPlan(outputDirectory, []*builderv0.DockerBuildRecipe{{
+		Name:       "bootstrap",
+		Dockerfile: "builder/Dockerfile",
+		Context:    ".",
+		Image:      img.FullName(),
+		Platforms:  []string{"linux/amd64", "linux/arm64"},
+	}})
+	if err != nil {
+		return s.Builder.BuildError(err)
+	}
+
+	s.Builder.WithBuildPlan(plan)
+	return s.Builder.BuildResponse()
+}
+
+// copyTree copies every regular file under from into to, preserving the relative
+// layout. Empty directories are skipped: they carry no build-context content and
+// would only be an unreproducible artifact in the recipe inventory.
+func copyTree(ctx context.Context, from, to string) error {
+	return filepath.WalkDir(from, func(entryPath string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		relative, err := filepath.Rel(from, entryPath)
+		if err != nil {
+			return err
+		}
+		return shared.CopyFile(ctx, entryPath, filepath.Join(to, relative))
+	})
 }
 
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {

--- a/builder.go
+++ b/builder.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -191,17 +192,24 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 // toolchain. The context is the recipe tree itself: the rendered builder/ files
 // plus the migrations the image applies at bootstrap.
 func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *resources.DockerImage, docker DockerTemplating) (*builderv0.BuildResponse, error) {
-	builderDirectory := filepath.Join(outputDirectory, "builder")
-	if err := shared.EmptyDir(ctx, builderDirectory); err != nil {
+	// The plan inventories the whole output directory and the recipe context is
+	// its root, so any pre-existing content the caller left here would be
+	// digested into the plan and copied into the image. Empty the directory the
+	// agent fully owns before rendering, as the deployment emitter does.
+	if err := shared.EmptyDir(ctx, outputDirectory); err != nil {
 		return s.Builder.BuildError(err)
 	}
-	if err := s.Templates(ctx, docker, services.WithBuilder(builderFS).WithDestination("%s", builderDirectory)); err != nil {
+
+	if err := s.Templates(ctx, docker, services.WithBuilder(builderFS).WithDestination("%s", filepath.Join(outputDirectory, "builder"))); err != nil {
 		return s.Builder.BuildError(err)
 	}
 
 	if s.WithMigration() {
+		// The Dockerfile's COPY migrations needs the directory to exist even when
+		// no migrations are authored yet, so create it before copying rather than
+		// letting copyTree leave it absent for an empty source.
 		migrationsDirectory := filepath.Join(outputDirectory, "migrations")
-		if err := shared.EmptyDir(ctx, migrationsDirectory); err != nil {
+		if err := os.MkdirAll(migrationsDirectory, 0o755); err != nil {
 			return s.Builder.BuildError(err)
 		}
 		if err := copyTree(ctx, s.Local("migrations"), migrationsDirectory); err != nil {
@@ -225,8 +233,8 @@ func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *
 }
 
 // copyTree copies every regular file under from into to, preserving the relative
-// layout. Empty directories are skipped: they carry no build-context content and
-// would only be an unreproducible artifact in the recipe inventory.
+// layout. Directory entries themselves are not created here; the caller
+// provisions any directory a build step requires to exist.
 func copyTree(ctx context.Context, from, to string) error {
 	return filepath.WalkDir(from, func(entryPath string, entry fs.DirEntry, err error) error {
 		if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.26.6
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/codefly-dev/core v0.3.4
+	github.com/codefly-dev/core v0.3.6
 	github.com/codefly-dev/gortk v0.2.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.3.4 h1:gTpAvIKb3sY8gOESkXDuKsPvIjG9d55kY5rGoVQR/YE=
-github.com/codefly-dev/core v0.3.4/go.mod h1:ca5IAJnFJSC3OPl5DcoRIi41BMfO0As8BaDGciYZ7nI=
+github.com/codefly-dev/core v0.3.6 h1:lt5EyL+uS1Z6Vzg+V/HhpnIV43Lu5rN9E0k+ZslIKHk=
+github.com/codefly-dev/core v0.3.6/go.mod h1:ca5IAJnFJSC3OPl5DcoRIi41BMfO0As8BaDGciYZ7nI=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=


### PR DESCRIPTION
Closes #63.

## Summary
- This agent renders its own bootstrap-image Dockerfile and previously called `WithDockerImages` — the "agent with its own docker build" triage case. It now emits a `DockerBuildPlan` when the CLI supplies an `output_directory`, so the image becomes a durable, reproducible recipe the CLI builds multi-arch (linux/amd64 + linux/arm64) without needing the agent toolchain.
- Re-pins core `v0.3.4 → v0.3.6` for the recipe contract and helpers (`BuildDockerBuildPlan`, `WithBuildPlan`).
- The legacy in-agent `docker build` is unchanged and still runs when `output_directory` is empty, so the CLI's response-type negotiation keeps working.

The recipe context is the recipe tree itself: the rendered `builder/` files (Dockerfile + `runtime-access.sql`) plus the migrations the image applies at bootstrap. Core's `SingleImageBuildPlan` / `RecipeBuildPlatforms` convenience helpers named in the issue are not in the released core (v0.3.6 is the latest tag and its shared runners don't yet emit plans), so the migration uses the released primitives directly with the same result.

## Test plan
- [x] `go test ./... -skip '^TestCreateToRunDocker$'` (matches CI) — green
- [x] New `TestBuildEmitsRecipeToOutputDirectory`: Build with `output_directory` returns a `DockerBuildPlan` (single recipe, `builder/Dockerfile`, context `.`, both platforms), writes a self-contained tree (builder + migrations), and the emitted plan verifies against that tree via `VerifyDockerBuildPlan`.
- [x] New `TestBuildRecipeOmitsMigrationsWhenDisabled`: with migrations disabled the recipe omits the migrations tree and still verifies.
- Validation: a consumer with no codefly toolchain can `docker buildx build --platform linux/amd64 -f builder/Dockerfile .` from the emitted output directory.