### PR TITLE
fix: lock and verify every bootstrap image input (#82)

### DIFF
--- a/.github/scripts/update-bootstrap-lock.sh
+++ b/.github/scripts/update-bootstrap-lock.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+# Moves bootstrap-image.json forward: the lock the bootstrap image builds from.
+#
+#   .github/scripts/update-bootstrap-lock.sh                 # same Alpine branch, same migrate
+#   ALPINE_BRANCH=v3.22 .github/scripts/update-bootstrap-lock.sh
+#   MIGRATE_VERSION=v4.20.0 .github/scripts/update-bootstrap-lock.sh
+#
+# Every value is resolved from upstream, never authored here: the base digest comes
+# from the registry, package versions from `apk policy` inside the digest-pinned
+# base on both architectures, and the migrate archive checksums from the release's
+# published sha256sum.txt. Run `go test ./...` afterwards and commit the diff.
+#
+# Why pinning packages this way, and what it costs:
+#
+# Alpine publishes no immutable package snapshot — a release branch keeps only the
+# newest -rN of each package. Pinning exact versions therefore trades availability
+# for integrity: once upstream replaces curl or postgresql17-client, the build fails
+# with "unable to select packages" instead of silently installing different bytes.
+# That failure is the signal to run this script, which is also how a security fix
+# reaches the image: rerun it, the resolved versions move, and the lock records what
+# the next build will install.
+
+set -euo pipefail
+
+ALPINE_BRANCH=${ALPINE_BRANCH:-v3.21}
+MIGRATE_VERSION=${MIGRATE_VERSION:-v4.19.1}
+PACKAGES=(curl postgresql17-client)
+ARCHITECTURES=(amd64 arm64)
+REPOSITORY="https://dl-cdn.alpinelinux.org/alpine/${ALPINE_BRANCH}/main"
+LOCK="$(git rev-parse --show-toplevel)/bootstrap-image.json"
+
+resolve_base_digest() {
+  local tag="alpine:${ALPINE_BRANCH#v}"
+  docker buildx imagetools inspect "$tag" |
+    awk '$1 == "Digest:" { print $2; exit }'
+}
+
+# The version each architecture resolves to must agree: one lock describes the
+# manifest list, so a per-architecture difference has to be resolved upstream
+# rather than averaged over here.
+resolve_package_versions() {
+  local base=$1
+  local resolved=""
+  local architecture
+  for architecture in "${ARCHITECTURES[@]}"; do
+    local versions
+    versions=$(docker run --rm --platform "linux/${architecture}" "$base" sh -c "
+      set -eu
+      printf '%s\n' '${REPOSITORY}' >/etc/apk/repositories
+      apk update >/dev/null
+      for package in ${PACKAGES[*]}; do
+        apk policy \"\$package\" | sed -n '2s/^ *\([^:]*\):.*/\1/p'
+      done
+    ")
+    if [[ -z "$resolved" ]]; then
+      resolved=$versions
+    elif [[ "$resolved" != "$versions" ]]; then
+      echo "package versions differ across architectures; resolve upstream first" >&2
+      return 1
+    fi
+  done
+  printf '%s\n' "$resolved"
+}
+
+resolve_archive_checksums() {
+  local checksums
+  checksums=$(curl -fsSL \
+    "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/sha256sum.txt")
+  local architecture
+  for architecture in "${ARCHITECTURES[@]}"; do
+    local checksum
+    checksum=$(awk -v archive="migrate.linux-${architecture}.tar.gz" \
+      '$2 == archive { print $1; exit }' <<<"$checksums")
+    if [[ ! "$checksum" =~ ^[0-9a-f]{64}$ ]]; then
+      echo "${MIGRATE_VERSION} publishes no checksum for linux-${architecture}" >&2
+      return 1
+    fi
+    printf '%s\n' "$checksum"
+  done
+}
+
+digest=$(resolve_base_digest)
+if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+  echo "could not resolve the alpine:${ALPINE_BRANCH#v} digest" >&2
+  exit 1
+fi
+base="alpine@${digest}"
+
+release=$(docker run --rm "$base" cat /etc/alpine-release)
+mapfile -t versions < <(resolve_package_versions "$base")
+mapfile -t checksums < <(resolve_archive_checksums)
+
+if [[ "${#versions[@]}" -ne "${#PACKAGES[@]}" ]]; then
+  echo "could not resolve every package version from ${REPOSITORY}" >&2
+  exit 1
+fi
+
+pinned=$(jq -n '[]')
+for index in "${!PACKAGES[@]}"; do
+  pinned=$(jq --arg name "${PACKAGES[$index]}" --arg version "${versions[$index]}" \
+    '. + [{name: $name, version: $version}]' <<<"$pinned")
+done
+
+archives=$(jq -n '[]')
+for index in "${!ARCHITECTURES[@]}"; do
+  archives=$(jq --arg architecture "${ARCHITECTURES[$index]}" --arg sha256 "${checksums[$index]}" \
+    '. + [{architecture: $architecture, sha256: $sha256}]' <<<"$archives")
+done
+
+jq -n \
+  --arg version "$release" \
+  --arg digest "$digest" \
+  --arg repository "$REPOSITORY" \
+  --arg migrate "$MIGRATE_VERSION" \
+  --argjson pinned "$pinned" \
+  --argjson archives "$archives" \
+  '{
+    base: {image: "alpine", version: $version, digest: $digest},
+    packages: {repository: $repository, pinned: $pinned},
+    migrate: {version: $migrate, archives: $archives}
+  }' >"$LOCK"
+
+echo "updated $LOCK:"
+cat "$LOCK"
+echo
+echo "run: go test ./... && git commit bootstrap-image.json"

--- a/.github/scripts/update-bootstrap-lock.sh
+++ b/.github/scripts/update-bootstrap-lock.sh
@@ -2,14 +2,23 @@
 
 # Moves bootstrap-image.json forward: the lock the bootstrap image builds from.
 #
-#   .github/scripts/update-bootstrap-lock.sh                 # same Alpine branch, same migrate
+#   .github/scripts/update-bootstrap-lock.sh                 # re-resolve what the lock already targets
+#   .github/scripts/update-bootstrap-lock.sh --check         # report drift, write nothing, exit 1 if stale
 #   ALPINE_BRANCH=v3.22 .github/scripts/update-bootstrap-lock.sh
 #   MIGRATE_VERSION=v4.20.0 .github/scripts/update-bootstrap-lock.sh
 #
 # Every value is resolved from upstream, never authored here: the base digest comes
-# from the registry, package versions from `apk policy` inside the digest-pinned
-# base on both architectures, and the migrate archive checksums from the release's
-# published sha256sum.txt. Run `go test ./...` afterwards and commit the diff.
+# from the registry, package versions from inside the digest-pinned base on both
+# architectures, and the migrate archive checksums from the release's published
+# sha256sum.txt. What the run targets — Alpine branch, migrate version, package set
+# — is read out of the current lock, so a plain rerun re-resolves the lock's own
+# intent instead of a default that could silently revert someone's bump. Run
+# `go test ./...` afterwards and commit the diff.
+#
+# The checksum file ships in the same GitHub release as the archives it covers, so
+# it pins identity — the bytes cannot change under a fixed version, and a mirror or
+# CDN cannot substitute them — but it shares a trust root with the artifact and is
+# therefore not proof of authorship. Locking the version is what bounds that trust.
 #
 # Why pinning packages this way, and what it costs:
 #
@@ -19,16 +28,43 @@
 # with "unable to select packages" instead of silently installing different bytes.
 # That failure is the signal to run this script, which is also how a security fix
 # reaches the image: rerun it, the resolved versions move, and the lock records what
-# the next build will install.
+# the next build will install. That signal covers pinned packages only, so the
+# bootstrap-lock-freshness workflow runs --check on a schedule to catch the inputs
+# that never fail a build: a base digest the branch has moved past, and a newer
+# migrate release.
 
 set -euo pipefail
 
-ALPINE_BRANCH=${ALPINE_BRANCH:-v3.21}
-MIGRATE_VERSION=${MIGRATE_VERSION:-v4.19.1}
-PACKAGES=(curl postgresql17-client)
-ARCHITECTURES=(amd64 arm64)
-REPOSITORY="https://dl-cdn.alpinelinux.org/alpine/${ALPINE_BRANCH}/main"
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+elif [[ -n "${1:-}" ]]; then
+  echo "usage: ${0##*/} [--check]" >&2
+  exit 2
+fi
+
 LOCK="$(git rev-parse --show-toplevel)/bootstrap-image.json"
+
+# The lock is the source of truth for what this run targets; the environment only
+# overrides it deliberately.
+lock_branch=$(jq -er '.packages.repositories[0] | capture("/(?<branch>v[0-9]+\\.[0-9]+)/").branch' "$LOCK")
+ALPINE_BRANCH=${ALPINE_BRANCH:-$lock_branch}
+MIGRATE_VERSION=${MIGRATE_VERSION:-$(jq -er '.migrate.version' "$LOCK")}
+mapfile -t PACKAGES < <(jq -er '.packages.pinned[].name' "$LOCK")
+mapfile -t ARCHITECTURES < <(jq -er '.migrate.archives[].architecture' "$LOCK")
+if [[ "${#PACKAGES[@]}" -eq 0 || "${#ARCHITECTURES[@]}" -eq 0 ]]; then
+  echo "could not read the package or architecture set from $LOCK" >&2
+  exit 1
+fi
+
+# One repository per apk repository line, all on the targeted branch. Additional
+# repositories in the lock are preserved by path, with the branch re-resolved.
+mapfile -t REPOSITORIES < <(jq -er --arg branch "$ALPINE_BRANCH" \
+  '.packages.repositories[] | sub("/v[0-9]+\\.[0-9]+/"; "/" + $branch + "/")' "$LOCK")
+if [[ "${#REPOSITORIES[@]}" -eq 0 ]]; then
+  echo "could not read the repository set from $LOCK" >&2
+  exit 1
+fi
 
 resolve_base_digest() {
   local tag="alpine:${ALPINE_BRANCH#v}"
@@ -47,12 +83,22 @@ resolve_package_versions() {
     local versions
     versions=$(docker run --rm --platform "linux/${architecture}" "$base" sh -c "
       set -eu
-      printf '%s\n' '${REPOSITORY}' >/etc/apk/repositories
+      printf '%s\n' ${REPOSITORIES[*]@Q} >/etc/apk/repositories
       apk update >/dev/null
       for package in ${PACKAGES[*]}; do
-        apk policy \"\$package\" | sed -n '2s/^ *\([^:]*\):.*/\1/p'
+        # apk policy lists candidates ascending, so the last one is what apk would
+        # install. Cross-check against the resolver itself: if a repository set ever
+        # makes these disagree, pinning the wrong candidate would silently lock an
+        # older, unpatched build.
+        candidate=\$(apk policy \"\$package\" | awk '/^  [^ ]/ { sub(/:\$/, \"\", \$1); version=\$1 } END { print version }')
+        selected=\$(apk add --simulate \"\$package\" | sed -n \"s/.* Installing \$package (\(.*\))\$/\1/p\" | tail -1)
+        if [ \"\$candidate\" != \"\$selected\" ]; then
+          echo \"\$package: apk policy offers \$candidate but apk would install \$selected\" >&2
+          exit 1
+        fi
+        printf '%s\n' \"\$candidate\"
       done
-    ")
+    ") || return 1
     if [[ -z "$resolved" ]]; then
       resolved=$versions
     elif [[ "$resolved" != "$versions" ]]; then
@@ -66,7 +112,10 @@ resolve_package_versions() {
 resolve_archive_checksums() {
   local checksums
   checksums=$(curl -fsSL \
-    "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/sha256sum.txt")
+    "https://github.com/golang-migrate/migrate/releases/download/${MIGRATE_VERSION}/sha256sum.txt") || {
+    echo "could not fetch published checksums for ${MIGRATE_VERSION}" >&2
+    return 1
+  }
   local architecture
   for architecture in "${ARCHITECTURES[@]}"; do
     local checksum
@@ -80,6 +129,24 @@ resolve_archive_checksums() {
   done
 }
 
+# Reports a newer upstream migrate release. Nothing else signals it: the pinned
+# archive keeps verifying and installing forever, so staleness here is invisible
+# until someone looks.
+report_migrate_staleness() {
+  local latest
+  if ! latest=$(curl -fsSL https://api.github.com/repos/golang-migrate/migrate/releases/latest |
+    jq -er '.tag_name'); then
+    echo "warning: could not reach the migrate release API; staleness unchecked" >&2
+    return 0
+  fi
+  if [[ "$latest" != "$MIGRATE_VERSION" ]]; then
+    echo "migrate ${MIGRATE_VERSION} is behind upstream ${latest}"
+    echo "  to take it: MIGRATE_VERSION=${latest} ${0##*/}"
+    return 1
+  fi
+  echo "migrate ${MIGRATE_VERSION} is the current upstream release"
+}
+
 digest=$(resolve_base_digest)
 if [[ ! "$digest" =~ ^sha256:[0-9a-f]{64}$ ]]; then
   echo "could not resolve the alpine:${ALPINE_BRANCH#v} digest" >&2
@@ -88,11 +155,24 @@ fi
 base="alpine@${digest}"
 
 release=$(docker run --rm "$base" cat /etc/alpine-release)
-mapfile -t versions < <(resolve_package_versions "$base")
-mapfile -t checksums < <(resolve_archive_checksums)
+
+# Command substitution, not process substitution: mapfile from <(…) discards the
+# producer's exit status, so a failed resolution would flow on as empty output.
+if ! versions_output=$(resolve_package_versions "$base"); then
+  exit 1
+fi
+mapfile -t versions <<<"$versions_output"
+if ! checksums_output=$(resolve_archive_checksums); then
+  exit 1
+fi
+mapfile -t checksums <<<"$checksums_output"
 
 if [[ "${#versions[@]}" -ne "${#PACKAGES[@]}" ]]; then
-  echo "could not resolve every package version from ${REPOSITORY}" >&2
+  echo "could not resolve every package version from ${REPOSITORIES[*]}" >&2
+  exit 1
+fi
+if [[ "${#checksums[@]}" -ne "${#ARCHITECTURES[@]}" ]]; then
+  echo "could not resolve every migrate archive checksum for ${MIGRATE_VERSION}" >&2
   exit 1
 fi
 
@@ -108,20 +188,50 @@ for index in "${!ARCHITECTURES[@]}"; do
     '. + [{architecture: $architecture, sha256: $sha256}]' <<<"$archives")
 done
 
-jq -n \
+resolved=$(jq -n \
   --arg version "$release" \
   --arg digest "$digest" \
-  --arg repository "$REPOSITORY" \
   --arg migrate "$MIGRATE_VERSION" \
+  --argjson repositories "$(jq -n --args '$ARGS.positional' "${REPOSITORIES[@]}")" \
   --argjson pinned "$pinned" \
   --argjson archives "$archives" \
   '{
     base: {image: "alpine", version: $version, digest: $digest},
-    packages: {repository: $repository, pinned: $pinned},
+    packages: {repositories: $repositories, pinned: $pinned},
     migrate: {version: $migrate, archives: $archives}
-  }' >"$LOCK"
+  }')
+
+stale=false
+if ! diff -u "$LOCK" <(printf '%s\n' "$resolved") >/dev/null; then
+  stale=true
+fi
+
+if [[ "$CHECK_ONLY" == true ]]; then
+  if [[ "$stale" == true ]]; then
+    echo "$LOCK is behind the inputs upstream now resolves to:"
+    diff -u "$LOCK" <(printf '%s\n' "$resolved") || true
+  else
+    echo "$LOCK matches the inputs upstream currently resolves to"
+  fi
+  current=true
+  report_migrate_staleness || current=false
+  if [[ "$stale" == true || "$current" == false ]]; then
+    echo "run .github/scripts/update-bootstrap-lock.sh to move the lock forward" >&2
+    exit 1
+  fi
+  exit 0
+fi
+
+# Write through a temporary file: redirecting straight into the lock truncates it
+# before jq runs, and an empty lock is embedded into the binary and fails at init.
+staged="${LOCK}.staged"
+trap 'rm -f -- "$staged"' EXIT
+printf '%s\n' "$resolved" >"$staged"
+mv -- "$staged" "$LOCK"
 
 echo "updated $LOCK:"
 cat "$LOCK"
+echo
+report_migrate_staleness || true
 echo
 echo "run: go test ./... && git commit bootstrap-image.json"

--- a/.github/workflows/bootstrap-lock-freshness.yml
+++ b/.github/workflows/bootstrap-lock-freshness.yml
@@ -1,0 +1,25 @@
+# Pinning the bootstrap image by digest stops it drifting, which also stops it
+# receiving upstream fixes. Only one of its inputs announces staleness on its own: a
+# replaced apk package version fails the build. A base digest the branch has moved
+# past, and a newer migrate release, never fail anything — so this reports them on a
+# schedule instead of gating pull requests on unrelated upstream releases.
+name: bootstrap-lock-freshness
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  freshness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+
+      - name: Check bootstrap image lock against upstream
+        run: .github/scripts/update-bootstrap-lock.sh --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,14 @@ jobs:
           cache: false
           go-version-file: go.mod
 
+      # Registered before the tests, not just before the multi-arch publish: the
+      # bootstrap image build test verifies linux/arm64, which needs emulation on an
+      # amd64 runner. Without this the arm64 case would skip and a wrong arm64
+      # archive checksum would pass CI.
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
+
       - name: Run unit tests
-        run: go test ./... -skip '^TestCreateToRunDocker$'
+        run: go test ./... -skip '^TestCreateToRunDocker$' -timeout 20m
 
       - name: Build runtime image
         run: docker build --build-arg SOURCE_DATE_EPOCH=0 --tag service-postgres:test .
@@ -115,9 +121,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
 
       - if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f

--- a/bootstrap-image.json
+++ b/bootstrap-image.json
@@ -5,7 +5,9 @@
     "digest": "sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d"
   },
   "packages": {
-    "repository": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main",
+    "repositories": [
+      "https://dl-cdn.alpinelinux.org/alpine/v3.21/main"
+    ],
     "pinned": [
       {
         "name": "curl",

--- a/bootstrap-image.json
+++ b/bootstrap-image.json
@@ -1,0 +1,33 @@
+{
+  "base": {
+    "image": "alpine",
+    "version": "3.21.7",
+    "digest": "sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d"
+  },
+  "packages": {
+    "repository": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main",
+    "pinned": [
+      {
+        "name": "curl",
+        "version": "8.14.1-r2"
+      },
+      {
+        "name": "postgresql17-client",
+        "version": "17.11-r0"
+      }
+    ]
+  },
+  "migrate": {
+    "version": "v4.19.1",
+    "archives": [
+      {
+        "architecture": "amd64",
+        "sha256": "2ac648fbd1b127b69ab5a7b33cf96212178f71e22379fc50573630c6f4c7ce18"
+      },
+      {
+        "architecture": "arm64",
+        "sha256": "2fea2455c0f3f07cc3f4b98471c951ad1a716059574b20b6416bd1e9058751c5"
+      }
+    ]
+  }
+}

--- a/bootstrap_image.go
+++ b/bootstrap_image.go
@@ -21,6 +21,17 @@ var bootstrapImageLockJSON []byte
 // resolve a migrate archive for each of them, and the image rejects any other.
 var bootstrapArchitectures = []string{"amd64", "arm64"}
 
+// bootstrapRecipePlatforms are the buildx platforms the emitted recipe targets,
+// derived from the architectures the lock resolves inputs for so a platform can
+// never be advertised without a verified migrate archive behind it.
+func bootstrapRecipePlatforms() []string {
+	platforms := make([]string, 0, len(bootstrapArchitectures))
+	for _, architecture := range bootstrapArchitectures {
+		platforms = append(platforms, "linux/"+architecture)
+	}
+	return platforms
+}
+
 // bootstrapLock resolves the inputs the bootstrap image builds from. The runtime
 // image lock covers only the managed Postgres image, so this separate image needs
 // its own source of truth.
@@ -40,9 +51,11 @@ type bootstrapImageLock struct {
 	Packages bootstrapPackages      `json:"packages"`
 	Migrate  bootstrapMigrateBinary `json:"migrate"`
 
-	// LockDigest is the sha256 of the lock document, derived when it is parsed. It
-	// is the single value two builds compare to prove they resolved the same
-	// inputs, and it travels with the image as a label.
+	// LockDigest is the sha256 of the lock's canonical encoding, derived when it is
+	// parsed. It is the single value two builds compare to prove they resolved the
+	// same inputs, and it travels with the image as a label. Canonical, not the
+	// document's own bytes: reindenting or reordering keys in the file changes no
+	// input, so it must not change the identity the provenance reports.
 	LockDigest string `json:"-"`
 }
 
@@ -53,8 +66,8 @@ type bootstrapBaseImage struct {
 }
 
 type bootstrapPackages struct {
-	Repository string             `json:"repository"`
-	Pinned     []bootstrapPackage `json:"pinned"`
+	Repositories []string           `json:"repositories"`
+	Pinned       []bootstrapPackage `json:"pinned"`
 }
 
 type bootstrapPackage struct {
@@ -77,6 +90,16 @@ type bootstrapMigrateArchive struct {
 // manifest for the platform it is building.
 func (b bootstrapBaseImage) Reference() string {
 	return b.Image + "@" + b.Digest
+}
+
+// RepositoryArguments renders the locked repositories as printf arguments, quoted
+// for the shell, in lock order. They become the image's entire apk repository set.
+func (p bootstrapPackages) RepositoryArguments() string {
+	quoted := make([]string, 0, len(p.Repositories))
+	for _, repository := range p.Repositories {
+		quoted = append(quoted, `"`+repository+`"`)
+	}
+	return strings.Join(quoted, " ")
 }
 
 // Specs renders the locked packages as apk arguments, each pinned to an exact
@@ -109,7 +132,7 @@ func (l *bootstrapImageLock) Provenance() []bootstrapProvenance {
 		{Arg: "CODEFLY_BOOTSTRAP_LOCK_DIGEST", Label: "dev.codefly.bootstrap.lock-digest", Value: l.LockDigest},
 		{Arg: "CODEFLY_BOOTSTRAP_BASE", Label: "dev.codefly.bootstrap.base", Value: l.Base.Reference()},
 		{Arg: "CODEFLY_BOOTSTRAP_BASE_VERSION", Label: "dev.codefly.bootstrap.base-version", Value: l.Base.Version},
-		{Arg: "CODEFLY_BOOTSTRAP_APK_REPOSITORY", Label: "dev.codefly.bootstrap.apk-repository", Value: l.Packages.Repository},
+		{Arg: "CODEFLY_BOOTSTRAP_APK_REPOSITORIES", Label: "dev.codefly.bootstrap.apk-repositories", Value: strings.Join(l.Packages.Repositories, " ")},
 		{Arg: "CODEFLY_BOOTSTRAP_APK_PACKAGES", Label: "dev.codefly.bootstrap.apk-packages", Value: l.Packages.Specs()},
 		{Arg: "CODEFLY_BOOTSTRAP_MIGRATE_VERSION", Label: "dev.codefly.bootstrap.migrate-version", Value: l.Migrate.Version},
 		{Arg: "CODEFLY_BOOTSTRAP_MIGRATE_ARCHIVES", Label: "dev.codefly.bootstrap.migrate-archives", Value: strings.Join(archives, ",")},
@@ -117,10 +140,10 @@ func (l *bootstrapImageLock) Provenance() []bootstrapProvenance {
 }
 
 // RecipeBuildArgs exposes the same resolved identities through the build recipe's
-// typed build arguments. They carry the locked values the Dockerfile already
-// defaults to, so the recipe records what it was built from without becoming the
-// thing that decides it: the digests and checksums the build verifies against are
-// literals in the Dockerfile, not arguments a caller can override.
+// typed build arguments, where core folds them into the plan's aggregate digest.
+// Nothing in the Dockerfile reads them: every input the build resolves, verifies
+// against, or records as a label is a rendered literal, so no caller can pass an
+// argument that changes what the image is or what it claims to be.
 func (l *bootstrapImageLock) RecipeBuildArgs() map[string]string {
 	provenance := l.Provenance()
 	buildArgs := make(map[string]string, len(provenance))
@@ -140,7 +163,11 @@ func parseBootstrapImageLock(content []byte) (*bootstrapImageLock, error) {
 	if err := lock.validate(); err != nil {
 		return nil, err
 	}
-	document := sha256.Sum256(content)
+	canonical, err := json.Marshal(lock)
+	if err != nil {
+		return nil, fmt.Errorf("encode bootstrap image lock: %w", err)
+	}
+	document := sha256.Sum256(canonical)
 	lock.LockDigest = "sha256:" + hex.EncodeToString(document[:])
 	return &lock, nil
 }
@@ -152,7 +179,7 @@ func (l *bootstrapImageLock) validate() error {
 	if l.Base.Version == "" {
 		return fmt.Errorf("bootstrap base image version is required")
 	}
-	if err := validateBootstrapDigest("bootstrap base image digest", l.Base.Digest); err != nil {
+	if err := validateSHA256Digest("bootstrap base image digest", l.Base.Digest); err != nil {
 		return err
 	}
 	if err := l.validatePackages(); err != nil {
@@ -162,18 +189,23 @@ func (l *bootstrapImageLock) validate() error {
 }
 
 func (l *bootstrapImageLock) validatePackages() error {
-	if !strings.HasPrefix(l.Packages.Repository, "https://") {
-		return fmt.Errorf("bootstrap apk repository must be an https URL, got %q", l.Packages.Repository)
+	if len(l.Packages.Repositories) == 0 {
+		return fmt.Errorf("bootstrap apk repositories are required")
 	}
 	branch, err := alpineReleaseBranch(l.Base.Version)
 	if err != nil {
 		return err
 	}
-	// A base bumped to a new Alpine release while the package repository stays on
-	// the previous branch resolves packages that were never built against that
-	// base, so the lock only accepts both moving together.
-	if !strings.Contains(l.Packages.Repository, "/"+branch+"/") {
-		return fmt.Errorf("bootstrap apk repository %q does not serve the locked Alpine %s branch", l.Packages.Repository, branch)
+	for _, repository := range l.Packages.Repositories {
+		if !strings.HasPrefix(repository, "https://") {
+			return fmt.Errorf("bootstrap apk repository must be an https URL, got %q", repository)
+		}
+		// A base bumped to a new Alpine release while a package repository stays on
+		// the previous branch resolves packages that were never built against that
+		// base, so the lock only accepts both moving together.
+		if !strings.Contains(repository, "/"+branch+"/") {
+			return fmt.Errorf("bootstrap apk repository %q does not serve the locked Alpine %s branch", repository, branch)
+		}
 	}
 	if len(l.Packages.Pinned) == 0 {
 		return fmt.Errorf("bootstrap apk packages are required")
@@ -209,7 +241,7 @@ func (l *bootstrapImageLock) validateMigrate() error {
 			return fmt.Errorf("bootstrap migrate archive for %s is locked twice", archive.Architecture)
 		}
 		locked[archive.Architecture] = true
-		if err := validateBootstrapChecksum(
+		if err := validateSHA256Checksum(
 			fmt.Sprintf("bootstrap migrate %s archive checksum", archive.Architecture),
 			archive.SHA256,
 		); err != nil {
@@ -233,18 +265,25 @@ func alpineReleaseBranch(version string) (string, error) {
 	return "v" + major + "." + minor, nil
 }
 
-func validateBootstrapDigest(field, value string) error {
+// validateSHA256Digest accepts an "sha256:<hex>" reference, the form both image
+// locks pin by.
+func validateSHA256Digest(field, value string) error {
 	algorithm, encoded, found := strings.Cut(value, ":")
-	if !found || algorithm != "sha256" {
+	if !found || algorithm != "sha256" || !isSHA256Hex(encoded) {
 		return fmt.Errorf("%s must be a sha256 digest", field)
 	}
-	return validateBootstrapChecksum(field, encoded)
+	return nil
 }
 
-func validateBootstrapChecksum(field, value string) error {
-	decoded, err := hex.DecodeString(value)
-	if err != nil || len(decoded) != sha256.Size {
+// validateSHA256Checksum accepts the bare hex a checksum file publishes.
+func validateSHA256Checksum(field, value string) error {
+	if !isSHA256Hex(value) {
 		return fmt.Errorf("%s must be a sha256 checksum", field)
 	}
 	return nil
+}
+
+func isSHA256Hex(value string) bool {
+	decoded, err := hex.DecodeString(value)
+	return err == nil && len(decoded) == sha256.Size
 }

--- a/bootstrap_image.go
+++ b/bootstrap_image.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/codefly-dev/core/shared"
+)
+
+//go:embed bootstrap-image.json
+var bootstrapImageLockJSON []byte
+
+// bootstrapArchitectures are the architectures the bootstrap image is built for,
+// matching the recipe's linux/amd64 + linux/arm64 platform list. The lock must
+// resolve a migrate archive for each of them, and the image rejects any other.
+var bootstrapArchitectures = []string{"amd64", "arm64"}
+
+// bootstrapLock resolves the inputs the bootstrap image builds from. The runtime
+// image lock covers only the managed Postgres image, so this separate image needs
+// its own source of truth.
+var bootstrapLock = shared.Must(parseBootstrapImageLock(bootstrapImageLockJSON))
+
+// bootstrapImageLock is the checked-in identity of every input the bootstrap
+// image consumes: the base image by digest, the apk repository with exact package
+// versions, and the migrate release archive by checksum per architecture. Nothing
+// the image builds from resolves against a mutable tag, and the migrate archive is
+// verified before any of its bytes are extracted or executed.
+//
+// .github/scripts/update-bootstrap-lock.sh is the supported way to change it; it
+// resolves each value from upstream (including migrate's published checksums)
+// rather than accepting hand-written digests.
+type bootstrapImageLock struct {
+	Base     bootstrapBaseImage     `json:"base"`
+	Packages bootstrapPackages      `json:"packages"`
+	Migrate  bootstrapMigrateBinary `json:"migrate"`
+
+	// LockDigest is the sha256 of the lock document, derived when it is parsed. It
+	// is the single value two builds compare to prove they resolved the same
+	// inputs, and it travels with the image as a label.
+	LockDigest string `json:"-"`
+}
+
+type bootstrapBaseImage struct {
+	Image   string `json:"image"`
+	Version string `json:"version"`
+	Digest  string `json:"digest"`
+}
+
+type bootstrapPackages struct {
+	Repository string             `json:"repository"`
+	Pinned     []bootstrapPackage `json:"pinned"`
+}
+
+type bootstrapPackage struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+type bootstrapMigrateBinary struct {
+	Version  string                    `json:"version"`
+	Archives []bootstrapMigrateArchive `json:"archives"`
+}
+
+type bootstrapMigrateArchive struct {
+	Architecture string `json:"architecture"`
+	SHA256       string `json:"sha256"`
+}
+
+// Reference is the base image the Dockerfile builds FROM. The locked digest is the
+// multi-platform index digest, so buildx still selects the per-architecture
+// manifest for the platform it is building.
+func (b bootstrapBaseImage) Reference() string {
+	return b.Image + "@" + b.Digest
+}
+
+// Specs renders the locked packages as apk arguments, each pinned to an exact
+// version.
+func (p bootstrapPackages) Specs() string {
+	specs := make([]string, 0, len(p.Pinned))
+	for _, pinned := range p.Pinned {
+		specs = append(specs, pinned.Name+"="+pinned.Version)
+	}
+	return strings.Join(specs, " ")
+}
+
+// bootstrapProvenance is one resolved input, exposed from the lock as a Dockerfile
+// build argument, an image label, and a typed field of the emitted build recipe.
+type bootstrapProvenance struct {
+	Arg   string
+	Label string
+	Value string
+}
+
+// Provenance lists the resolved identities the image and the emitted recipe
+// record, so a consumer can read what a built artifact was assembled from without
+// re-resolving anything.
+func (l *bootstrapImageLock) Provenance() []bootstrapProvenance {
+	archives := make([]string, 0, len(l.Migrate.Archives))
+	for _, archive := range l.Migrate.Archives {
+		archives = append(archives, archive.Architecture+"="+archive.SHA256)
+	}
+	return []bootstrapProvenance{
+		{Arg: "CODEFLY_BOOTSTRAP_LOCK_DIGEST", Label: "dev.codefly.bootstrap.lock-digest", Value: l.LockDigest},
+		{Arg: "CODEFLY_BOOTSTRAP_BASE", Label: "dev.codefly.bootstrap.base", Value: l.Base.Reference()},
+		{Arg: "CODEFLY_BOOTSTRAP_BASE_VERSION", Label: "dev.codefly.bootstrap.base-version", Value: l.Base.Version},
+		{Arg: "CODEFLY_BOOTSTRAP_APK_REPOSITORY", Label: "dev.codefly.bootstrap.apk-repository", Value: l.Packages.Repository},
+		{Arg: "CODEFLY_BOOTSTRAP_APK_PACKAGES", Label: "dev.codefly.bootstrap.apk-packages", Value: l.Packages.Specs()},
+		{Arg: "CODEFLY_BOOTSTRAP_MIGRATE_VERSION", Label: "dev.codefly.bootstrap.migrate-version", Value: l.Migrate.Version},
+		{Arg: "CODEFLY_BOOTSTRAP_MIGRATE_ARCHIVES", Label: "dev.codefly.bootstrap.migrate-archives", Value: strings.Join(archives, ",")},
+	}
+}
+
+// RecipeBuildArgs exposes the same resolved identities through the build recipe's
+// typed build arguments. They carry the locked values the Dockerfile already
+// defaults to, so the recipe records what it was built from without becoming the
+// thing that decides it: the digests and checksums the build verifies against are
+// literals in the Dockerfile, not arguments a caller can override.
+func (l *bootstrapImageLock) RecipeBuildArgs() map[string]string {
+	provenance := l.Provenance()
+	buildArgs := make(map[string]string, len(provenance))
+	for _, entry := range provenance {
+		buildArgs[entry.Arg] = entry.Value
+	}
+	return buildArgs
+}
+
+func parseBootstrapImageLock(content []byte) (*bootstrapImageLock, error) {
+	var lock bootstrapImageLock
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&lock); err != nil {
+		return nil, fmt.Errorf("parse bootstrap image lock: %w", err)
+	}
+	if err := lock.validate(); err != nil {
+		return nil, err
+	}
+	document := sha256.Sum256(content)
+	lock.LockDigest = "sha256:" + hex.EncodeToString(document[:])
+	return &lock, nil
+}
+
+func (l *bootstrapImageLock) validate() error {
+	if l.Base.Image == "" {
+		return fmt.Errorf("bootstrap base image name is required")
+	}
+	if l.Base.Version == "" {
+		return fmt.Errorf("bootstrap base image version is required")
+	}
+	if err := validateBootstrapDigest("bootstrap base image digest", l.Base.Digest); err != nil {
+		return err
+	}
+	if err := l.validatePackages(); err != nil {
+		return err
+	}
+	return l.validateMigrate()
+}
+
+func (l *bootstrapImageLock) validatePackages() error {
+	if !strings.HasPrefix(l.Packages.Repository, "https://") {
+		return fmt.Errorf("bootstrap apk repository must be an https URL, got %q", l.Packages.Repository)
+	}
+	branch, err := alpineReleaseBranch(l.Base.Version)
+	if err != nil {
+		return err
+	}
+	// A base bumped to a new Alpine release while the package repository stays on
+	// the previous branch resolves packages that were never built against that
+	// base, so the lock only accepts both moving together.
+	if !strings.Contains(l.Packages.Repository, "/"+branch+"/") {
+		return fmt.Errorf("bootstrap apk repository %q does not serve the locked Alpine %s branch", l.Packages.Repository, branch)
+	}
+	if len(l.Packages.Pinned) == 0 {
+		return fmt.Errorf("bootstrap apk packages are required")
+	}
+	for _, pinned := range l.Packages.Pinned {
+		if pinned.Name == "" {
+			return fmt.Errorf("bootstrap apk package name is required")
+		}
+		if pinned.Version == "" {
+			return fmt.Errorf("bootstrap apk package %s must pin an exact version", pinned.Name)
+		}
+		if strings.ContainsAny(pinned.Name+pinned.Version, " =") {
+			return fmt.Errorf("bootstrap apk package %s=%s is not a single apk constraint", pinned.Name, pinned.Version)
+		}
+	}
+	return nil
+}
+
+func (l *bootstrapImageLock) validateMigrate() error {
+	if !strings.HasPrefix(l.Migrate.Version, "v") {
+		return fmt.Errorf("bootstrap migrate version must be a release tag, got %q", l.Migrate.Version)
+	}
+	locked := make(map[string]bool, len(l.Migrate.Archives))
+	for _, archive := range l.Migrate.Archives {
+		if !slices.Contains(bootstrapArchitectures, archive.Architecture) {
+			return fmt.Errorf(
+				"bootstrap migrate archive architecture %q is not one of %s",
+				archive.Architecture,
+				strings.Join(bootstrapArchitectures, ", "),
+			)
+		}
+		if locked[archive.Architecture] {
+			return fmt.Errorf("bootstrap migrate archive for %s is locked twice", archive.Architecture)
+		}
+		locked[archive.Architecture] = true
+		if err := validateBootstrapChecksum(
+			fmt.Sprintf("bootstrap migrate %s archive checksum", archive.Architecture),
+			archive.SHA256,
+		); err != nil {
+			return err
+		}
+	}
+	for _, architecture := range bootstrapArchitectures {
+		if !locked[architecture] {
+			return fmt.Errorf("bootstrap migrate archive for %s is required", architecture)
+		}
+	}
+	return nil
+}
+
+func alpineReleaseBranch(version string) (string, error) {
+	major, rest, found := strings.Cut(version, ".")
+	minor, _, _ := strings.Cut(rest, ".")
+	if !found || major == "" || minor == "" {
+		return "", fmt.Errorf("bootstrap base image version %q is not an Alpine release version", version)
+	}
+	return "v" + major + "." + minor, nil
+}
+
+func validateBootstrapDigest(field, value string) error {
+	algorithm, encoded, found := strings.Cut(value, ":")
+	if !found || algorithm != "sha256" {
+		return fmt.Errorf("%s must be a sha256 digest", field)
+	}
+	return validateBootstrapChecksum(field, encoded)
+}
+
+func validateBootstrapChecksum(field, value string) error {
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != sha256.Size {
+		return fmt.Errorf("%s must be a sha256 checksum", field)
+	}
+	return nil
+}

--- a/bootstrap_image_test.go
+++ b/bootstrap_image_test.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBootstrapImageLockMatchesCommittedDocument(t *testing.T) {
+	content, err := os.ReadFile("bootstrap-image.json")
+	require.NoError(t, err)
+	lock, err := parseBootstrapImageLock(content)
+	require.NoError(t, err)
+	require.Equal(t, lock, bootstrapLock)
+
+	document := sha256.Sum256(content)
+	require.Equal(t, "sha256:"+hex.EncodeToString(document[:]), bootstrapLock.LockDigest)
+}
+
+// The bootstrap image downloads the migrate archive with curl and its command
+// reconciles runtime access with psql, so both tools must stay pinned in the lock
+// rather than being pulled from whatever the repository serves.
+func TestBootstrapImageLockPinsBuildAndCommandTooling(t *testing.T) {
+	pinned := map[string]string{}
+	for _, entry := range bootstrapLock.Packages.Pinned {
+		pinned[entry.Name] = entry.Version
+	}
+	require.Contains(t, pinned, "curl")
+	require.Contains(t, pinned, "postgresql17-client")
+}
+
+func TestBootstrapProvenanceExposesEveryResolvedInput(t *testing.T) {
+	provenance := bootstrapLock.Provenance()
+	require.NotEmpty(t, provenance)
+
+	arguments := map[string]bool{}
+	labels := map[string]bool{}
+	for _, entry := range provenance {
+		require.NotEmpty(t, entry.Arg)
+		require.NotEmpty(t, entry.Label)
+		require.NotEmpty(t, entry.Value, entry.Arg)
+		require.False(t, arguments[entry.Arg], "duplicate build argument %s", entry.Arg)
+		require.False(t, labels[entry.Label], "duplicate label %s", entry.Label)
+		arguments[entry.Arg] = true
+		labels[entry.Label] = true
+	}
+
+	values := map[string]string{}
+	for _, entry := range provenance {
+		values[entry.Label] = entry.Value
+	}
+	require.Equal(t, bootstrapLock.LockDigest, values["dev.codefly.bootstrap.lock-digest"])
+	require.Equal(t, bootstrapLock.Base.Reference(), values["dev.codefly.bootstrap.base"])
+	require.Equal(t, bootstrapLock.Packages.Specs(), values["dev.codefly.bootstrap.apk-packages"])
+	require.Contains(t, values["dev.codefly.bootstrap.migrate-archives"], "amd64=")
+	require.Contains(t, values["dev.codefly.bootstrap.migrate-archives"], "arm64=")
+
+	buildArgs := bootstrapLock.RecipeBuildArgs()
+	require.Len(t, buildArgs, len(provenance))
+	for _, entry := range provenance {
+		require.Equal(t, entry.Value, buildArgs[entry.Arg])
+	}
+}
+
+func TestParseBootstrapImageLockRejectsUnverifiableInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		amend func(document map[string]any)
+		error string
+	}{
+		{
+			name:  "missing base digest",
+			amend: func(document map[string]any) { lockBase(document)["digest"] = "" },
+			error: "bootstrap base image digest must be a sha256 digest",
+		},
+		{
+			name:  "base pinned by tag instead of digest",
+			amend: func(document map[string]any) { lockBase(document)["digest"] = "3.21.7" },
+			error: "bootstrap base image digest must be a sha256 digest",
+		},
+		{
+			name:  "truncated base digest",
+			amend: func(document map[string]any) { lockBase(document)["digest"] = "sha256:48b0309ca019d89d" },
+			error: "bootstrap base image digest must be a sha256 checksum",
+		},
+		{
+			name:  "missing base version",
+			amend: func(document map[string]any) { lockBase(document)["version"] = "" },
+			error: "bootstrap base image version is required",
+		},
+		{
+			name: "plaintext package repository",
+			amend: func(document map[string]any) {
+				lockPackages(document)["repository"] = "http://dl-cdn.alpinelinux.org/alpine/v3.21/main"
+			},
+			error: `bootstrap apk repository must be an https URL, got "http://dl-cdn.alpinelinux.org/alpine/v3.21/main"`,
+		},
+		{
+			name:  "package repository left on the previous release branch",
+			amend: func(document map[string]any) { lockBase(document)["version"] = "3.22.1" },
+			error: `bootstrap apk repository "https://dl-cdn.alpinelinux.org/alpine/v3.21/main" does not serve the locked Alpine v3.22 branch`,
+		},
+		{
+			name: "package without an exact version",
+			amend: func(document map[string]any) {
+				lockPackages(document)["pinned"] = []any{map[string]any{"name": "curl", "version": ""}}
+			},
+			error: "bootstrap apk package curl must pin an exact version",
+		},
+		{
+			name:  "no pinned packages",
+			amend: func(document map[string]any) { lockPackages(document)["pinned"] = []any{} },
+			error: "bootstrap apk packages are required",
+		},
+		{
+			name:  "migrate pinned to a moving reference",
+			amend: func(document map[string]any) { lockMigrate(document)["version"] = "latest" },
+			error: `bootstrap migrate version must be a release tag, got "latest"`,
+		},
+		{
+			name: "archive without a checksum",
+			amend: func(document map[string]any) {
+				lockArchives(document)[0].(map[string]any)["sha256"] = ""
+			},
+			error: "bootstrap migrate amd64 archive checksum must be a sha256 checksum",
+		},
+		{
+			name: "architecture locked twice",
+			amend: func(document map[string]any) {
+				lockArchives(document)[1].(map[string]any)["architecture"] = "amd64"
+			},
+			error: "bootstrap migrate archive for amd64 is locked twice",
+		},
+		{
+			name: "unsupported architecture",
+			amend: func(document map[string]any) {
+				lockArchives(document)[1].(map[string]any)["architecture"] = "riscv64"
+			},
+			error: `bootstrap migrate archive architecture "riscv64" is not one of amd64, arm64`,
+		},
+		{
+			name: "architecture missing from the lock",
+			amend: func(document map[string]any) {
+				lockMigrate(document)["archives"] = lockArchives(document)[:1]
+			},
+			error: "bootstrap migrate archive for arm64 is required",
+		},
+		{
+			name: "unknown field",
+			amend: func(document map[string]any) {
+				lockMigrate(document)["checksums"] = map[string]any{"amd64": "unverified"}
+			},
+			error: `parse bootstrap image lock: json: unknown field "checksums"`,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			document := committedBootstrapLockDocument(t)
+			test.amend(document)
+			amended, err := json.Marshal(document)
+			require.NoError(t, err)
+
+			_, err = parseBootstrapImageLock(amended)
+			require.EqualError(t, err, test.error)
+		})
+	}
+}
+
+func committedBootstrapLockDocument(t *testing.T) map[string]any {
+	t.Helper()
+	content, err := os.ReadFile("bootstrap-image.json")
+	require.NoError(t, err)
+	var document map[string]any
+	require.NoError(t, json.Unmarshal(content, &document))
+	return document
+}
+
+func lockBase(document map[string]any) map[string]any {
+	return document["base"].(map[string]any)
+}
+
+func lockPackages(document map[string]any) map[string]any {
+	return document["packages"].(map[string]any)
+}
+
+func lockMigrate(document map[string]any) map[string]any {
+	return document["migrate"].(map[string]any)
+}
+
+func lockArchives(document map[string]any) []any {
+	return lockMigrate(document)["archives"].([]any)
+}
+
+func TestBootstrapDockerfileLocksEveryInput(t *testing.T) {
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
+		Bootstrap:                    bootstrapLock,
+		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+	})
+
+	require.Contains(t, dockerfile, "FROM "+bootstrapLock.Base.Reference())
+	require.NotContains(t, dockerfile, bootstrapLock.Base.Image+":", "base image must not resolve through a mutable tag")
+
+	require.Contains(t, dockerfile, bootstrapLock.Packages.Repository+"\" >/etc/apk/repositories")
+	require.Contains(t, dockerfile, "apk add --no-cache "+bootstrapLock.Packages.Specs())
+
+	script := bootstrapMigrateInstallScript(t, dockerfile)
+	for _, archive := range bootstrapLock.Migrate.Archives {
+		require.Contains(t, script, archive.Architecture+") checksum="+archive.SHA256)
+	}
+	require.Contains(t, script, "/releases/download/"+bootstrapLock.Migrate.Version+"/migrate.linux-${architecture}.tar.gz")
+
+	// The archive lands in a file that is checksum-verified before anything reads
+	// it, so unverified bytes never reach tar — the shape a curl-into-tar pipe
+	// cannot have.
+	require.NotContains(t, script, "| tar")
+	download := strings.Index(script, "-o /tmp/migrate.tar.gz")
+	verification := strings.Index(script, "sha256sum -c -")
+	extraction := strings.Index(script, "tar -xzf")
+	installation := strings.Index(script, "install -m 0755")
+	require.Positive(t, download)
+	require.Greater(t, verification, download)
+	require.Greater(t, extraction, verification)
+	require.Greater(t, installation, extraction)
+
+	for _, entry := range bootstrapLock.Provenance() {
+		require.Contains(t, dockerfile, "ARG "+entry.Arg+"=\""+entry.Value+"\"")
+		require.Contains(t, dockerfile, entry.Label+"=\"$"+entry.Arg+"\"")
+	}
+}
+
+// TestBootstrapImageBuildsLockedInputsPerArchitecture builds the image the
+// template renders and reads back what the locked inputs actually resolved to: the
+// base release, the pinned client version, and a migrate binary that executes on
+// the target architecture and reports the locked version.
+func TestBootstrapImageBuildsLockedInputsPerArchitecture(t *testing.T) {
+	requireDocker(t)
+	context := bootstrapBuildContext(t)
+
+	machines := map[string]string{"amd64": "x86_64", "arm64": "aarch64"}
+	for _, architecture := range bootstrapArchitectures {
+		t.Run(architecture, func(t *testing.T) {
+			platform := "linux/" + architecture
+			requireDockerPlatform(t, platform)
+
+			tag := fmt.Sprintf("service-postgres-bootstrap-lock-test-%s:%d", architecture, time.Now().UnixNano())
+			t.Cleanup(func() { _ = exec.Command("docker", "image", "rm", tag).Run() })
+			build := exec.Command("docker", "build", "--platform", platform, "--tag", tag, context)
+			output, err := build.CombinedOutput()
+			require.NoError(t, err, "%s build failed: %s", platform, output)
+
+			inspect, err := exec.Command("docker", "image", "inspect", tag, "--format", "{{json .Config.Labels}}").Output()
+			require.NoError(t, err)
+			labels := map[string]string{}
+			require.NoError(t, json.Unmarshal(inspect, &labels))
+			for _, entry := range bootstrapLock.Provenance() {
+				require.Equal(t, entry.Value, labels[entry.Label])
+			}
+
+			resolved, err := exec.Command("docker", "run", "--rm", "--platform", platform,
+				"--entrypoint", "sh", tag, "-c",
+				"migrate -version; uname -m; cat /etc/alpine-release; psql --version",
+			).CombinedOutput()
+			require.NoError(t, err, string(resolved))
+			require.Contains(t, string(resolved), strings.TrimPrefix(bootstrapLock.Migrate.Version, "v"))
+			require.Contains(t, string(resolved), machines[architecture])
+			require.Contains(t, string(resolved), bootstrapLock.Base.Version)
+			client, _, _ := strings.Cut(bootstrapPinnedVersion(t, "postgresql17-client"), "-r")
+			require.Contains(t, string(resolved), "(PostgreSQL) "+client)
+		})
+	}
+}
+
+// TestBootstrapImageRejectsTamperedMigrateArchive runs the Dockerfile's own install
+// step against a substituted archive: only the download is replaced, so the
+// verification under test is the template's. The archive carries a payload that
+// records its own execution, so the test can prove the tampered bytes were never
+// extracted or run.
+func TestBootstrapImageRejectsTamperedMigrateArchive(t *testing.T) {
+	requireDocker(t)
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
+		Bootstrap:                    bootstrapLock,
+		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+	})
+	script := bootstrapMigrateInstallScript(t, dockerfile)
+
+	download := regexp.MustCompile(`curl -fsSL -o /tmp/migrate\.tar\.gz "[^"]+"`)
+	require.Len(t, download.FindAllString(script, -1), 1, "install step no longer downloads the archive to a file")
+	script = download.ReplaceAllString(script, "cp /fixture/migrate.tar.gz /tmp/migrate.tar.gz")
+
+	fixture := t.TempDir()
+	writeTamperedMigrateArchive(t, filepath.Join(fixture, "migrate.tar.gz"))
+
+	output, err := exec.Command("docker", "run", "--rm",
+		"--volume", fixture+":/fixture",
+		bootstrapLock.Base.Reference(), "sh", "-c", script,
+	).CombinedOutput()
+	require.Error(t, err, "tampered archive was accepted: %s", output)
+	require.Contains(t, string(output), "FAILED")
+	require.NoFileExists(t, filepath.Join(fixture, "executed"),
+		"tampered archive was extracted and executed")
+}
+
+// bootstrapBuildContext stages a build context for the bootstrap Dockerfile: the
+// rendered Dockerfile plus the runtime-access.sql it COPYs.
+func bootstrapBuildContext(t *testing.T) string {
+	t.Helper()
+	context := t.TempDir()
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
+		Bootstrap:                    bootstrapLock,
+		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+	})
+	require.NoError(t, os.WriteFile(filepath.Join(context, "Dockerfile"), []byte(dockerfile), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(context, "runtime-access.sql"), []byte("SELECT 1;\n"), 0o644))
+	return context
+}
+
+// bootstrapMigrateInstallScript lifts the migrate install step out of the rendered
+// Dockerfile as a runnable shell script, so a test exercises the template's own
+// commands instead of a re-typed copy of them.
+func bootstrapMigrateInstallScript(t *testing.T, dockerfile string) string {
+	t.Helper()
+	var scripts []string
+	lines := strings.Split(dockerfile, "\n")
+	for index := 0; index < len(lines); index++ {
+		script, isRun := strings.CutPrefix(lines[index], "RUN ")
+		if !isRun {
+			continue
+		}
+		for strings.HasSuffix(script, "\\") && index+1 < len(lines) {
+			index++
+			script = strings.TrimSuffix(script, "\\") + lines[index]
+		}
+		if strings.Contains(script, "sha256sum -c -") {
+			scripts = append(scripts, script)
+		}
+	}
+	require.Len(t, scripts, 1, "exactly one build step must verify the migrate archive")
+	return scripts[0]
+}
+
+// writeTamperedMigrateArchive writes an archive shaped like the migrate release but
+// carrying a payload that records being run, so an accepted archive is observable.
+func writeTamperedMigrateArchive(t *testing.T, path string) {
+	t.Helper()
+	payload := []byte("#!/bin/sh\ntouch /fixture/executed\n")
+
+	file, err := os.Create(path)
+	require.NoError(t, err)
+	compressor := gzip.NewWriter(file)
+	archive := tar.NewWriter(compressor)
+	require.NoError(t, archive.WriteHeader(&tar.Header{
+		Name: "migrate",
+		Mode: 0o755,
+		Size: int64(len(payload)),
+	}))
+	_, err = archive.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, archive.Close())
+	require.NoError(t, compressor.Close())
+	require.NoError(t, file.Close())
+}
+
+func bootstrapPinnedVersion(t *testing.T, name string) string {
+	t.Helper()
+	for _, pinned := range bootstrapLock.Packages.Pinned {
+		if pinned.Name == name {
+			return pinned.Version
+		}
+	}
+	t.Fatalf("bootstrap lock does not pin %s", name)
+	return ""
+}
+
+func requireDocker(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// requireDockerPlatform skips when the host cannot run images for platform: a
+// foreign architecture needs emulation the runner may not have installed, and a
+// silent pass would claim coverage the run never had.
+func requireDockerPlatform(t *testing.T, platform string) {
+	t.Helper()
+	probe := exec.Command("docker", "run", "--rm", "--platform", platform, bootstrapLock.Base.Reference(), "true")
+	if output, err := probe.CombinedOutput(); err != nil {
+		t.Skipf("docker cannot run %s images on this host: %v\n%s", platform, err, output)
+	}
+}

--- a/bootstrap_image_test.go
+++ b/bootstrap_image_test.go
@@ -492,18 +492,26 @@ func requireDocker(t *testing.T) {
 	}
 }
 
-// requireDockerPlatform skips when the host cannot run images for platform, because
-// a foreign architecture needs emulation a developer machine may not have. Under CI
-// it fails instead: that is the run whose green result is taken as proof both
-// architectures were verified, so it must not be able to quietly verify one.
+// requireDockerPlatform skips when the host cannot build images for platform,
+// because a foreign architecture needs emulation a developer machine may not have.
+// Under CI it fails instead: that is the run whose green result is taken as proof
+// both architectures were verified, so it must not be able to quietly verify one.
+//
+// The probe builds rather than runs, matching what it gates. `docker run
+// --platform` against the locked base is refused outright ("cannot overwrite
+// digest") whenever the requested platform is not the one the pinned index digest
+// resolves to by default, so it reports a missing emulator on every host for every
+// foreign architecture. A build resolves the per-platform manifest out of the index
+// the way the real build does, and its RUN still needs the emulator.
 func requireDockerPlatform(t *testing.T, platform string) {
 	t.Helper()
-	probe := exec.Command("docker", "run", "--rm", "--platform", platform, bootstrapLock.Base.Reference(), "true")
+	probe := exec.Command("docker", "build", "--platform", platform, "--quiet", "-")
+	probe.Stdin = strings.NewReader("FROM " + bootstrapLock.Base.Reference() + "\nRUN true\n")
 	output, err := probe.CombinedOutput()
 	if err == nil {
 		return
 	}
-	message := fmt.Sprintf("docker cannot run %s images on this host: %v\n%s", platform, err, output)
+	message := fmt.Sprintf("docker cannot build %s images on this host: %v\n%s", platform, err, output)
 	if os.Getenv("CI") != "" {
 		t.Fatal(message + "\nCI must register emulation (docker/setup-qemu-action) before running these tests")
 	}

--- a/bootstrap_image_test.go
+++ b/bootstrap_image_test.go
@@ -7,10 +7,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -25,8 +28,56 @@ func TestBootstrapImageLockMatchesCommittedDocument(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, lock, bootstrapLock)
 
-	document := sha256.Sum256(content)
+	canonical, err := json.Marshal(lock)
+	require.NoError(t, err)
+	document := sha256.Sum256(canonical)
 	require.Equal(t, "sha256:"+hex.EncodeToString(document[:]), bootstrapLock.LockDigest)
+}
+
+// TestBootstrapImageLockDigestIgnoresDocumentFormatting covers the value a consumer
+// compares across two builds: reindenting the lock resolves the same inputs, so it
+// must not report a different identity.
+func TestBootstrapImageLockDigestIgnoresDocumentFormatting(t *testing.T) {
+	document := committedBootstrapLockDocument(t)
+	compact, err := json.Marshal(document)
+	require.NoError(t, err)
+	indented, err := json.MarshalIndent(document, "", "\t")
+	require.NoError(t, err)
+	require.NotEqual(t, compact, indented)
+
+	fromCompact, err := parseBootstrapImageLock(compact)
+	require.NoError(t, err)
+	fromIndented, err := parseBootstrapImageLock(indented)
+	require.NoError(t, err)
+
+	require.Equal(t, bootstrapLock.LockDigest, fromCompact.LockDigest)
+	require.Equal(t, bootstrapLock.LockDigest, fromIndented.LockDigest)
+}
+
+// TestBootstrapImageLockChecksumsMatchPublishedArchives is the check that makes a
+// locked checksum falsifiable: it downloads each archive the lock pins and hashes
+// it. Nothing else in the suite can tell a correct checksum from a plausible one —
+// the template test only asserts the value is present, and the per-architecture
+// build test needs emulation the host may not have.
+func TestBootstrapImageLockChecksumsMatchPublishedArchives(t *testing.T) {
+	for _, archive := range bootstrapLock.Migrate.Archives {
+		t.Run(archive.Architecture, func(t *testing.T) {
+			url := fmt.Sprintf(
+				"https://github.com/golang-migrate/migrate/releases/download/%s/migrate.linux-%s.tar.gz",
+				bootstrapLock.Migrate.Version, archive.Architecture,
+			)
+			response, err := http.Get(url)
+			require.NoError(t, err, "cannot reach %s to verify the locked checksum", url)
+			defer func() { require.NoError(t, response.Body.Close()) }()
+			require.Equal(t, http.StatusOK, response.StatusCode, url)
+
+			hasher := sha256.New()
+			_, err = io.Copy(hasher, response.Body)
+			require.NoError(t, err)
+			require.Equal(t, archive.SHA256, hex.EncodeToString(hasher.Sum(nil)),
+				"locked checksum does not match the archive published at %s", url)
+		})
+	}
 }
 
 // The bootstrap image downloads the migrate archive with curl and its command
@@ -64,6 +115,7 @@ func TestBootstrapProvenanceExposesEveryResolvedInput(t *testing.T) {
 	require.Equal(t, bootstrapLock.LockDigest, values["dev.codefly.bootstrap.lock-digest"])
 	require.Equal(t, bootstrapLock.Base.Reference(), values["dev.codefly.bootstrap.base"])
 	require.Equal(t, bootstrapLock.Packages.Specs(), values["dev.codefly.bootstrap.apk-packages"])
+	require.Equal(t, strings.Join(bootstrapLock.Packages.Repositories, " "), values["dev.codefly.bootstrap.apk-repositories"])
 	require.Contains(t, values["dev.codefly.bootstrap.migrate-archives"], "amd64=")
 	require.Contains(t, values["dev.codefly.bootstrap.migrate-archives"], "arm64=")
 
@@ -93,7 +145,7 @@ func TestParseBootstrapImageLockRejectsUnverifiableInput(t *testing.T) {
 		{
 			name:  "truncated base digest",
 			amend: func(document map[string]any) { lockBase(document)["digest"] = "sha256:48b0309ca019d89d" },
-			error: "bootstrap base image digest must be a sha256 checksum",
+			error: "bootstrap base image digest must be a sha256 digest",
 		},
 		{
 			name:  "missing base version",
@@ -103,7 +155,7 @@ func TestParseBootstrapImageLockRejectsUnverifiableInput(t *testing.T) {
 		{
 			name: "plaintext package repository",
 			amend: func(document map[string]any) {
-				lockPackages(document)["repository"] = "http://dl-cdn.alpinelinux.org/alpine/v3.21/main"
+				lockPackages(document)["repositories"] = []any{"http://dl-cdn.alpinelinux.org/alpine/v3.21/main"}
 			},
 			error: `bootstrap apk repository must be an https URL, got "http://dl-cdn.alpinelinux.org/alpine/v3.21/main"`,
 		},
@@ -118,6 +170,11 @@ func TestParseBootstrapImageLockRejectsUnverifiableInput(t *testing.T) {
 				lockPackages(document)["pinned"] = []any{map[string]any{"name": "curl", "version": ""}}
 			},
 			error: "bootstrap apk package curl must pin an exact version",
+		},
+		{
+			name:  "no package repositories",
+			amend: func(document map[string]any) { lockPackages(document)["repositories"] = []any{} },
+			error: "bootstrap apk repositories are required",
 		},
 		{
 			name:  "no pinned packages",
@@ -205,14 +262,16 @@ func lockArchives(document map[string]any) []any {
 
 func TestBootstrapDockerfileLocksEveryInput(t *testing.T) {
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 	})
 
 	require.Contains(t, dockerfile, "FROM "+bootstrapLock.Base.Reference())
 	require.NotContains(t, dockerfile, bootstrapLock.Base.Image+":", "base image must not resolve through a mutable tag")
 
-	require.Contains(t, dockerfile, bootstrapLock.Packages.Repository+"\" >/etc/apk/repositories")
+	for _, repository := range bootstrapLock.Packages.Repositories {
+		require.Contains(t, dockerfile, `"`+repository+`"`)
+	}
+	require.Contains(t, dockerfile, ">/etc/apk/repositories")
 	require.Contains(t, dockerfile, "apk add --no-cache "+bootstrapLock.Packages.Specs())
 
 	script := bootstrapMigrateInstallScript(t, dockerfile)
@@ -234,10 +293,23 @@ func TestBootstrapDockerfileLocksEveryInput(t *testing.T) {
 	require.Greater(t, extraction, verification)
 	require.Greater(t, installation, extraction)
 
+	// Literal label values, and no ARG behind them: a label that resolves a build
+	// argument reports whatever the caller passed, not what built the image.
 	for _, entry := range bootstrapLock.Provenance() {
-		require.Contains(t, dockerfile, "ARG "+entry.Arg+"=\""+entry.Value+"\"")
-		require.Contains(t, dockerfile, entry.Label+"=\"$"+entry.Arg+"\"")
+		require.Contains(t, dockerfile, entry.Label+"=\""+entry.Value+"\"")
+		require.NotContains(t, dockerfile, "ARG "+entry.Arg)
+		require.NotContains(t, dockerfile, "$"+entry.Arg)
 	}
+}
+
+// TestBootstrapDockerfileRendersFromZeroValueTemplating covers the locked inputs no
+// caller passes in: they reach the template through DockerTemplating's own method,
+// so a value constructed without them still renders a fully pinned image instead of
+// failing at render with a nil dereference.
+func TestBootstrapDockerfileRendersFromZeroValueTemplating(t *testing.T) {
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{})
+	require.Contains(t, dockerfile, "FROM "+bootstrapLock.Base.Reference())
+	require.Contains(t, dockerfile, "apk add --no-cache "+bootstrapLock.Packages.Specs())
 }
 
 // TestBootstrapImageBuildsLockedInputsPerArchitecture builds the image the
@@ -268,17 +340,49 @@ func TestBootstrapImageBuildsLockedInputsPerArchitecture(t *testing.T) {
 				require.Equal(t, entry.Value, labels[entry.Label])
 			}
 
+			machine, named := machines[architecture]
+			require.True(t, named, "no expected machine name for %s", architecture)
+
 			resolved, err := exec.Command("docker", "run", "--rm", "--platform", platform,
 				"--entrypoint", "sh", tag, "-c",
 				"migrate -version; uname -m; cat /etc/alpine-release; psql --version",
 			).CombinedOutput()
 			require.NoError(t, err, string(resolved))
 			require.Contains(t, string(resolved), strings.TrimPrefix(bootstrapLock.Migrate.Version, "v"))
-			require.Contains(t, string(resolved), machines[architecture])
+			require.Contains(t, string(resolved), machine)
 			require.Contains(t, string(resolved), bootstrapLock.Base.Version)
 			client, _, _ := strings.Cut(bootstrapPinnedVersion(t, "postgresql17-client"), "-r")
 			require.Contains(t, string(resolved), "(PostgreSQL) "+client)
 		})
+	}
+}
+
+// TestBootstrapImageLabelsCannotBeOverriddenAtBuildTime covers the provenance the
+// image reports about itself: passing the same names the recipe carries as build
+// arguments must not change a single label, or the labels are a caller's claim
+// rather than evidence of what was built.
+func TestBootstrapImageLabelsCannotBeOverriddenAtBuildTime(t *testing.T) {
+	requireDocker(t)
+	requireDockerPlatform(t, "linux/"+runtime.GOARCH)
+	context := bootstrapBuildContext(t)
+
+	arguments := []string{"build", "--tag", ""}
+	for argument := range bootstrapLock.RecipeBuildArgs() {
+		arguments = append(arguments, "--build-arg", argument+"=forged")
+	}
+	tag := fmt.Sprintf("service-postgres-bootstrap-forge-test:%d", time.Now().UnixNano())
+	arguments[2] = tag
+	t.Cleanup(func() { _ = exec.Command("docker", "image", "rm", tag).Run() })
+
+	output, err := exec.Command("docker", append(arguments, context)...).CombinedOutput()
+	require.NoError(t, err, string(output))
+
+	inspect, err := exec.Command("docker", "image", "inspect", tag, "--format", "{{json .Config.Labels}}").Output()
+	require.NoError(t, err)
+	labels := map[string]string{}
+	require.NoError(t, json.Unmarshal(inspect, &labels))
+	for _, entry := range bootstrapLock.Provenance() {
+		require.Equal(t, entry.Value, labels[entry.Label], "%s was forged by a build argument", entry.Label)
 	}
 }
 
@@ -290,7 +394,6 @@ func TestBootstrapImageBuildsLockedInputsPerArchitecture(t *testing.T) {
 func TestBootstrapImageRejectsTamperedMigrateArchive(t *testing.T) {
 	requireDocker(t)
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 	})
 	script := bootstrapMigrateInstallScript(t, dockerfile)
@@ -318,7 +421,6 @@ func bootstrapBuildContext(t *testing.T) string {
 	t.Helper()
 	context := t.TempDir()
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 	})
 	require.NoError(t, os.WriteFile(filepath.Join(context, "Dockerfile"), []byte(dockerfile), 0o644))
@@ -390,13 +492,20 @@ func requireDocker(t *testing.T) {
 	}
 }
 
-// requireDockerPlatform skips when the host cannot run images for platform: a
-// foreign architecture needs emulation the runner may not have installed, and a
-// silent pass would claim coverage the run never had.
+// requireDockerPlatform skips when the host cannot run images for platform, because
+// a foreign architecture needs emulation a developer machine may not have. Under CI
+// it fails instead: that is the run whose green result is taken as proof both
+// architectures were verified, so it must not be able to quietly verify one.
 func requireDockerPlatform(t *testing.T, platform string) {
 	t.Helper()
 	probe := exec.Command("docker", "run", "--rm", "--platform", platform, bootstrapLock.Base.Reference(), "true")
-	if output, err := probe.CombinedOutput(); err != nil {
-		t.Skipf("docker cannot run %s images on this host: %v\n%s", platform, err, output)
+	output, err := probe.CombinedOutput()
+	if err == nil {
+		return
 	}
+	message := fmt.Sprintf("docker cannot run %s images on this host: %v\n%s", platform, err, output)
+	if os.Getenv("CI") != "" {
+		t.Fatal(message + "\nCI must register emulation (docker/setup-qemu-action) before running these tests")
+	}
+	t.Skip(message)
 }

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -24,6 +24,7 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			parameters := DockerTemplating{
+				Bootstrap:                    bootstrapLock,
 				MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 				WithMigration:                test.withMigrations,
 				ReadOnlyRole:                 "codefly_app_ro",
@@ -49,8 +50,10 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 				"x86_64) architecture=amd64",
 				"aarch64) architecture=arm64",
 				`case "${architecture}" in`,
-				"amd64|arm64)",
-				"/releases/download/v4.19.1/migrate.linux-${architecture}.tar.gz",
+				"amd64) checksum=",
+				"arm64) checksum=",
+				`*) echo "unsupported target architecture: ${architecture}" >&2; exit 1 ;;`,
+				"/releases/download/" + bootstrapLock.Migrate.Version + "/migrate.linux-${architecture}.tar.gz",
 			} {
 				if !strings.Contains(dockerfile, required) {
 					t.Fatalf("bootstrap image is not target-architecture portable: missing %q", required)
@@ -91,6 +94,7 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	}
 	root := t.TempDir()
 	parameters := DockerTemplating{
+		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 	}
 	if err := os.WriteFile(
@@ -115,6 +119,7 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 
 func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *testing.T) {
 	parameters := DockerTemplating{
+		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 		ReadOnlyRole:                 "codefly_app_ro",
 		ReadWriteRole:                "codefly_app_rw",
@@ -148,6 +153,7 @@ func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *tes
 
 func TestRuntimeAccessTemplatePreservesDirectWriterWithoutDelegatedRoles(t *testing.T) {
 	parameters := DockerTemplating{
+		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 		ReadOnlyRole:                 "codefly_app_ro",
 		ReadWriteRole:                "codefly_app_rw",

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -24,7 +24,6 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			parameters := DockerTemplating{
-				Bootstrap:                    bootstrapLock,
 				MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 				WithMigration:                test.withMigrations,
 				ReadOnlyRole:                 "codefly_app_ro",
@@ -94,7 +93,6 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	}
 	root := t.TempDir()
 	parameters := DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 	}
 	if err := os.WriteFile(
@@ -119,7 +117,6 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 
 func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *testing.T) {
 	parameters := DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 		ReadOnlyRole:                 "codefly_app_ro",
 		ReadWriteRole:                "codefly_app_rw",
@@ -153,7 +150,6 @@ func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *tes
 
 func TestRuntimeAccessTemplatePreservesDirectWriterWithoutDelegatedRoles(t *testing.T) {
 	parameters := DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 		ReadOnlyRole:                 "codefly_app_ro",
 		ReadWriteRole:                "codefly_app_rw",

--- a/build_test.go
+++ b/build_test.go
@@ -182,3 +182,50 @@ func TestBuildRecipeCreatesEmptyMigrationsDirectory(t *testing.T) {
 	require.DirExists(t, filepath.Join(outputDirectory, "migrations"))
 	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
 }
+
+// TestBuildRecipeLocksBootstrapInputs covers the recipe a consumer builds without
+// the agent: the Dockerfile pins the base by digest and the recipe's typed build
+// arguments record every resolved bootstrap identity, including the lock digest.
+func TestBuildRecipeLocksBootstrapInputs(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	recipe := response.GetResult().GetDockerBuildPlan().GetRecipes()[0]
+	require.Equal(t, bootstrapLock.RecipeBuildArgs(), recipe.GetBuildArgs())
+	require.Equal(t, bootstrapLock.LockDigest, recipe.GetBuildArgs()["CODEFLY_BOOTSTRAP_LOCK_DIGEST"])
+
+	dockerfile, err := os.ReadFile(filepath.Join(outputDirectory, "builder", "Dockerfile"))
+	require.NoError(t, err)
+	require.Contains(t, string(dockerfile), "FROM "+bootstrapLock.Base.Reference())
+}
+
+// TestBuildRecipeResolvesIdenticalInputsAcrossEmissions builds the recipe twice
+// from independent builders and output directories: the resolved inputs, and the
+// aggregate digest over the tree they produce, must not depend on the emitting run.
+func TestBuildRecipeResolvesIdenticalInputsAcrossEmissions(t *testing.T) {
+	ctx := context.Background()
+
+	emit := func() (*builderv0.DockerBuildPlan, []byte) {
+		builder := newBuildTestBuilder(t)
+		outputDirectory := t.TempDir()
+		response, err := builder.Build(ctx, buildRequest(outputDirectory))
+		require.NoError(t, err)
+		require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+		dockerfile, err := os.ReadFile(filepath.Join(outputDirectory, "builder", "Dockerfile"))
+		require.NoError(t, err)
+		return response.GetResult().GetDockerBuildPlan(), dockerfile
+	}
+
+	firstPlan, firstDockerfile := emit()
+	secondPlan, secondDockerfile := emit()
+
+	require.Equal(t, firstDockerfile, secondDockerfile)
+	require.Equal(t, firstPlan.GetRecipes()[0].GetBuildArgs(), secondPlan.GetRecipes()[0].GetBuildArgs())
+	require.NotEmpty(t, firstPlan.GetDigest())
+	require.Equal(t, firstPlan.GetDigest(), secondPlan.GetDigest())
+}

--- a/builder.go
+++ b/builder.go
@@ -104,6 +104,7 @@ func (s *Builder) Upgrade(ctx context.Context, req *builderv0.UpgradeRequest) (*
 }
 
 type DockerTemplating struct {
+	Bootstrap                    *bootstrapImageLock
 	MigrationConnectionKeyHolder string
 	WithMigration                bool
 	ReadOnlyRole                 string
@@ -144,6 +145,7 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 		return s.Builder.BuildError(err)
 	}
 	docker := DockerTemplating{
+		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: fmt.Sprintf("{%s}", migrationConnectionEnvironmentKey),
 		WithMigration:                s.WithMigration(),
 		ReadOnlyRole:                 readOnlyRole,
@@ -242,6 +244,10 @@ func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *
 		Context:    ".",
 		Image:      img.FullName(),
 		Platforms:  []string{"linux/amd64", "linux/arm64"},
+		// The recipe carries the resolved bootstrap inputs it was rendered from, so a
+		// consumer reads the base, package and migrate identities off the plan
+		// instead of re-resolving them.
+		BuildArgs: docker.Bootstrap.RecipeBuildArgs(),
 	}})
 	if err != nil {
 		return s.Builder.BuildError(err)

--- a/builder.go
+++ b/builder.go
@@ -104,13 +104,19 @@ func (s *Builder) Upgrade(ctx context.Context, req *builderv0.UpgradeRequest) (*
 }
 
 type DockerTemplating struct {
-	Bootstrap                    *bootstrapImageLock
 	MigrationConnectionKeyHolder string
 	WithMigration                bool
 	ReadOnlyRole                 string
 	ReadWriteRole                string
 	Schemas                      []string
 	ReadWriteRoles               []string
+}
+
+// Bootstrap resolves the locked bootstrap inputs the Dockerfile renders from. A
+// method, not a field: the template dereferences it on its first line, so a
+// constructed value must not be able to omit it.
+func (DockerTemplating) Bootstrap() *bootstrapImageLock {
+	return bootstrapLock
 }
 
 func (s *Builder) WithMigration() bool {
@@ -145,7 +151,6 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 		return s.Builder.BuildError(err)
 	}
 	docker := DockerTemplating{
-		Bootstrap:                    bootstrapLock,
 		MigrationConnectionKeyHolder: fmt.Sprintf("{%s}", migrationConnectionEnvironmentKey),
 		WithMigration:                s.WithMigration(),
 		ReadOnlyRole:                 readOnlyRole,
@@ -243,11 +248,11 @@ func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *
 		Dockerfile: "builder/Dockerfile",
 		Context:    ".",
 		Image:      img.FullName(),
-		Platforms:  []string{"linux/amd64", "linux/arm64"},
+		Platforms:  bootstrapRecipePlatforms(),
 		// The recipe carries the resolved bootstrap inputs it was rendered from, so a
 		// consumer reads the base, package and migrate identities off the plan
 		// instead of re-resolving them.
-		BuildArgs: docker.Bootstrap.RecipeBuildArgs(),
+		BuildArgs: docker.Bootstrap().RecipeBuildArgs(),
 	}})
 	if err != nil {
 		return s.Builder.BuildError(err)

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"embed"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -139,10 +138,8 @@ func parseRuntimeImageLock(content []byte) (*resources.DockerImage, error) {
 	if lock.Digest == "" {
 		return nil, fmt.Errorf("runtime image digest is required")
 	}
-	algorithm, encoded, found := strings.Cut(lock.Digest, ":")
-	decoded, err := hex.DecodeString(encoded)
-	if !found || algorithm != "sha256" || err != nil || len(decoded) != 32 {
-		return nil, fmt.Errorf("runtime image digest must be a sha256 digest")
+	if err := validateSHA256Digest("runtime image digest", lock.Digest); err != nil {
+		return nil, err
 	}
 	return &resources.DockerImage{
 		Name:   lock.Name,

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -1,19 +1,19 @@
 FROM {{ .Bootstrap.Base.Reference }}
 
 ARG TARGETARCH
-{{- range .Bootstrap.Provenance }}
-ARG {{ .Arg }}="{{ .Value }}"
-{{- end }}
+
+# Literals, not build arguments: a label is provenance only if it reports what
+# actually built the image, and a --build-arg must not be able to rewrite it.
 LABEL {{ range $index, $entry := .Bootstrap.Provenance }}{{ if $index }} \
-      {{ end }}{{ $entry.Label }}="${{ $entry.Arg }}"{{ end }}
+      {{ end }}{{ $entry.Label }}="{{ $entry.Value }}"{{ end }}
 
 WORKDIR /app
 
-# apk resolves from the locked repository alone, and every package is pinned to an
+# apk resolves from the locked repositories alone, and every package is pinned to an
 # exact version: once upstream replaces one of them the build fails instead of
 # quietly installing different bytes. .github/scripts/update-bootstrap-lock.sh
 # moves the lock forward.
-RUN printf '%s\n' "{{ .Bootstrap.Packages.Repository }}" >/etc/apk/repositories \
+RUN printf '%s\n' {{ .Bootstrap.Packages.RepositoryArguments }} >/etc/apk/repositories \
     && apk add --no-cache {{ .Bootstrap.Packages.Specs }}
 
 # The archive is downloaded to a file and checksum-verified against the lock before

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -1,19 +1,40 @@
-FROM alpine:3.21
+FROM {{ .Bootstrap.Base.Reference }}
 
 ARG TARGETARCH
+{{- range .Bootstrap.Provenance }}
+ARG {{ .Arg }}="{{ .Value }}"
+{{- end }}
+LABEL {{ range $index, $entry := .Bootstrap.Provenance }}{{ if $index }} \
+      {{ end }}{{ $entry.Label }}="${{ $entry.Arg }}"{{ end }}
 
 WORKDIR /app
 
-RUN apk add --no-cache curl postgresql17-client
-RUN architecture="${TARGETARCH:-$(apk --print-arch)}" \
-    && case "${architecture}" in \
+# apk resolves from the locked repository alone, and every package is pinned to an
+# exact version: once upstream replaces one of them the build fails instead of
+# quietly installing different bytes. .github/scripts/update-bootstrap-lock.sh
+# moves the lock forward.
+RUN printf '%s\n' "{{ .Bootstrap.Packages.Repository }}" >/etc/apk/repositories \
+    && apk add --no-cache {{ .Bootstrap.Packages.Specs }}
+
+# The archive is downloaded to a file and checksum-verified against the lock before
+# anything unpacks or runs it, so tampered release bytes never reach tar.
+RUN set -eu; \
+    architecture="${TARGETARCH:-$(apk --print-arch)}"; \
+    case "${architecture}" in \
       x86_64) architecture=amd64 ;; \
       aarch64) architecture=arm64 ;; \
-      amd64|arm64) ;; \
+    esac; \
+    case "${architecture}" in \
+{{- range .Bootstrap.Migrate.Archives }}
+      {{ .Architecture }}) checksum={{ .SHA256 }} ;; \
+{{- end }}
       *) echo "unsupported target architecture: ${architecture}" >&2; exit 1 ;; \
-    esac \
-    && curl -fsSL "https://github.com/golang-migrate/migrate/releases/download/v4.19.1/migrate.linux-${architecture}.tar.gz" | tar xz \
-    && mv migrate /usr/local/bin/migrate
+    esac; \
+    curl -fsSL -o /tmp/migrate.tar.gz "https://github.com/golang-migrate/migrate/releases/download/{{ .Bootstrap.Migrate.Version }}/migrate.linux-${architecture}.tar.gz"; \
+    printf '%s  %s\n' "${checksum}" /tmp/migrate.tar.gz | sha256sum -c -; \
+    tar -xzf /tmp/migrate.tar.gz -C /tmp migrate; \
+    install -m 0755 /tmp/migrate /usr/local/bin/migrate; \
+    rm -f /tmp/migrate.tar.gz /tmp/migrate
 
 COPY . .
 


### PR DESCRIPTION
Closes #82.

## Summary

- The bootstrap image (separate from the digest-locked runtime image) resolved every input at build time: `FROM alpine:3.21`, `apk add curl postgresql17-client` with no versions, and a migrate release piped from curl straight into tar. Two builds of the same commit could install different bytes, and the downloaded executable was never verified — the F16 finding.
- `bootstrap-image.json` is now the checked-in source of truth for the base image digest, the apk repository plus exact package versions, and the migrate archive sha256 for amd64 and arm64. It is parsed and validated at load (sha256 shapes, exact package pins, both architectures present, package repository on the same Alpine branch as the locked base), so a half-finished lock edit fails loudly instead of producing a weaker image.
- The install step downloads the archive to a file, verifies it against the locked checksum, and only then extracts and installs it; an unsupported target architecture is still rejected as before (#40's `TARGETARCH` handling and the runtime-role/Job work are untouched).
- Resolved identities — base, base version, apk repositories, apk package pins, migrate version, per-arch archive checksums, and the lock's own digest — are exposed as image `LABEL`s and as the emitted `DockerBuildRecipe.build_args`. Every one of them is a rendered literal in the Dockerfile: nothing there reads a build argument, so no caller can pass one that changes what the image is or what it reports about itself.
- `.github/scripts/update-bootstrap-lock.sh` is the deliberate update path: it resolves the base digest from the registry, package versions from `apk policy` inside the digest-pinned base on both architectures (refusing to proceed if they disagree), and the archive checksums from the release's published `sha256sum.txt`. No value is authored by hand.

### Before / after

| input | before | after |
| --- | --- | --- |
| base image | `alpine:3.21` (mutable) | `alpine@sha256:48b0309…` (3.21.7) |
| apk packages | `curl postgresql17-client`, any version, base's repository list | `curl=8.14.1-r2 postgresql17-client=17.11-r0` from the locked repository set alone |
| migrate | `v4.19.1` archive piped from curl straight into tar, unverified | downloaded to a file, sha256-verified per architecture, then extracted |
| provenance | none | 7 image labels + recipe `build_args`, incl. lock digest |

### Follow-up commit: making these guarantees falsifiable

A review of the above found several of them true only by luck of today's inputs; `ff67223` fixes the causes. Highlights: locked checksums are now hashed against the published archives in a test (a one-character edit fails without needing emulation), QEMU is registered before `go test` so the arm64 case runs in CI and fails rather than skips there, the update script reads its targets from the lock instead of literal defaults that could revert a bump, `apk policy` resolution takes the newest candidate cross-checked against the resolver (it took the oldest), script failures no longer surface as `unbound variable`, the lock is written through a staged file, and the provenance labels are literals rather than overridable ARGs.

`f4bcdfd` then fixes a bug that the fail-under-CI rule itself exposed: the per-architecture gate probed emulation with `docker run --platform … alpine@<index digest>`, which a daemon refuses outright ("cannot overwrite digest") whenever the requested platform is not the one that digest resolves to by default — so CI failed on `linux/arm64` with QEMU registered and working, while the host-platform case (and every local run) passed. The probe now builds `FROM <locked base>` + `RUN true` for the platform, resolving the per-platform manifest the way the build under test does. Under the old silent-skip behaviour this would have gone unnoticed and arm64 would never have been verified in CI.

### Availability tradeoff (documented in the update script)

Alpine publishes no immutable package snapshot — a release branch keeps only the newest `-rN`. Pinning exact versions therefore trades availability for integrity: when upstream replaces `curl` or `postgresql17-client`, the build fails with `unable to select packages` rather than silently installing different bytes. That failure is the signal to rerun the update script, which is also how a security fix reaches the image.

That signal covers pinned packages only — a base digest the branch has moved past, and a newer migrate release, never fail anything — so `update-bootstrap-lock.sh --check` reports both and a weekly `bootstrap-lock-freshness` workflow runs it. It is deliberately not a PR gate: it should not turn unrelated pull requests red because upstream published a release.

The checksum file ships in the same GitHub release as the archives it covers, so it pins identity (fixed bytes under a fixed version, no mirror or CDN substitution) but shares a trust root with the artifact — it is not proof of authorship. Locking the version is what bounds that trust.

## Test plan

- [x] `go test ./... -skip '^TestCreateToRunDocker$'` — green (227s), all four packages.
- [x] `TestBootstrapImageBuildsLockedInputsPerArchitecture` — real `docker build` for `linux/amd64` **and** `linux/arm64`, then reads back from the running image: `migrate -version` = 4.19.1, `uname -m` = x86_64 / aarch64 (so the binary is executable on the target arch), `/etc/alpine-release` = 3.21.7, `psql` = 17.11, and every provenance label equals the lock. Skips with an explicit message when the host cannot run a foreign-architecture image (a CI runner without QEMU reports the skip rather than passing silently).
- [x] `TestBootstrapImageRejectsTamperedMigrateArchive` — lifts the Dockerfile's own install step out of the rendered template, substitutes only the download with a tampered archive whose payload records its own execution, and runs it in the digest-pinned base: exit non-zero, `sha256sum` reports `FAILED`, and the payload marker is absent — verification fails before extraction or execution.
- [x] `TestBuildRecipeLocksBootstrapInputs` / `TestBuildRecipeResolvesIdenticalInputsAcrossEmissions` — the emitted recipe carries the lock's build args, and two independent emissions produce byte-identical Dockerfiles and the same aggregate plan digest.
- [x] `TestParseBootstrapImageLockRejectsUnverifiableInput` — 14 cases: tag-instead-of-digest, truncated digest, plaintext repository, repository left on the previous Alpine branch, unpinned package, moving migrate reference, missing/duplicate/unknown architecture, unknown lock field.
- [x] Two `docker build --no-cache` runs from separate contexts: identical resolved inputs (labels, `migrate`/`psql`/base versions). Image digests are not compared — build timestamps are not controlled here.
- [x] `.github/scripts/update-bootstrap-lock.sh` run end to end: it regenerates the committed `bootstrap-image.json` byte-for-byte from upstream, so the lock is reproducible rather than hand-written.
- [x] `shellcheck` clean on the new script.

## Limitations

- `--check` currently reports one real finding: migrate `v4.19.1` is behind upstream `v4.20.1`, so the scheduled freshness job will be red until someone takes the bump with `MIGRATE_VERSION=v4.20.1 .github/scripts/update-bootstrap-lock.sh`. That is the detector working, not a defect: trivy on the built bootstrap image shows the pinned migrate binary carries 44 HIGH + 5 CRITICAL in its vendored Go dependencies (the Alpine layer itself is clean, 0). The bump is a deliberate CLI version change and is not taken here.

- The per-architecture build test needs emulation for the foreign architecture; on a runner without it, that subtest skips with a message naming the missing prerequisite. In CI's `go test` step (before QEMU setup) expect `linux/arm64` to skip and `linux/amd64` to build natively.
- Package availability is fail-closed by design (see above): a bootstrap build can start failing without any change in this repository, and the fix is to rerun the update script.
- No cross-repository dependency: nothing in `core`/`proto` changed, and the recipe uses the existing `build_args` field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


