### PR TITLE
chore: bump core to v0.3.8 (Go 1.27) (#452)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.27.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/codefly-dev/core v0.3.6
+	github.com/codefly-dev/core v0.3.8
 	github.com/codefly-dev/gortk v0.2.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.10.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.3.6 h1:lt5EyL+uS1Z6Vzg+V/HhpnIV43Lu5rN9E0k+ZslIKHk=
-github.com/codefly-dev/core v0.3.6/go.mod h1:ca5IAJnFJSC3OPl5DcoRIi41BMfO0As8BaDGciYZ7nI=
+github.com/codefly-dev/core v0.3.8 h1:iqXrad1zwpX1CzAKr53TeuYLWHV8B5QkhHVV6unb9Os=
+github.com/codefly-dev/core v0.3.8/go.mod h1:4V8BP4F5mnRDZvylhC9P5N7rfifpAma5n3dW4YD+gtQ=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=


### PR DESCRIPTION
Part of codefly-dev/cli#452.

## Summary

- Bump `github.com/codefly-dev/core` v0.3.6 → v0.3.8 **on `main`** so this repo aligns with the CLI (codefly-dev/cli#451) on the same core contract.
- core v0.3.8 targets Go 1.27, so the module's `go` directive moves to `go 1.27.0`.

This supersedes the earlier bump PR that was stacked on the `cli-owned-build` epic branch: that epic had already merged to `main` (carrying v0.3.6) before the bump landed, so the bump was stranded on a dead branch and never reached `main`. This PR targets `main` directly.

## Test plan

- [x] `go build ./...` clean (Go 1.27)
- [x] `go vet ./...` clean
- [x] `go mod tidy` leaves only go.mod + go.sum changed
- [ ] CI green (`ci` runs now — PR targets main)