### PR TITLE
fix: ignore editor leftovers beside migrations (#83)

### DIFF
--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -114,23 +114,28 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	}
 }
 
-// TestBootstrapImageDropsStrayMigrationFiles proves the deployed bootstrap runs
-// migrate over the same filtered set the local runtime applies: an editor backup
-// that keeps a migration's prefix must not reach the image.
-func TestBootstrapImageDropsStrayMigrationFiles(t *testing.T) {
+// TestBootstrapImageAppliesOnlyRealMigrations drives the deployed bootstrap end
+// to end against a disposable Postgres: the image must prune exactly what the
+// runtime filter hides — nothing more — and then apply every real migration,
+// whatever extension it carries.
+func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Fatal(err)
 	}
-	root := t.TempDir()
 	parameters := DockerTemplating{
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 		WithMigration:                true,
+		MigrationFileNamePattern:     migrationFileNamePattern,
 	}
-	if err := os.WriteFile(
-		filepath.Join(root, "Dockerfile"),
-		[]byte(renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)),
-		0o644,
-	); err != nil {
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)
+	// One definition of a migration filename: a prune that drifts from the
+	// runtime filter deletes files the runtime would have applied.
+	if !strings.Contains(dockerfile, migrationFileNamePattern) {
+		t.Fatalf("bootstrap prune does not use the runtime filename pattern %q", migrationFileNamePattern)
+	}
+
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(root, "runtime-access.sql"), []byte("SELECT 1;\n"), 0o644); err != nil {
@@ -140,27 +145,50 @@ func TestBootstrapImageDropsStrayMigrationFiles(t *testing.T) {
 	if err := os.MkdirAll(migrations, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	kept := []string{"1_init.up.sql", "1_init.down.sql", "2_add_index.up.sql", "2_add_index.down.sql"}
-	stray := []string{"2_add_index.up.sql~", "2_add_index.up.sql.bak", "2_add_index.up.sql.orig", ".2_add_index.up.sql.swp"}
-	for _, name := range append(append([]string{}, kept...), stray...) {
-		if err := os.WriteFile(filepath.Join(migrations, name), []byte("SELECT 1;\n"), 0o644); err != nil {
+	// Version 3 deliberately uses a non-.sql extension: golang-migrate applies it,
+	// so pruning it would leave the bootstrap reporting success over an
+	// unmigrated database.
+	kept := map[string]string{
+		"1_init.up.sql":         "CREATE TABLE deployed_one (id INT PRIMARY KEY);",
+		"1_init.down.sql":       "DROP TABLE deployed_one;",
+		"2_add_index.up.sql":    "CREATE INDEX deployed_one_id_idx ON deployed_one (id);",
+		"2_add_index.down.sql":  "DROP INDEX deployed_one_id_idx;",
+		"3_flavored.up.pgsql":   "CREATE TABLE deployed_three (id INT PRIMARY KEY);",
+		"3_flavored.down.pgsql": "DROP TABLE deployed_three;",
+	}
+	stray := []string{
+		"2_add_index.up.sql~",
+		"2_add_index.up.sql.bak",
+		"2_add_index.up.sql.orig",
+		".2_add_index.up.sql.swp",
+		"3_flavored.up.pgsql~",
+	}
+	for name, body := range kept {
+		if err := os.WriteFile(filepath.Join(migrations, name), []byte(body+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range stray {
+		body := "CREATE TABLE stray_must_not_apply (id INT);\n"
+		if err := os.WriteFile(filepath.Join(migrations, name), []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
 	}
 
-	tag := fmt.Sprintf("service-postgres-bootstrap-stray-test:%d", time.Now().UnixNano())
+	tag := fmt.Sprintf("service-postgres-bootstrap-migrations-test:%d", time.Now().UnixNano())
 	t.Cleanup(func() {
 		_ = exec.Command("docker", "image", "rm", tag).Run()
 	})
 	if output, err := exec.Command("docker", "build", "--tag", tag, root).CombinedOutput(); err != nil {
 		t.Fatalf("bootstrap image build failed: %v\n%s", err, output)
 	}
+
 	output, err := exec.Command("docker", "run", "--rm", tag, "ls", "-A", "/app/migrations").CombinedOutput()
 	if err != nil {
 		t.Fatalf("list packaged migrations: %v\n%s", err, output)
 	}
 	packaged := strings.Fields(string(output))
-	for _, name := range kept {
+	for name := range kept {
 		if !slices.Contains(packaged, name) {
 			t.Errorf("bootstrap image dropped migration %q: %v", name, packaged)
 		}
@@ -170,6 +198,87 @@ func TestBootstrapImageDropsStrayMigrationFiles(t *testing.T) {
 			t.Errorf("bootstrap image packaged stray file %q, which blocks the whole lineage", name)
 		}
 	}
+
+	database := startDisposablePostgres(t)
+	bootstrap := exec.Command(
+		"docker", "run", "--rm",
+		"--network", "container:"+database,
+		"--env", migrationConnectionEnvironmentKey+"=postgres://postgres:bootstrap-test@127.0.0.1:5432/postgres?sslmode=disable",
+		tag,
+	)
+	if output, err := bootstrap.CombinedOutput(); err != nil {
+		t.Fatalf("bootstrap job failed against a real database: %v\n%s", err, output)
+	}
+
+	// psql renders booleans as t/f.
+	for relation, want := range map[string]string{
+		"public.deployed_one":         "t",
+		"public.deployed_three":       "t",
+		"public.stray_must_not_apply": "f",
+	} {
+		got := queryDisposablePostgres(t, database, fmt.Sprintf("SELECT to_regclass('%s') IS NOT NULL", relation))
+		if got != want {
+			t.Errorf("relation %s present = %q, want %q", relation, got, want)
+		}
+	}
+	// Concatenation casts the boolean to text, so dirty reads "false" here.
+	if ledger := queryDisposablePostgres(t, database, "SELECT version || '/' || dirty FROM schema_migrations"); ledger != "3/false" {
+		t.Errorf("migration ledger = %q, want %q", ledger, "3/false")
+	}
+}
+
+// startDisposablePostgres runs the Postgres image this repository already pins
+// for its runtime and returns the container name, ready for connections.
+func startDisposablePostgres(t *testing.T) string {
+	t.Helper()
+	dockerfile, err := os.ReadFile("Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var image string
+	for _, line := range strings.Split(string(dockerfile), "\n") {
+		if rest, found := strings.CutPrefix(line, "ARG POSTGRES_IMAGE="); found {
+			image = strings.TrimSpace(rest)
+			break
+		}
+	}
+	if image == "" {
+		t.Fatal("no pinned POSTGRES_IMAGE in Dockerfile")
+	}
+
+	name := fmt.Sprintf("service-postgres-bootstrap-db-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "rm", "--force", name).Run()
+	})
+	run := exec.Command(
+		"docker", "run", "--detach", "--name", name,
+		"--env", "POSTGRES_PASSWORD=bootstrap-test",
+		image,
+	)
+	if output, err := run.CombinedOutput(); err != nil {
+		t.Fatalf("start disposable postgres: %v\n%s", err, output)
+	}
+	for range 60 {
+		if exec.Command("docker", "exec", name, "pg_isready", "--username", "postgres").Run() == nil {
+			return name
+		}
+		time.Sleep(time.Second)
+	}
+	logs, _ := exec.Command("docker", "logs", name).CombinedOutput()
+	t.Fatalf("disposable postgres never became ready\n%s", logs)
+	return ""
+}
+
+func queryDisposablePostgres(t *testing.T, container string, query string) string {
+	t.Helper()
+	output, err := exec.Command(
+		"docker", "exec", container,
+		"psql", "--username", "postgres", "--no-align", "--tuples-only", "--command", query,
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("query %q: %v\n%s", query, err, output)
+	}
+	return strings.TrimSpace(string(output))
 }
 
 func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *testing.T) {

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"text/template"
@@ -110,6 +111,64 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	command := exec.Command("docker", "build", "--build-arg", "TARGETARCH=", "--tag", tag, root)
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("legacy Docker build without TARGETARCH failed: %v\n%s", err, output)
+	}
+}
+
+// TestBootstrapImageDropsStrayMigrationFiles proves the deployed bootstrap runs
+// migrate over the same filtered set the local runtime applies: an editor backup
+// that keeps a migration's prefix must not reach the image.
+func TestBootstrapImageDropsStrayMigrationFiles(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Fatal(err)
+	}
+	root := t.TempDir()
+	parameters := DockerTemplating{
+		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+		WithMigration:                true,
+	}
+	if err := os.WriteFile(
+		filepath.Join(root, "Dockerfile"),
+		[]byte(renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)),
+		0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "runtime-access.sql"), []byte("SELECT 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	migrations := filepath.Join(root, "migrations")
+	if err := os.MkdirAll(migrations, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	kept := []string{"1_init.up.sql", "1_init.down.sql", "2_add_index.up.sql", "2_add_index.down.sql"}
+	stray := []string{"2_add_index.up.sql~", "2_add_index.up.sql.bak", "2_add_index.up.sql.orig", ".2_add_index.up.sql.swp"}
+	for _, name := range append(append([]string{}, kept...), stray...) {
+		if err := os.WriteFile(filepath.Join(migrations, name), []byte("SELECT 1;\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	tag := fmt.Sprintf("service-postgres-bootstrap-stray-test:%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		_ = exec.Command("docker", "image", "rm", tag).Run()
+	})
+	if output, err := exec.Command("docker", "build", "--tag", tag, root).CombinedOutput(); err != nil {
+		t.Fatalf("bootstrap image build failed: %v\n%s", err, output)
+	}
+	output, err := exec.Command("docker", "run", "--rm", tag, "ls", "-A", "/app/migrations").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list packaged migrations: %v\n%s", err, output)
+	}
+	packaged := strings.Fields(string(output))
+	for _, name := range kept {
+		if !slices.Contains(packaged, name) {
+			t.Errorf("bootstrap image dropped migration %q: %v", name, packaged)
+		}
+	}
+	for _, name := range stray {
+		if slices.Contains(packaged, name) {
+			t.Errorf("bootstrap image packaged stray file %q, which blocks the whole lineage", name)
+		}
 	}
 }
 

--- a/builder.go
+++ b/builder.go
@@ -106,6 +106,7 @@ func (s *Builder) Upgrade(ctx context.Context, req *builderv0.UpgradeRequest) (*
 type DockerTemplating struct {
 	MigrationConnectionKeyHolder string
 	WithMigration                bool
+	MigrationFileNamePattern     string // rendered so the image prunes exactly what the runtime filter hides
 	ReadOnlyRole                 string
 	ReadWriteRole                string
 	Schemas                      []string
@@ -146,6 +147,7 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 	docker := DockerTemplating{
 		MigrationConnectionKeyHolder: fmt.Sprintf("{%s}", migrationConnectionEnvironmentKey),
 		WithMigration:                s.WithMigration(),
+		MigrationFileNamePattern:     migrationFileNamePattern,
 		ReadOnlyRole:                 readOnlyRole,
 		ReadWriteRole:                readWriteRole,
 		Schemas:                      schemas,

--- a/main_test.go
+++ b/main_test.go
@@ -390,6 +390,21 @@ func assertStrayMigrationFilesDoNotBlockLineage(
 	}
 
 	require.NoError(t, runtime.applyMigration(ctx), "startup migrations must ignore editor leftovers")
+
+	// A save that writes a backup emits a change event for that file too. Acting
+	// on it would replay the version it shadows — down then up — and destroy the
+	// rows in the table that migration owns.
+	survivorID := "00000000-0000-0000-0000-000000000010"
+	require.NoError(t, owner.AppendFixture(ctx, relation, survivorID))
+	require.NoError(
+		t,
+		runtime.updateMigration(ctx, path.Join(migrationDirectory, "2_replay.up.sql.bak")),
+		"a change event for a non-migration file must be ignored",
+	)
+	survived, err := owner.HasFixture(ctx, relation, survivorID)
+	require.NoError(t, err)
+	require.True(t, survived, "an editor backup must not trigger a destructive migration replay")
+
 	require.NoError(t, runtime.updateMigration(ctx, migrationUp), "hot reload must ignore editor leftovers")
 	exists, err := owner.RelationExists(ctx, relation)
 	require.NoError(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -227,6 +227,7 @@ func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext) {
 	found, err = reader.HasFixture(ctx, migrationRelation, replayFixtureID)
 	require.NoError(t, err, "reader grants must be reconciled after migration replay")
 	require.False(t, found)
+	assertStrayMigrationFilesDoNotBlockLineage(t, ctx, runtime, owner, migrationDirectory, migrationUp, migrationRelation)
 	tenantRelation := serviceName + "_tenant_scope"
 	require.NoError(t, owner.InstallTenantFixture(ctx, tenantRelation))
 
@@ -354,6 +355,55 @@ func assertMigrationConnectionsAreOwned(t *testing.T, ctx context.Context, runti
 		}
 		time.Sleep(25 * time.Millisecond)
 	}
+}
+
+// assertStrayMigrationFilesDoNotBlockLineage exercises the editor-leftover case
+// against the real database. A backup keeping a migration's own prefix parses as
+// the same version and direction as the file it shadows, which used to make the
+// source driver refuse every migration path — startup and hot reload alike. A
+// genuine version collision must still fail, naming both files.
+func assertStrayMigrationFilesDoNotBlockLineage(
+	t *testing.T,
+	ctx context.Context,
+	runtime *Runtime,
+	owner *postgresCapabilityProbe,
+	migrationDirectory string,
+	migrationUp string,
+	relation string,
+) {
+	t.Helper()
+
+	const strayRelation = "stray_must_not_apply"
+	for _, stray := range []string{
+		"2_replay.up.sql~",
+		"2_replay.up.sql.bak",
+		"2_replay.up.sql.orig",
+		".2_replay.up.sql.swp",
+	} {
+		strayPath := path.Join(migrationDirectory, stray)
+		require.NoError(t, os.WriteFile(
+			strayPath,
+			[]byte("CREATE TABLE "+pq.QuoteIdentifier(strayRelation)+" (id UUID PRIMARY KEY);"),
+			0o600,
+		))
+		defer os.Remove(strayPath)
+	}
+
+	require.NoError(t, runtime.applyMigration(ctx), "startup migrations must ignore editor leftovers")
+	require.NoError(t, runtime.updateMigration(ctx, migrationUp), "hot reload must ignore editor leftovers")
+	exists, err := owner.RelationExists(ctx, relation)
+	require.NoError(t, err)
+	require.True(t, exists, "the migration the leftovers shadow must stay applied")
+	exists, err = owner.RelationExists(ctx, strayRelation)
+	require.NoError(t, err)
+	require.False(t, exists, "no SQL from an ignored file may reach the database")
+
+	conflictPath := path.Join(migrationDirectory, "2_conflict.up.sql")
+	require.NoError(t, os.WriteFile(conflictPath, []byte("SELECT 1;"), 0o600))
+	defer os.Remove(conflictPath)
+	err = runtime.applyMigration(ctx)
+	require.ErrorContains(t, err, "2_conflict.up.sql")
+	require.ErrorContains(t, err, "2_replay.up.sql")
 }
 
 func assertDockerStateSurvivesContainerRecreation(

--- a/migrations.go
+++ b/migrations.go
@@ -5,8 +5,10 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"net/url"
+	"io/fs"
+	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -15,6 +17,8 @@ import (
 	"github.com/codefly-dev/core/wool"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/postgres"
+	"github.com/golang-migrate/migrate/v4/source"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
 )
 
 // migrationSource is one independent migration lineage applied against the
@@ -43,10 +47,74 @@ func (m migrationSource) label() string {
 	return m.name
 }
 
-// fileURL returns the file:// migration source URL golang-migrate expects.
-func (m migrationSource) fileURL() string {
-	u := url.URL{Scheme: "file", Path: m.dir}
-	return u.String()
+// migrationFileName matches the conventional golang-migrate filename:
+// <version>_<name>.up.sql or <version>_<name>.down.sql.
+var migrationFileName = regexp.MustCompile(`^([0-9]+)_.+\.(up|down)\.sql$`)
+
+// migrationFS hides every directory entry that is not a conventional migration
+// filename. golang-migrate parses the extension as a free-form group, so an
+// editor backup left beside a migration — 2_add_index.up.sql~, .bak, .orig —
+// parses as the SAME version and direction as the file it shadows and makes the
+// source driver reject the entire lineage as a duplicate.
+type migrationFS struct {
+	fs.FS
+}
+
+func (f migrationFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	entries, err := fs.ReadDir(f.FS, name)
+	if err != nil {
+		return nil, err
+	}
+	var migrations []fs.DirEntry
+	for _, entry := range entries {
+		if !entry.IsDir() && migrationFileName.MatchString(entry.Name()) {
+			migrations = append(migrations, entry)
+		}
+	}
+	return migrations, nil
+}
+
+// openSource builds the golang-migrate source driver for one lineage over the
+// filtered view of its directory.
+func (m migrationSource) openSource() (source.Driver, error) {
+	if err := m.checkConflicts(); err != nil {
+		return nil, err
+	}
+	return iofs.New(migrationFS{os.DirFS(m.dir)}, ".")
+}
+
+// checkConflicts rejects two migration files claiming the same version and
+// direction — a real authoring mistake, unlike the editor leftovers filtered
+// above. golang-migrate names only the file it read second, which does not say
+// what it collides with.
+func (m migrationSource) checkConflicts() error {
+	entries, err := os.ReadDir(m.dir)
+	if err != nil {
+		return err
+	}
+	claimed := make(map[string]string)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		match := migrationFileName.FindStringSubmatch(entry.Name())
+		if match == nil {
+			continue
+		}
+		version, err := strconv.ParseUint(match[1], 10, 64)
+		if err != nil {
+			// golang-migrate skips a version it cannot parse; stay aligned with
+			// what the source driver will actually see.
+			continue
+		}
+		key := fmt.Sprintf("%d.%s", version, match[2])
+		if first, taken := claimed[key]; taken {
+			return fmt.Errorf("migration version %d has two %s files: %q and %q",
+				version, match[2], first, entry.Name())
+		}
+		claimed[key] = entry.Name()
+	}
+	return nil
 }
 
 // migrationSources resolves every migration lineage to apply to the shared
@@ -224,7 +292,15 @@ func (s *Runtime) openMigration(ctx context.Context, src migrationSource) (*migr
 			wrapMigrationCloseError("SQL pool after driver failure", pool.Close()),
 		)
 	}
-	migration, err := migrate.NewWithDatabaseInstance(src.fileURL(), s.Settings.DatabaseName, driver)
+	sourceDriver, err := src.openSource()
+	if err != nil {
+		return nil, errors.Join(
+			s.Wool.Wrapf(err, "cannot read migrations for source %q", src.label()),
+			wrapMigrationCloseError("database driver after source failure", driver.Close()),
+			wrapMigrationCloseError("SQL pool after source failure", pool.Close()),
+		)
+	}
+	migration, err := migrate.NewWithInstance(src.label(), sourceDriver, s.Settings.DatabaseName, driver)
 	if err != nil {
 		return nil, errors.Join(
 			s.Wool.Wrapf(err, "cannot create migration"),

--- a/migrations.go
+++ b/migrations.go
@@ -47,21 +47,39 @@ func (m migrationSource) label() string {
 	return m.name
 }
 
-// migrationFileName matches the conventional golang-migrate filename:
-// <version>_<name>.up.sql or <version>_<name>.down.sql.
-var migrationFileName = regexp.MustCompile(`^([0-9]+)_.+\.(up|down)\.sql$`)
+// migrationFileNamePattern is the ONE definition of a conventional
+// golang-migrate filename: <version>_<name>.<up|down>.<ext>. It is POSIX ERE so
+// the bootstrap image's shell prune matches it with grep -E over the same names
+// this runtime applies; builder.go renders it into the Dockerfile.
+//
+// The extension is a single alphanumeric run, exactly what golang-migrate's own
+// `migrate create -ext` produces. Its parser accepts ANY extension (a free-form
+// group), which is why an editor backup left beside a migration —
+// 2_add_index.up.sql~, .bak, .orig — parses as the SAME version and direction as
+// the file it shadows and makes the source driver reject the entire lineage as a
+// duplicate. Requiring a plain extension excludes the leftovers while keeping
+// every real migration, whatever it is named (.sql, .pgsql, .psql).
+const migrationFileNamePattern = `^([0-9]+)_.+\.(up|down)\.[A-Za-z0-9]+$`
 
-// migrationFS hides every directory entry that is not a conventional migration
-// filename. golang-migrate parses the extension as a free-form group, so an
-// editor backup left beside a migration — 2_add_index.up.sql~, .bak, .orig —
-// parses as the SAME version and direction as the file it shadows and makes the
-// source driver reject the entire lineage as a duplicate.
+var migrationFileName = regexp.MustCompile(migrationFileNamePattern)
+
+// migrationFS serves golang-migrate ONE snapshot of the migration files, taken
+// by openSource. Handing over a precomputed listing rather than re-reading the
+// directory keeps the conflict check and the exposed set from disagreeing when a
+// file lands between the two scans — hot reload runs while an editor is writing.
 type migrationFS struct {
 	fs.FS
+	entries []fs.DirEntry
 }
 
-func (f migrationFS) ReadDir(name string) ([]fs.DirEntry, error) {
-	entries, err := fs.ReadDir(f.FS, name)
+func (f migrationFS) ReadDir(string) ([]fs.DirEntry, error) {
+	return f.entries, nil
+}
+
+// openSource builds the golang-migrate source driver for one lineage over the
+// migration files in its directory, hiding everything that is not one.
+func (m migrationSource) openSource() (source.Driver, error) {
+	entries, err := os.ReadDir(m.dir)
 	if err != nil {
 		return nil, err
 	}
@@ -71,36 +89,20 @@ func (f migrationFS) ReadDir(name string) ([]fs.DirEntry, error) {
 			migrations = append(migrations, entry)
 		}
 	}
-	return migrations, nil
-}
-
-// openSource builds the golang-migrate source driver for one lineage over the
-// filtered view of its directory.
-func (m migrationSource) openSource() (source.Driver, error) {
-	if err := m.checkConflicts(); err != nil {
+	if err := checkConflicts(migrations); err != nil {
 		return nil, err
 	}
-	return iofs.New(migrationFS{os.DirFS(m.dir)}, ".")
+	return iofs.New(migrationFS{FS: os.DirFS(m.dir), entries: migrations}, ".")
 }
 
 // checkConflicts rejects two migration files claiming the same version and
-// direction — a real authoring mistake, unlike the editor leftovers filtered
-// above. golang-migrate names only the file it read second, which does not say
-// what it collides with.
-func (m migrationSource) checkConflicts() error {
-	entries, err := os.ReadDir(m.dir)
-	if err != nil {
-		return err
-	}
+// direction — a real authoring mistake, unlike the editor leftovers already
+// filtered out. golang-migrate names only the file it read second, which does
+// not say what it collides with.
+func checkConflicts(migrations []fs.DirEntry) error {
 	claimed := make(map[string]string)
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
+	for _, entry := range migrations {
 		match := migrationFileName.FindStringSubmatch(entry.Name())
-		if match == nil {
-			continue
-		}
 		version, err := strconv.ParseUint(match[1], 10, 64)
 		if err != nil {
 			// golang-migrate skips a version it cannot parse; stay aligned with
@@ -368,8 +370,17 @@ func (s *Runtime) updateMigration(ctx context.Context, migrationFile string) (ru
 		return nil
 	}
 
-	// Extract the migration number from the filename (NNN_name.up.sql).
+	// A write to anything that is not a migration file must not touch the
+	// schema: the replay below rolls the version down and back up, so acting on
+	// an editor backup (2_x.up.sql~, .bak) would drop and rebuild the table that
+	// file shadows, destroying its rows.
 	base := filepath.Base(migrationFile)
+	if !migrationFileName.MatchString(base) {
+		s.Wool.Debug("changed file is not a migration", wool.Field("file", base))
+		return nil
+	}
+
+	// Extract the migration number from the filename (NNN_name.up.sql).
 	s.Wool.Info(fmt.Sprintf("applying migration: %v (source %s)", base, owner.label()))
 	migrationNumber, err := strconv.Atoi(strings.Split(base, "_")[0])
 	if err != nil {

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -92,5 +94,85 @@ func mustMkdir(t *testing.T, p string) {
 	t.Helper()
 	if err := os.MkdirAll(p, 0o755); err != nil {
 		t.Fatalf("mkdir %s: %v", p, err)
+	}
+}
+
+// TestMigrationSourceIgnoresEditorLeftovers locks the acceptance case from the
+// bug: a backup file keeping the migration's own prefix parses as the same
+// version and direction and used to make golang-migrate reject the whole
+// lineage as a duplicate.
+func TestMigrationSourceIgnoresEditorLeftovers(t *testing.T) {
+	dir := t.TempDir()
+	for name, body := range map[string]string{
+		"1_init.up.sql":         "CREATE TABLE one ();",
+		"1_init.down.sql":       "DROP TABLE one;",
+		"2_pending.up.sql":      "CREATE TABLE two ();",
+		"2_pending.down.sql":    "DROP TABLE two;",
+		"2_pending.up.sql~":     "CREATE TABLE stale ();",
+		"2_pending.up.sql.bak":  "CREATE TABLE stale ();",
+		"2_pending.up.sql.orig": "CREATE TABLE stale ();",
+		".2_pending.up.sql.swp": "binary",
+		"#2_pending.up.sql#":    "CREATE TABLE stale ();",
+		"README.md":             "not a migration",
+	} {
+		mustWrite(t, filepath.Join(dir, name), body)
+	}
+	mustMkdir(t, filepath.Join(dir, "archive"))
+
+	driver, err := migrationSource{dir: dir}.openSource()
+	if err != nil {
+		t.Fatalf("openSource: %v", err)
+	}
+	defer driver.Close()
+
+	first, err := driver.First()
+	if err != nil || first != 1 {
+		t.Fatalf("First() = %d, %v; want 1", first, err)
+	}
+	next, err := driver.Next(1)
+	if err != nil || next != 2 {
+		t.Fatalf("Next(1) = %d, %v; want 2", next, err)
+	}
+	if _, err := driver.Next(2); err == nil {
+		t.Fatal("Next(2) must report the end of the lineage")
+	}
+
+	body, _, err := driver.ReadUp(2)
+	if err != nil {
+		t.Fatalf("ReadUp(2): %v", err)
+	}
+	defer body.Close()
+	content, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read migration body: %v", err)
+	}
+	if string(content) != "CREATE TABLE two ();" {
+		t.Fatalf("ReadUp(2) served %q, want the real migration", content)
+	}
+}
+
+// TestMigrationSourceRejectsConflictingVersions keeps a genuine authoring
+// mistake failing, and naming both files.
+func TestMigrationSourceRejectsConflictingVersions(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "1_init.up.sql"), "CREATE TABLE one ();")
+	mustWrite(t, filepath.Join(dir, "2_add_index.up.sql"), "CREATE INDEX a ON one (id);")
+	mustWrite(t, filepath.Join(dir, "02_add_column.up.sql"), "ALTER TABLE one ADD COLUMN id INT;")
+
+	_, err := migrationSource{dir: dir}.openSource()
+	if err == nil {
+		t.Fatal("two up files for version 2 must fail")
+	}
+	for _, name := range []string{"02_add_column.up.sql", "2_add_index.up.sql"} {
+		if !strings.Contains(err.Error(), name) {
+			t.Errorf("error %q does not name the conflicting file %q", err, name)
+		}
+	}
+}
+
+func mustWrite(t *testing.T, p string, body string) {
+	t.Helper()
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", p, err)
 	}
 }

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -100,7 +100,9 @@ func mustMkdir(t *testing.T, p string) {
 // TestMigrationSourceIgnoresEditorLeftovers locks the acceptance case from the
 // bug: a backup file keeping the migration's own prefix parses as the same
 // version and direction and used to make golang-migrate reject the whole
-// lineage as a duplicate.
+// lineage as a duplicate. Version 3 uses a non-.sql extension, which
+// golang-migrate accepts and the filter must therefore keep: hiding it would
+// leave Up() reporting ErrNoChange over an unapplied migration.
 func TestMigrationSourceIgnoresEditorLeftovers(t *testing.T) {
 	dir := t.TempDir()
 	for name, body := range map[string]string{
@@ -108,6 +110,8 @@ func TestMigrationSourceIgnoresEditorLeftovers(t *testing.T) {
 		"1_init.down.sql":       "DROP TABLE one;",
 		"2_pending.up.sql":      "CREATE TABLE two ();",
 		"2_pending.down.sql":    "DROP TABLE two;",
+		"3_flavored.up.pgsql":   "CREATE TABLE three ();",
+		"3_flavored.down.pgsql": "DROP TABLE three;",
 		"2_pending.up.sql~":     "CREATE TABLE stale ();",
 		"2_pending.up.sql.bak":  "CREATE TABLE stale ();",
 		"2_pending.up.sql.orig": "CREATE TABLE stale ();",
@@ -133,8 +137,12 @@ func TestMigrationSourceIgnoresEditorLeftovers(t *testing.T) {
 	if err != nil || next != 2 {
 		t.Fatalf("Next(1) = %d, %v; want 2", next, err)
 	}
-	if _, err := driver.Next(2); err == nil {
-		t.Fatal("Next(2) must report the end of the lineage")
+	next, err = driver.Next(2)
+	if err != nil || next != 3 {
+		t.Fatalf("Next(2) = %d, %v; want 3 — a migration is not defined by its extension", next, err)
+	}
+	if _, err := driver.Next(3); err == nil {
+		t.Fatal("Next(3) must report the end of the lineage")
 	}
 
 	body, _, err := driver.ReadUp(2)
@@ -167,6 +175,26 @@ func TestMigrationSourceRejectsConflictingVersions(t *testing.T) {
 		if !strings.Contains(err.Error(), name) {
 			t.Errorf("error %q does not name the conflicting file %q", err, name)
 		}
+	}
+}
+
+// TestMigrationSourceServesOneDirectorySnapshot pins the property that keeps the
+// conflict check and the applied set in agreement: the files are read once, so a
+// save landing mid-apply cannot change what an open driver runs.
+func TestMigrationSourceServesOneDirectorySnapshot(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "1_init.up.sql"), "CREATE TABLE one ();")
+
+	driver, err := migrationSource{dir: dir}.openSource()
+	if err != nil {
+		t.Fatalf("openSource: %v", err)
+	}
+	defer driver.Close()
+
+	mustWrite(t, filepath.Join(dir, "2_added_later.up.sql"), "CREATE TABLE two ();")
+
+	if _, err := driver.Next(1); err == nil {
+		t.Fatal("a file written after the source was opened must not join the lineage mid-apply")
 	}
 }
 

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -21,9 +21,10 @@ COPY . .
 COPY migrations /app/migrations
 # An editor backup kept beside a migration (2_x.up.sql~, .bak, .orig) parses as
 # the same version and direction as the file it shadows, so migrate rejects the
-# whole directory as a duplicate. Keep only conventional migration filenames.
+# whole directory as a duplicate. Drop exactly what the runtime filter hides:
+# the pattern is rendered from the single Go definition.
 RUN find /app/migrations -maxdepth 1 -type f | while read -r file; do \
-      echo "${file##*/}" | grep -qE '^[0-9]+_.+\.(up|down)\.sql$' || rm -f "${file}"; \
+      echo "${file##*/}" | grep -qE '{{ .MigrationFileNamePattern }}' || rm -f "${file}"; \
     done
 {{- end }}
 COPY runtime-access.sql /app/runtime-access.sql

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -19,6 +19,12 @@ COPY . .
 
 {{- if .WithMigration }}
 COPY migrations /app/migrations
+# An editor backup kept beside a migration (2_x.up.sql~, .bak, .orig) parses as
+# the same version and direction as the file it shadows, so migrate rejects the
+# whole directory as a duplicate. Keep only conventional migration filenames.
+RUN find /app/migrations -maxdepth 1 -type f | while read -r file; do \
+      echo "${file##*/}" | grep -qE '^[0-9]+_.+\.(up|down)\.sql$' || rm -f "${file}"; \
+    done
 {{- end }}
 COPY runtime-access.sql /app/runtime-access.sql
 


### PR DESCRIPTION
Closes #83.

## Summary

- golang-migrate parses a migration filename's extension as a free-form group, so `2_x.up.sql~`, `2_x.up.sql.bak` and `2_x.up.sql.orig` parse as the *same* version and direction as the file they shadow. The source driver then refuses the entire directory, and since `Init`, `Start` and hot reload all open it, one editor backup kept the service from ever reporting ready — with an error that never said which file to delete.
- The source driver is now built with `source/iofs` over an `fs.FS` that exposes only files matching `^[0-9]+_.+\.(up|down)\.[A-Za-z0-9]+$` — the shape `migrate create -ext` produces. It excludes every editor leftover while keeping any real migration whatever its extension (`.sql`, `.pgsql`, `.psql`); a narrower `.sql`-only rule would hide a real migration and make `Up()` return `ErrNoChange` over an unapplied schema. The directory is read once and that snapshot is handed to the driver, so the conflict check and the applied set cannot disagree when a save lands mid-scan.
- A *genuine* collision (two files claiming one version and direction) is still refused, now naming both files — the library's own error names only the one it read second.
- Hot reload ignores a change event for a file that is not a migration. `updateMigration` replays a version down and back up, so acting on `2_x.up.sql.bak` would drop and rebuild the table that migration owns, destroying its rows.
- The deployed bootstrap runs the `migrate` CLI over the directory `COPY`d into the image, so the Dockerfile prunes non-migration files after the copy. The pattern is one Go constant rendered into the template, so the image's prune cannot drift from the runtime's filter.

## Test plan

- [x] `TestMigrationSourceIgnoresEditorLeftovers` — a directory of `~`, `.bak`, `.orig`, `.swp` and `#...#` leftovers plus `README.md` and a subdirectory exposes exactly the declared migrations, including a `.pgsql` one that must stay in the lineage.
- [x] `TestMigrationSourceRejectsConflictingVersions` — `2_add_index.up.sql` and `02_add_column.up.sql` fail, and the error names both.
- [x] `TestMigrationSourceServesOneDirectorySnapshot` — a file written after the source is opened does not join the lineage mid-apply.
- [x] `TestCreateToRunDocker` (real disposable Postgres) — `assertStrayMigrationFilesDoNotBlockLineage` asserts startup (`applyMigration`) and hot reload (`updateMigration`) both succeed with leftovers present, that a change event for a backup file leaves existing rows intact, that no SQL from an ignored file reached the database, and that a real duplicate still fails naming both files.
- [x] `TestBootstrapImageAppliesOnlyRealMigrations` — builds the bootstrap image and runs its real command against a disposable Postgres (the pinned image this repo already uses): both the `.sql` and `.pgsql` migrations applied, `stray_must_not_apply` absent, ledger at `3/false`, and the rendered Dockerfile asserted to carry the runtime's own pattern.
- [x] Mutation-checked: restoring the `.sql`-only pattern fails the leftovers test; removing the hot-reload guard fails the real-database replay assertion.
- [x] `go test ./... -skip '^TestCreateToRunDocker$'` (CI's command), `TestCreateToRunDocker`, and `go vet ./...` all pass.

## Risk

The Dockerfile prune deletes files inside the built image only; the repository and the build context on disk are untouched. It removes top-level regular files whose names are not migrations — the same rule, from the same constant, that the runtime applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)