### PR TITLE
fix: patch OpenSSL to 3.5.8-r0 in runtime image (#74)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,10 @@ RUN mkdir /tmp/pgvector /tmp/pgvector-install && \
 FROM ${POSTGRES_IMAGE} AS runtime
 
 RUN rm /usr/local/bin/gosu
-RUN apk add --no-cache su-exec=0.3-r0 && \
+RUN apk add --no-cache --upgrade \
+    libcrypto3=3.5.8-r0 \
+    libssl3=3.5.8-r0 \
+    su-exec=0.3-r0 && \
     ln -s /sbin/su-exec /usr/local/bin/gosu && \
     rm /var/log/apk.log
 COPY --from=pgvector-builder /tmp/pgvector-install/ /

--- a/agent.codefly.yaml
+++ b/agent.codefly.yaml
@@ -1,4 +1,4 @@
 publisher: codefly.dev
 kind: codefly:service
 name: postgres
-version: 0.0.129
+version: 0.0.130

--- a/runtime-image.json
+++ b/runtime-image.json
@@ -1,5 +1,5 @@
 {
   "name": "ghcr.io/codefly-dev/service-postgres",
   "tag": "postgres-17.10-pgvector-0.8.5-alpine3.24",
-  "digest": "sha256:eb55334a89f89c080b7dff59781b5186cb80413198c142c4ef29b0ca6892a0ce"
+  "digest": "sha256:56916207b62669bc9a033d434b156d0d25e1bf3c3f08a34652e45a684784bf23"
 }

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -120,6 +120,8 @@ func TestRuntimeDockerfilePinsReproducibleBuildInputs(t *testing.T) {
 	require.Contains(t, dockerfile, "build-base=0.5-r4")
 	require.Contains(t, dockerfile, "clang21=21.1.8-r3")
 	require.Contains(t, dockerfile, "llvm21-dev=21.1.8-r1")
+	require.Contains(t, dockerfile, "libcrypto3=3.5.8-r0")
+	require.Contains(t, dockerfile, "libssl3=3.5.8-r0")
 	require.Contains(t, dockerfile, "su-exec=0.3-r0")
 	require.Contains(t, dockerfile, "RUN rm /usr/local/bin/gosu")
 	require.Contains(t, dockerfile, "ln -s /sbin/su-exec /usr/local/bin/gosu")


### PR DESCRIPTION
Closes #74.

## Summary

- CVE-2026-14456 (HIGH) affects Alpine `libcrypto3`/`libssl3` `3.5.7-r0`, which the pinned `postgres:17.10-alpine3.24` base bakes in. Alpine 3.24's `main` repo already publishes the fixed `3.5.8-r0`, so the runtime stage now upgrades both packages to that pinned version — no base-image bump needed.
- Relocked `runtime-image.json` to the reproducibly-rebuilt multi-platform digest (`sha256:5691…`), and bumped the agent to `0.0.130` so downstream modules can re-pin.

## Verification

- Built the runtime image and confirmed `libcrypto3-3.5.8-r0` / `libssl3-3.5.8-r0`.
- Trivy scan of the rebuilt image (`--severity HIGH,CRITICAL`, same pinned scanner as CI) reports **0** vulnerabilities.
- Recomputed the `linux/amd64,linux/arm64` index digest with the pinned buildkit and `rewrite-timestamp` / `SOURCE_DATE_EPOCH=0`; the OCI index carries exactly the two platform manifests CI verifies.

## Test plan

- [x] `go test ./... -skip '^TestCreateToRunDocker$'`
- [x] Local runtime build + smoke of OpenSSL package versions
- [x] Trivy HIGH/CRITICAL scan clean
- [ ] CI rebuilds to the locked digest and its Trivy gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)