### PR TITLE
feat: bound SQL readiness, migrations and bootstrap Jobs by explicit budgets (#80)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130
 
       - name: Run unit tests
-        run: go test ./... -skip '^(TestCreateToRunDocker|TestDirtyMigrationFailsClosed|TestLifecycleContractDocker)$' -timeout 20m
+        run: go test ./... -skip '^(TestCreateToRunDocker|TestDirtyMigrationFailsClosed|TestLifecycleContractDocker|TestMigrationLockBudgetExpiresWhilePeerHoldsTheLock|TestMigrationStatementBudgetExpiresAndPreservesTheLedger)$' -timeout 20m
 
       - name: Build runtime image
         run: docker build --build-arg SOURCE_DATE_EPOCH=0 --tag service-postgres:test .
@@ -69,6 +69,16 @@ jobs:
         env:
           SERVICE_POSTGRES_TEST_IMAGE: service-postgres:test
         run: go test . -run '^TestDirtyMigrationFailsClosed$' -timeout 20m
+
+      # Real-database regression for the migration budgets
+      # (codefly-dev/service-postgres#80). Both budgets are enforced by session
+      # GUCs, so only a real backend holding a real lock and running a real long
+      # statement can show that they bite. Same image and same mandatory
+      # prerequisite as the step above.
+      - name: Migration budget regression
+        env:
+          SERVICE_POSTGRES_TEST_IMAGE: service-postgres:test
+        run: go test . -run '^(TestMigrationLockBudgetExpiresWhilePeerHoldsTheLock|TestMigrationStatementBudgetExpiresAndPreservesTheLedger)$' -timeout 20m
 
       - name: Smoke test runtime image
         shell: bash

--- a/bootstrap_readiness_test.go
+++ b/bootstrap_readiness_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The bootstrap image's readiness wait is shell, and its contract — give up
+// nonzero inside a budget, and tell a database that is merely unavailable apart
+// from one that is misconfigured — only holds when a shell actually runs it.
+// This executes the rendered CMD as a real subprocess against stub clients, so
+// a regression in the rendered text fails here rather than in a cluster.
+func TestBootstrapReadinessWaitEndsWithinItsBudget(t *testing.T) {
+	const budget = 4 * time.Second
+	// The loop checks the deadline before sleeping, so it can overshoot by one
+	// poll interval plus process spawn. It can also stop up to a second early:
+	// `date +%s` has second granularity, so the deadline it computes is
+	// anywhere inside the second the loop started in.
+	const overshoot = 6 * time.Second
+	const granularity = time.Second
+	// A real DSN shape, so a run that echoes what it connected to fails the
+	// credential assertion below.
+	const connection = "postgresql://owner:s3cr3tpassword@10.255.255.1:5432/app?sslmode=disable"
+
+	tests := []struct {
+		name             string
+		readinessStatus  int
+		withMigration    bool
+		wantExit         int
+		wantMessage      string
+		wantMinElapsed   time.Duration
+		wantMaxElapsed   time.Duration
+		wantBootstrapRan bool
+	}{
+		{
+			name:            "unavailable database exhausts the budget",
+			readinessStatus: 2,
+			withMigration:   true,
+			wantExit:        1,
+			wantMessage:     "did not accept connections within 4s (last pg_isready status 2)",
+			wantMinElapsed:  budget - granularity,
+			wantMaxElapsed:  budget + overshoot,
+		},
+		{
+			// An unusable configuration is not worth waiting out: it must fail
+			// well before the budget rather than after it.
+			name:            "invalid connection parameters fail immediately",
+			readinessStatus: 3,
+			withMigration:   true,
+			wantExit:        78,
+			wantMessage:     "database connection parameters are invalid",
+			wantMaxElapsed:  budget,
+		},
+		{
+			name:             "available database proceeds to bootstrap",
+			readinessStatus:  0,
+			wantExit:         0,
+			wantMaxElapsed:   budget,
+			wantBootstrapRan: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			stubs := t.TempDir()
+			writeClientStub(t, stubs, "pg_isready", test.readinessStatus)
+			writeClientStub(t, stubs, "psql", 0)
+
+			command := exec.Command("sh", "-c", bootstrapCommand(t, int(budget/time.Second), test.withMigration))
+			command.Env = append(os.Environ(),
+				"PATH="+stubs+string(os.PathListSeparator)+os.Getenv("PATH"),
+				migrationConnectionEnvironmentKey+"="+connection,
+			)
+			started := time.Now()
+			output, err := command.CombinedOutput()
+			elapsed := time.Since(started)
+
+			if got := exitCode(t, err); got != test.wantExit {
+				t.Fatalf("exit code = %d, want %d\n%s", got, test.wantExit, output)
+			}
+			if test.wantMessage != "" && !strings.Contains(string(output), test.wantMessage) {
+				t.Fatalf("output does not report the failing phase %q:\n%s", test.wantMessage, output)
+			}
+			// A terminal error must stay useful without becoming a credential
+			// leak: the DSN password never reaches the Job's logs.
+			if strings.Contains(string(output), "s3cr3tpassword") {
+				t.Fatalf("bootstrap output leaked the connection password:\n%s", output)
+			}
+			if elapsed < test.wantMinElapsed {
+				t.Fatalf("gave up after %s, before the %s budget was spent", elapsed, test.wantMinElapsed)
+			}
+			if elapsed > test.wantMaxElapsed {
+				t.Fatalf("took %s, beyond the %s bound", elapsed, test.wantMaxElapsed)
+			}
+			// The readiness loop is a gate: bootstrap work must not run against
+			// a database that never answered.
+			if ran := clientStubRan(t, stubs, "psql"); ran != test.wantBootstrapRan {
+				t.Fatalf("bootstrap ran = %t, want %t\n%s", ran, test.wantBootstrapRan, output)
+			}
+		})
+	}
+}
+
+// bootstrapCommand renders the Dockerfile and returns its CMD as the single
+// shell string Docker would hand to /bin/sh -c.
+func bootstrapCommand(t *testing.T, readinessSeconds int, withMigration bool) string {
+	t.Helper()
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
+		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+		WithMigration:                withMigration,
+		ReadinessTimeoutSeconds:      readinessSeconds,
+	})
+	_, command, found := strings.Cut(dockerfile, "\nCMD ")
+	if !found {
+		t.Fatalf("rendered Dockerfile has no CMD:\n%s", dockerfile)
+	}
+	return strings.ReplaceAll(command, "\\\n", "")
+}
+
+// writeClientStub installs a postgres client the bootstrap CMD invokes,
+// recording that it ran and exiting with the given status.
+func writeClientStub(t *testing.T, directory, name string, status int) {
+	t.Helper()
+	script := fmt.Sprintf("#!/bin/sh\ntouch %s\nexit %d\n", filepath.Join(directory, name+".ran"), status)
+	if err := os.WriteFile(filepath.Join(directory, name), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func clientStubRan(t *testing.T, directory, name string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(directory, name+".ran"))
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return err == nil
+}
+
+func exitCode(t *testing.T, err error) int {
+	t.Helper()
+	if err == nil {
+		return 0
+	}
+	var exit *exec.ExitError
+	if !errors.As(err, &exit) {
+		t.Fatal(err)
+	}
+	return exit.ExitCode()
+}

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -27,6 +27,7 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 			parameters := DockerTemplating{
 				MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 				WithMigration:                test.withMigrations,
+				ReadinessTimeoutSeconds:      300,
 				ReadOnlyRole:                 "codefly_app_ro",
 				ReadWriteRole:                "codefly_app_rw",
 				Schemas:                      []string{"public", "audit"},
@@ -38,11 +39,18 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 			if !strings.Contains(dockerfile, "psql \"${"+migrationConnectionEnvironmentKey+"}\"") {
 				t.Fatal("bootstrap image does not always reconcile runtime roles")
 			}
-			if !strings.Contains(
-				dockerfile,
-				"until pg_isready -d \"${"+migrationConnectionEnvironmentKey+"}\" >/dev/null 2>&1; do sleep 2; done",
-			) {
+			if !strings.Contains(dockerfile, "pg_isready -q -d \"${"+migrationConnectionEnvironmentKey+"}\"") {
 				t.Fatal("bootstrap image does not wait for Postgres readiness")
+			}
+			for _, required := range []string{
+				"readiness_deadline=$(($(date +%s) + 300))",
+				"did not accept connections within 300s",
+				"exit 1",
+				"exit 78",
+			} {
+				if !strings.Contains(dockerfile, required) {
+					t.Fatalf("bootstrap readiness wait is not bounded: missing %q", required)
+				}
 			}
 			for _, required := range []string{
 				"ARG TARGETARCH",
@@ -95,6 +103,7 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	root := t.TempDir()
 	parameters := DockerTemplating{
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+		ReadinessTimeoutSeconds:      defaultBootstrapReadinessSeconds,
 	}
 	if err := os.WriteFile(
 		filepath.Join(root, "Dockerfile"),

--- a/builder.go
+++ b/builder.go
@@ -107,6 +107,7 @@ type DockerTemplating struct {
 	MigrationConnectionKeyHolder string
 	WithMigration                bool
 	MigrationFileNamePattern     string // rendered so the image prunes exactly what the runtime filter hides
+	ReadinessTimeoutSeconds      int
 	ReadOnlyRole                 string
 	ReadWriteRole                string
 	Schemas                      []string
@@ -151,10 +152,14 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 	if err != nil {
 		return s.Builder.BuildError(err)
 	}
+	if err = s.Settings.Timeouts.validate(); err != nil {
+		return s.Builder.BuildError(err)
+	}
 	docker := DockerTemplating{
 		MigrationConnectionKeyHolder: fmt.Sprintf("{%s}", migrationConnectionEnvironmentKey),
 		WithMigration:                s.WithMigration(),
 		MigrationFileNamePattern:     migrationFileNamePattern,
+		ReadinessTimeoutSeconds:      s.Settings.Timeouts.BootstrapReadinessSeconds(),
 		ReadOnlyRole:                 readOnlyRole,
 		ReadWriteRole:                readWriteRole,
 		Schemas:                      schemas,
@@ -293,10 +298,14 @@ func copyTree(ctx context.Context, from, to string) error {
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
 	defer s.Wool.Catch()
 
+	if err := s.Settings.Timeouts.validate(); err != nil {
+		return s.Builder.DeployError(err)
+	}
 	parameters := &DeploymentTemplateParameters{
-		WithBootstrap: true,
-		ManagedImage:  s.dockerImage().FullName(),
-		DatabaseName:  s.DatabaseName,
+		WithBootstrap:               true,
+		ManagedImage:                s.dockerImage().FullName(),
+		DatabaseName:                s.DatabaseName,
+		BootstrapJobDeadlineSeconds: s.Settings.Timeouts.BootstrapJobSeconds(),
 	}
 	var restrictedConfiguration *v0.Configuration
 	response, err := s.Builder.DeployKustomize(ctx, req, services.KustomizeDeployment{
@@ -564,6 +573,7 @@ func (s *Builder) Communicate(stream builderv0.Builder_CommunicateServer) error 
 
 // all: so the scaffolded .gitignore (a dotfile go:embed skips by default) is
 // carried into the factory tree and rendered into new services.
+//
 //go:embed all:templates/factory
 var factoryFS embed.FS
 

--- a/deployment_test.go
+++ b/deployment_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -18,18 +19,21 @@ import (
 
 func TestDeploymentTemplatesWithMigration(t *testing.T) {
 	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentTemplateParameters{
-		WithBootstrap:    true,
-		ManagedImage:     image.FullName(),
-		BootstrapJobName: "postgres-aaaaaaaaaaaa",
+		WithBootstrap:               true,
+		ManagedImage:                image.FullName(),
+		BootstrapJobName:            "postgres-aaaaaaaaaaaa",
+		BootstrapJobDeadlineSeconds: 240,
 	})
 	assertMigrationResource(t, dir, true)
 	assertEphemeralSecret(t, dir)
+	assertBootstrapJobDeadline(t, dir, 240)
 }
 
 func TestDeploymentTemplatesWithoutBootstrap(t *testing.T) {
 	dir := agenttesting.AssertKustomizeTemplates(t, deploymentFS, DeploymentTemplateParameters{
-		ManagedImage:     image.FullName(),
-		BootstrapJobName: "postgres-aaaaaaaaaaaa",
+		ManagedImage:                image.FullName(),
+		BootstrapJobName:            "postgres-aaaaaaaaaaaa",
+		BootstrapJobDeadlineSeconds: 240,
 	})
 	assertMigrationResource(t, dir, false)
 }
@@ -160,6 +164,35 @@ func TestEphemeralDeploymentRetainsValueBasedConfigurationAndSecret(t *testing.T
 	job := readDeploymentFile(t, destination, "base", "job.yaml")
 	require.Contains(t, job, "registry.example.com/module/postgres")
 	require.Regexp(t, `^postgres-[0-9a-f]{12}$`, bootstrapJobResourceName(t, job))
+	// A service that configures no budget still deploys a Job bounded in
+	// elapsed time.
+	require.Contains(t, job, fmt.Sprintf("activeDeadlineSeconds: %d", defaultBootstrapJobSeconds))
+}
+
+// assertBootstrapJobDeadline pins the elapsed-time bound on the Job itself.
+// backoffLimit counts failed pods and cannot stop a container that is still
+// running, so it is not a substitute.
+func assertBootstrapJobDeadline(t *testing.T, dir string, expected int) {
+	t.Helper()
+	content := readDeploymentFile(t, dir, "base", "job.yaml")
+	var job struct {
+		Spec struct {
+			ActiveDeadlineSeconds *int `yaml:"activeDeadlineSeconds"`
+			BackoffLimit          *int `yaml:"backoffLimit"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal([]byte(content), &job); err != nil {
+		t.Fatal(err)
+	}
+	if job.Spec.ActiveDeadlineSeconds == nil {
+		t.Fatalf("bootstrap Job has no activeDeadlineSeconds:\n%s", content)
+	}
+	if *job.Spec.ActiveDeadlineSeconds != expected {
+		t.Fatalf("activeDeadlineSeconds = %d, want %d", *job.Spec.ActiveDeadlineSeconds, expected)
+	}
+	if job.Spec.BackoffLimit == nil {
+		t.Fatalf("bootstrap Job lost its backoffLimit:\n%s", content)
+	}
 }
 
 func assertMigrationResource(t *testing.T, dir string, expected bool) {

--- a/main.go
+++ b/main.go
@@ -108,6 +108,11 @@ type Settings struct {
 	// Paths are relative to this service's directory (or absolute). A source
 	// whose directory is missing is skipped with a warning.
 	MigrationSources []MigrationSource `yaml:"migration-sources"`
+
+	// Timeouts bounds every wait this agent performs or renders: readiness
+	// probing, connection establishment, migration locking and statements, and
+	// the deployed bootstrap Job. See Timeouts for the keys and defaults.
+	Timeouts Timeouts `yaml:"timeouts"`
 }
 
 // MigrationSource declares one additional service contributing migrations to
@@ -165,6 +170,7 @@ type DeploymentTemplateParameters struct {
 	ManagedImage                 string
 	BootstrapJobName             string
 	DatabaseName                 string
+	BootstrapJobDeadlineSeconds  int
 	StatefulSetSecretReferences  map[string]*builderv0.KubernetesSecretKeyReference
 	BootstrapJobSecretReferences map[string]*builderv0.KubernetesSecretKeyReference
 }

--- a/migrations.go
+++ b/migrations.go
@@ -224,26 +224,38 @@ func (s *Runtime) applyMigration(ctx context.Context) error {
 }
 
 // applySource brings ONE migration lineage up to date against the shared db,
-// using that source's dedicated tracking table. Retries the driver handshake a
-// few times (the pool may still be warming up); a dirty lineage fails closed.
+// using that source's dedicated tracking table. Retries the driver handshake
+// (the pool may still be warming up); a dirty lineage fails closed.
+//
+// The handshake takes golang-migrate's advisory lock, so a peer already
+// migrating this lineage is exactly the wait the lock budget bounds. The
+// retries share that one budget rather than each getting their own: three
+// attempts against a lock held by someone else would otherwise wait three
+// times as long as the configured lock budget.
 func (s *Runtime) applySource(ctx context.Context, src migrationSource) error {
-	maxRetry := 3
+	budget := s.Settings.Timeouts.migrationLock()
+	deadline, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
 	var lastErr error
-	for range maxRetry {
-		handle, err := s.openMigration(ctx, src)
-		if err != nil {
-			lastErr = err
-			select {
-			case <-ctx.Done():
-				return errors.Join(lastErr, ctx.Err())
-			case <-time.After(time.Second):
-			}
-			continue
+	for {
+		handle, err := s.openMigration(deadline, src)
+		if err == nil {
+			return errors.Join(s.runUp(handle.migration, src), handle.Close())
 		}
-		return errors.Join(s.runUp(handle.migration, src), handle.Close())
+		lastErr = err
+		select {
+		case <-deadline.Done():
+			return s.Wool.Wrapf(errors.Join(lastErr, deadline.Err()),
+				"cannot prepare migration for source %q within %s", src.label(), budget)
+		case <-time.After(migrationOpenRetryInterval):
+		}
 	}
-	return s.Wool.Wrapf(lastErr, "cannot prepare migration for source %q after %d attempts", src.label(), maxRetry)
 }
+
+// migrationOpenRetryInterval paces the driver-handshake retries; how many of
+// them happen is whatever the lock budget affords.
+const migrationOpenRetryInterval = time.Second
 
 // migrationHandle owns every resource golang-migrate opens for one migration
 // lineage. The postgres driver reserves a dedicated *sql.Conn; closing only the
@@ -294,9 +306,21 @@ func (s *Runtime) openMigration(ctx context.Context, src migrationSource) (*migr
 			wrapMigrationCloseError("SQL pool after connection failure", pool.Close()),
 		)
 	}
+	if err = s.boundMigrationSession(ctx, conn); err != nil {
+		return nil, errors.Join(
+			err,
+			wrapMigrationCloseError("database connection after budget failure", conn.Close()),
+			wrapMigrationCloseError("SQL pool after budget failure", pool.Close()),
+		)
+	}
 	driver, err := postgres.WithConnection(ctx, conn, &postgres.Config{
 		DatabaseName:    s.Settings.DatabaseName,
 		MigrationsTable: src.table, // "" → schema_migrations (default)
+		// The driver's own statement budget is a client-side deadline. Give it
+		// a grace period over the server-side one so the backend wins the race
+		// and reports "canceling statement due to statement timeout" instead of
+		// a bare context deadline.
+		StatementTimeout: s.Settings.Timeouts.migrationStatement() + migrationStatementGrace,
 	})
 	if err != nil {
 		return nil, errors.Join(
@@ -323,6 +347,35 @@ func (s *Runtime) openMigration(ctx context.Context, src migrationSource) (*migr
 	}
 	return &migrationHandle{migration: migration, pool: pool}, nil
 }
+
+// boundMigrationSession puts the lock and statement budgets on the connection
+// golang-migrate is about to take ownership of. They have to be server-side
+// GUCs: the driver acquires its advisory lock, reads and writes the version
+// row, and drops tables under context.Background(), so no caller context ever
+// reaches those statements. lock_timeout bounds the advisory-lock wait, and
+// statement_timeout bounds every statement including that wait.
+func (s *Runtime) boundMigrationSession(ctx context.Context, conn *sql.Conn) error {
+	budgets := []struct {
+		setting string
+		budget  time.Duration
+	}{
+		{setting: "lock_timeout", budget: s.Settings.Timeouts.migrationLock()},
+		{setting: "statement_timeout", budget: s.Settings.Timeouts.migrationStatement()},
+	}
+	for _, b := range budgets {
+		// Neither GUC can be parameterized; both values are whole seconds from
+		// validated settings, rendered as integer milliseconds.
+		statement := fmt.Sprintf("SET %s = %d", b.setting, b.budget.Milliseconds())
+		if _, err := conn.ExecContext(ctx, statement); err != nil {
+			return s.Wool.Wrapf(err, "cannot bound migration %s", b.setting)
+		}
+	}
+	return nil
+}
+
+// migrationStatementGrace separates the driver's client-side statement deadline
+// from the server-side statement_timeout carrying the same budget.
+const migrationStatementGrace = 15 * time.Second
 
 // runUp brings one lineage up to date. A dirty ledger fails closed: golang-migrate's
 // Drop deletes every base table in the schema — including the other services sharing

--- a/migrations_budget_test.go
+++ b/migrations_budget_test.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-migrate/migrate/v4/database"
+)
+
+// Both migration budgets are enforced by the server, because golang-migrate's
+// postgres driver takes its advisory lock and runs every statement under
+// context.Background(): no caller context reaches that SQL. Nothing but a real
+// backend holding a real lock and running a real long statement can show that
+// the budgets bite, so these tests run one.
+
+func TestMigrationLockBudgetExpiresWhilePeerHoldsTheLock(t *testing.T) {
+	const lockBudget = 3 * time.Second
+	runtime, connection := budgetRuntime(t, Timeouts{
+		MigrationLock:      int(lockBudget / time.Second),
+		MigrationStatement: 30,
+	})
+	source := migrationSourceFrom(t, map[string]string{
+		"1_create_table.up.sql": "CREATE TABLE IF NOT EXISTS thing (id integer primary key);",
+	})
+
+	// Bring the lineage into existence first, so the tracking table this test
+	// inspects afterwards is the one golang-migrate itself created.
+	if err := runtime.applySource(context.Background(), source); err != nil {
+		t.Fatal(err)
+	}
+
+	release := holdMigrationLock(t, connection, runtime.Settings.DatabaseName, source)
+
+	started := time.Now()
+	err := runtime.applySource(context.Background(), source)
+	elapsed := time.Since(started)
+	release()
+
+	if err == nil {
+		t.Fatal("migration acquired a lock another session was holding")
+	}
+	// The retries share one lock budget: three attempts must not wait three
+	// times as long as the budget allows.
+	if elapsed > 3*lockBudget {
+		t.Fatalf("lock wait took %s against a %s budget: %v", elapsed, lockBudget, err)
+	}
+	if !strings.Contains(err.Error(), "lock timeout") && !strings.Contains(err.Error(), "canceling statement") {
+		t.Fatalf("failure does not report the lock budget: %v", err)
+	}
+	assertMigrationConnectionsReleased(t, connection, runtime.Settings.DatabaseName)
+}
+
+func TestMigrationStatementBudgetExpiresAndPreservesTheLedger(t *testing.T) {
+	const statementBudget = 3 * time.Second
+	runtime, connection := budgetRuntime(t, Timeouts{
+		MigrationLock:      30,
+		MigrationStatement: int(statementBudget / time.Second),
+	})
+	source := migrationSourceFrom(t, map[string]string{
+		"1_slow.up.sql": "SELECT pg_sleep(120);",
+	})
+
+	started := time.Now()
+	err := runtime.applySource(context.Background(), source)
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("a migration statement ran past its budget without failing")
+	}
+	if elapsed > 4*statementBudget {
+		t.Fatalf("statement took %s against a %s budget: %v", elapsed, statementBudget, err)
+	}
+	if !strings.Contains(err.Error(), "statement timeout") {
+		t.Fatalf("failure does not report the statement budget: %v", err)
+	}
+
+	// The evidence of what went wrong must survive the failure: a budget
+	// expiry does not license dropping the schema or rewriting the version
+	// pointer. Recovering a dirty ledger is a separate, deliberate decision
+	// (codefly-dev/service-postgres#76).
+	version, dirty := migrationLedger(t, connection)
+	if version != 1 || !dirty {
+		t.Fatalf("ledger = version %d dirty %t, want the interrupted migration preserved as version 1 dirty", version, dirty)
+	}
+	assertMigrationConnectionsReleased(t, connection, runtime.Settings.DatabaseName)
+}
+
+// budgetRuntime wires the production agent to one isolated database on a
+// disposable postgres, carrying the budgets under test, and returns the owner
+// connection string alongside it.
+func budgetRuntime(t *testing.T, timeouts Timeouts) (*Runtime, string) {
+	t.Helper()
+	server := startDisposablePostgres(t)
+	isolated := disposableDatabase(t, server)
+	// The control plane keeps a pool open on the database it creates, and the
+	// assertions below count the backends a failed migration leaves behind.
+	// Release it here: nothing in these tests goes through it, and cleanup
+	// still drops the database.
+	if err := isolated.Close(); err != nil {
+		t.Fatal(err)
+	}
+	connection := server.dsn(isolated.Name)
+
+	runtime := NewRuntime()
+	runtime.Settings.DatabaseName = isolated.Name
+	runtime.Settings.Timeouts = timeouts
+	bounded, err := withConnectTimeout(connection, timeouts.connect())
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.connection = bounded
+	return runtime, connection
+}
+
+// migrationSourceFrom writes migration files to a fresh directory and returns
+// the lineage pointing at it.
+func migrationSourceFrom(t *testing.T, files map[string]string) migrationSource {
+	t.Helper()
+	directory := t.TempDir()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(directory, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return migrationSource{dir: directory}
+}
+
+// holdMigrationLock takes the same advisory lock golang-migrate takes for this
+// lineage, from a session the runtime does not control.
+func holdMigrationLock(t *testing.T, connection, databaseName string, src migrationSource) func() {
+	t.Helper()
+	table := src.table
+	if table == "" {
+		table = "schema_migrations"
+	}
+	lockID, err := database.GenerateAdvisoryLockId(databaseName, "public", table)
+	if err != nil {
+		t.Fatal(err)
+	}
+	peer, err := sql.Open("postgres", connection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	held, err := peer.Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = held.ExecContext(context.Background(), "SELECT pg_advisory_lock($1)", lockID); err != nil {
+		t.Fatal(err)
+	}
+	return func() {
+		_ = held.Close()
+		_ = peer.Close()
+	}
+}
+
+func migrationLedger(t *testing.T, connection string) (int, bool) {
+	t.Helper()
+	db, err := sql.Open("postgres", connection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	var version int
+	var dirty bool
+	if err = db.QueryRowContext(context.Background(),
+		"SELECT version, dirty FROM schema_migrations").Scan(&version, &dirty); err != nil {
+		t.Fatal(err)
+	}
+	return version, dirty
+}
+
+// assertMigrationConnectionsReleased proves the failed attempt left no backend
+// behind: a leaked migration connection keeps its advisory lock and blocks the
+// next run.
+func assertMigrationConnectionsReleased(t *testing.T, connection, databaseName string) {
+	t.Helper()
+	db, err := sql.Open("postgres", connection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+	// The pool backing this very query is one connection, and postgres reports
+	// backends asynchronously, so allow a moment for the closed ones to go.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		var backends int
+		if err = db.QueryRowContext(context.Background(),
+			"SELECT count(*) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+			databaseName).Scan(&backends); err != nil {
+			t.Fatal(err)
+		}
+		if backends == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%d migration backend(s) survived the budget expiry", backends)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}

--- a/runtime.go
+++ b/runtime.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"database/sql"
+	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +25,10 @@ import (
 const (
 	postgresDataCacheKey  = "postgres-data"
 	postgresDataDirectory = "/var/lib/postgresql/data"
+
+	// readinessProbeInterval paces the readiness loop. The number of attempts
+	// is whatever the readiness budget affords, not a separate knob.
+	readinessProbeInterval = 3 * time.Second
 )
 
 type persistentCacheMounter interface {
@@ -80,7 +86,7 @@ func NewRuntime() *Runtime {
 func (s *Runtime) Load(ctx context.Context, req *runtimev0.LoadRequest) (*runtimev0.LoadResponse, error) {
 	defer s.Wool.Catch()
 
-	return s.Runtime.LoadService(ctx, req, services.RuntimeLoad{
+	response, err := s.Runtime.LoadService(ctx, req, services.RuntimeLoad{
 		Settings:     s.Settings,
 		Requirements: requirements,
 		ResolveEndpoints: func(ctx context.Context, endpoints []*basev0.Endpoint) error {
@@ -93,6 +99,13 @@ func (s *Runtime) Load(ctx context.Context, req *runtimev0.LoadRequest) (*runtim
 			return nil
 		},
 	})
+	if err != nil {
+		return response, err
+	}
+	if err = s.Settings.Timeouts.validate(); err != nil {
+		return s.Runtime.LoadError(err)
+	}
+	return response, nil
 }
 
 func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtimev0.InitResponse, error) {
@@ -156,7 +169,11 @@ func (s *Runtime) Init(ctx context.Context, req *runtimev0.InitRequest) (*runtim
 
 	}
 
-	s.connection, err = s.createOwnerConnectionString(ctx, configuration, hostInstance.Address, false)
+	connection, err := s.createOwnerConnectionString(ctx, configuration, hostInstance.Address, false)
+	if err != nil {
+		return s.Runtime.InitError(err)
+	}
+	s.connection, err = withConnectTimeout(connection, s.Settings.Timeouts.connect())
 	if err != nil {
 		return s.Runtime.InitError(err)
 	}
@@ -330,7 +347,8 @@ func (s *Runtime) WaitForReady(ctx context.Context) error {
 	defer s.Wool.Catch()
 	ctx = s.Wool.Inject(ctx)
 
-	s.Wool.Debug("waiting for database readiness")
+	budget := s.Settings.Timeouts.readiness()
+	s.Wool.Debug("waiting for database readiness", wool.Field("budget", budget.String()))
 
 	// One pool, opened once and reused for every probe. sql.Open is lazy
 	// (it doesn't dial until Ping), so a single *sql.DB pinged in a loop is
@@ -342,22 +360,71 @@ func (s *Runtime) WaitForReady(ctx context.Context) error {
 		return s.Wool.Wrapf(err, "cannot open database")
 	}
 	defer db.Close()
-	maxRetry := 30
-	var lastErr error
-	for range maxRetry {
-		err = db.Ping()
+
+	deadline, cancel := context.WithTimeout(ctx, budget)
+	defer cancel()
+
+	retry := time.NewTicker(readinessProbeInterval)
+	defer retry.Stop()
+
+	// The last probe failure that came from the database rather than from our
+	// own budget running out: that is what tells the user why postgres never
+	// answered, and it is lost if a cancellation overwrites it.
+	var lastProbeErr error
+	for {
+		err = probeReady(deadline, db)
 		if err == nil {
-			s.Wool.Debug("ping successful")
-			// Try to execute a simple query
-			_, err = db.Exec("SELECT 1")
-			if err == nil {
-				s.Wool.Debug("database ready!")
-				return nil
-			}
+			s.Wool.Debug("database ready!")
+			return nil
 		}
-		lastErr = err
+		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			lastProbeErr = err
+		}
 		s.Wool.Debug("waiting for database to be ready", wool.ErrField(err))
-		time.Sleep(3 * time.Second)
+		select {
+		case <-deadline.Done():
+			return s.readinessFailure(ctx, budget, deadline.Err(), lastProbeErr)
+		case <-retry.C:
+		}
+	}
+}
+
+// probeReady answers whether postgres is accepting work, and returns as soon as
+// ctx is done. Establishment is bounded by the DSN's connect_timeout rather
+// than by ctx — libpq reads the startup handshake off a raw socket deadline —
+// so a peer that accepts TCP and then goes silent would otherwise hold a
+// cancelled caller for the whole connect budget.
+func probeReady(ctx context.Context, db *sql.DB) error {
+	probe := make(chan error, 1)
+	go func() {
+		if err := db.PingContext(ctx); err != nil {
+			probe <- err
+			return
+		}
+		// A backend that accepts connections is not necessarily one that runs
+		// queries: postgres answers the handshake during crash recovery and
+		// refuses statements until it finishes.
+		_, err := db.ExecContext(ctx, "SELECT 1")
+		probe <- err
+	}()
+	select {
+	case err := <-probe:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// readinessFailure names the phase, says whether the budget ran out or the
+// caller gave up, and carries the last database-side failure. The connection
+// string is never included: it holds the migration-owner password.
+func (s *Runtime) readinessFailure(ctx context.Context, budget time.Duration, ended, lastProbeErr error) error {
+	phase := fmt.Sprintf("database readiness budget of %s expired", budget)
+	if errors.Is(ended, context.Canceled) {
+		phase = "database readiness wait cancelled"
+	}
+	if lastProbeErr == nil {
+		lastProbeErr = ended
 	}
 	// Tail container logs so the user sees the real failure (bad CMD,
 	// disk full, port collision, ...) instead of a generic timeout.
@@ -366,9 +433,9 @@ func (s *Runtime) WaitForReady(ctx context.Context) error {
 		tail = s.runnerEnvironment.TailLogs(ctx, 30)
 	}
 	if tail != "" {
-		return s.Wool.NewError("database not ready after %d retries (last probe: %v); container logs (tail 30):\n%s", maxRetry, lastErr, tail)
+		return s.Wool.NewError("%s (last probe: %v); container logs (tail 30):\n%s", phase, lastProbeErr, tail)
 	}
-	return s.Wool.NewError("database not ready after %d retries (last probe: %v)", maxRetry, lastErr)
+	return s.Wool.NewError("%s (last probe: %v)", phase, lastProbeErr)
 }
 
 func (s *Runtime) Start(ctx context.Context, req *runtimev0.StartRequest) (*runtimev0.StartResponse, error) {

--- a/runtime_readiness_test.go
+++ b/runtime_readiness_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	runtimev0 "github.com/codefly-dev/core/generated/go/codefly/services/runtime/v0"
+)
+
+// A database that refuses connections is the easy case. The hard one is a peer
+// that completes the TCP handshake and then says nothing: libpq blocks reading
+// the startup response, so a readiness wait that is not bounded and not
+// cancellable parks there forever. These drive that peer for real.
+func TestWaitForReadyEndsWhenBudgetExpires(t *testing.T) {
+	runtime := readinessRuntime(t, Timeouts{Readiness: 2, Connect: 1})
+
+	started := time.Now()
+	err := runtime.WaitForReady(context.Background())
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("readiness reported success against a peer that never spoke Postgres")
+	}
+	if elapsed > 8*time.Second {
+		t.Fatalf("readiness took %s to spend a 2s budget", elapsed)
+	}
+	if !strings.Contains(err.Error(), "readiness budget of 2s expired") {
+		t.Fatalf("failure does not name the phase and budget: %v", err)
+	}
+	// The budget expiring must not erase what the database last did: an
+	// operator needs the probe failure, not just "time ran out".
+	if strings.Contains(err.Error(), "last probe: <nil>") {
+		t.Fatalf("failure dropped the last probe error: %v", err)
+	}
+	if strings.Contains(err.Error(), "s3cr3tpassword") {
+		t.Fatalf("failure leaked the connection password: %v", err)
+	}
+}
+
+func TestWaitForReadyReturnsWhenCallerCancels(t *testing.T) {
+	// A readiness budget far longer than the test: only the cancellation can
+	// end this wait.
+	runtime := readinessRuntime(t, Timeouts{Readiness: 600, Connect: 600})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}()
+
+	started := time.Now()
+	err := runtime.WaitForReady(ctx)
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("readiness reported success after the caller gave up")
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("cancellation took %s to be observed", elapsed)
+	}
+	if !strings.Contains(err.Error(), "readiness wait cancelled") {
+		t.Fatalf("failure does not report the cancellation: %v", err)
+	}
+}
+
+// A readiness failure has to reach the caller as a lifecycle status: the
+// deferred panic-recovery helper wrapping every RPC must not turn a cancelled
+// wait into a response that looks like a healthy start.
+func TestStartReportsACancelledReadinessWaitAsAnError(t *testing.T) {
+	runtime := readinessRuntime(t, Timeouts{Readiness: 600, Connect: 600})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	response, err := runtime.Start(ctx, &runtimev0.StartRequest{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response.GetStatus().GetState() != runtimev0.StartStatus_ERROR {
+		t.Fatalf("start state = %s, want ERROR", response.GetStatus().GetState())
+	}
+	if !strings.Contains(response.GetStatus().GetMessage(), "readiness wait cancelled") {
+		t.Fatalf("start status does not carry the cancellation: %q", response.GetStatus().GetMessage())
+	}
+}
+
+// readinessRuntime points a Runtime at a listener that accepts connections and
+// then holds them open without ever answering the startup handshake.
+func readinessRuntime(t *testing.T, timeouts Timeouts) *Runtime {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		for {
+			connection, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				return
+			}
+			t.Cleanup(func() { _ = connection.Close() })
+		}
+	}()
+
+	runtime := NewRuntime()
+	runtime.Settings.DatabaseName = "app"
+	runtime.Settings.Timeouts = timeouts
+	connection, err := withConnectTimeout(
+		postgresConnectionString(listener.Addr().String(), "app", "owner", "s3cr3tpassword", false, false),
+		timeouts.connect(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runtime.connection = connection
+	return runtime
+}
+
+func TestWithConnectTimeoutBoundsEstablishment(t *testing.T) {
+	dsn := postgresConnectionString("db.example.com:5432", "app", "owner", "secret", true, false)
+	bounded, err := withConnectTimeout(dsn, 7*time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(bounded, "connect_timeout=7") {
+		t.Fatalf("connection string is not bounded: %s", bounded)
+	}
+	if !strings.Contains(bounded, "owner:secret@db.example.com:5432/app") {
+		t.Fatalf("connection string lost its target: %s", bounded)
+	}
+
+	if _, err = withConnectTimeout("postgresql://%zz", time.Second); err == nil {
+		t.Fatal("an unparseable connection string was accepted")
+	}
+}

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -43,3 +43,20 @@ Set `auth-mode: external-identity` for managed cloud Postgres with password auth
 Consumers acquire a short-lived token at connect time rather than reading a password from the DSN. The primary path is in-process token acquisition with `azidentity` wired into pgx's `BeforeConnect` hook, which sets the per-connection password to a freshly minted token (see `module-saas-starter#154`). The passwordless DSN supplies the host, database, and principal; the token supplies the credential.
 
 For tenant isolation, application migrations must enable row-level security and define policies against transaction-local tenant/user settings. Go services should use the service-owned library at `github.com/codefly-dev/service-postgres/libs/go`, which resolves an authenticated principal from context, issues separate read-only/read-write stores without exposing raw pools, and provides tenant-scoped transaction advisory locks without exposing tenant identity to repository code.
+
+## Operation budgets
+
+Every wait this service performs or renders is bounded, and each bound is configurable under `timeouts:` in the service settings. A value is a whole number of seconds; omitting one selects the default below, and a negative or out-of-range value is rejected when the service loads rather than at the moment the wait would have run.
+
+| Setting | Default | Bounds |
+| --- | --- | --- |
+| `connect-seconds` | 5 | One connection establishment — dial, TLS, and the Postgres startup handshake — for every connection the agent opens against its own database. |
+| `readiness-seconds` | 90 | The whole "the database answers queries" wait in `Init` and `Start`, retries included. |
+| `migration-lock-seconds` | 30 | Acquiring a migration lineage's advisory lock, including the driver-handshake retries that share the one budget. |
+| `migration-statement-seconds` | 600 | One statement inside a migration. |
+| `bootstrap-readiness-seconds` | 300 | The deployed bootstrap container's wait for the database to accept connections. |
+| `bootstrap-job-seconds` | 1800 | The bootstrap `Job`'s `activeDeadlineSeconds`. `backoffLimit` counts failed pods and cannot stop a container that is still running, so the elapsed-time bound is its own field. |
+
+The two migration budgets are session `lock_timeout` and `statement_timeout` on the connection the migration driver owns. They have to be enforced by the server: the driver takes its advisory lock, reads and writes the version row, and drops tables under `context.Background()`, so cancelling the caller does not cancel that SQL.
+
+A budget that expires names the phase it expired in and carries the last database-side failure; connection strings are never included. The bootstrap container distinguishes a database that is merely unavailable — it retries until its budget is spent, then exits `1` — from connection parameters that cannot work, which exit `78` immediately. A budget expiry during a migration leaves the tracking table exactly as it found it, so an interrupted lineage stays available for inspection.

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -51,6 +51,20 @@ RUN find /app/migrations -maxdepth 1 -type f | while read -r file; do \
 COPY runtime-access.sql /app/runtime-access.sql
 
 CMD set -eu; \
-    until pg_isready -d "${{.MigrationConnectionKeyHolder}}" >/dev/null 2>&1; do sleep 2; done; \
+    readiness_deadline=$(($(date +%s) + {{ .ReadinessTimeoutSeconds }})); \
+    while :; do \
+      readiness=0; \
+      pg_isready -q -d "${{.MigrationConnectionKeyHolder}}" || readiness=$?; \
+      if [ "$readiness" -eq 0 ]; then break; fi; \
+      if [ "$readiness" -eq 3 ]; then \
+        echo "bootstrap: database connection parameters are invalid (pg_isready status 3)" >&2; \
+        exit 78; \
+      fi; \
+      if [ "$(date +%s)" -ge "$readiness_deadline" ]; then \
+        echo "bootstrap: database did not accept connections within {{ .ReadinessTimeoutSeconds }}s (last pg_isready status $readiness)" >&2; \
+        exit 1; \
+      fi; \
+      sleep 2; \
+    done; \
 {{ if .WithMigration }}    /usr/local/bin/migrate -path /app/migrations -database "${{.MigrationConnectionKeyHolder}}" up; \
 {{ end }}    psql "${{.MigrationConnectionKeyHolder}}" --no-psqlrc --set=ON_ERROR_STOP=1 --file=/app/runtime-access.sql

--- a/templates/deployment/kustomize/base/job.yaml.tmpl
+++ b/templates/deployment/kustomize/base/job.yaml.tmpl
@@ -7,6 +7,9 @@ metadata:
     codefly.dev/bootstrap-service: {{ .Service.Name.DNSCase }}
 spec:
   backoffLimit: 4
+  # backoffLimit counts failed pods; it cannot stop a container that is still
+  # running, so the elapsed-time bound has to be its own field.
+  activeDeadlineSeconds: {{ .Deployment.Parameters.BootstrapJobDeadlineSeconds }}
   template:
     metadata:
       labels:

--- a/timeouts.go
+++ b/timeouts.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// Timeouts are the operation budgets that bound every wait this agent performs
+// or renders into an artifact. Each value is a whole number of seconds; zero
+// selects the documented default, so an omitted `timeouts:` block keeps the
+// shipped behavior.
+//
+//	timeouts:
+//	  connect-seconds: 5
+//	  readiness-seconds: 90
+//	  migration-lock-seconds: 30
+//	  migration-statement-seconds: 600
+//	  bootstrap-readiness-seconds: 300
+//	  bootstrap-job-seconds: 1800
+type Timeouts struct {
+	// Connect bounds ONE connection establishment — dial, TLS, and the startup
+	// handshake — for every connection the agent opens against its own
+	// database. It is libpq's connect_timeout, so it also covers a TCP peer
+	// that accepts the connection and then never speaks the wire protocol.
+	Connect int `yaml:"connect-seconds"`
+
+	// Readiness bounds the whole "postgres answers queries" wait in Init and
+	// Start, retries included.
+	Readiness int `yaml:"readiness-seconds"`
+
+	// MigrationLock bounds reaching a usable migration handle for one lineage.
+	// The driver handshake takes golang-migrate's advisory lock, so this is
+	// both the session lock_timeout and the budget for the handshake retries.
+	MigrationLock int `yaml:"migration-lock-seconds"`
+
+	// MigrationStatement bounds ONE statement inside a migration, as the
+	// session statement_timeout and the driver's own statement budget.
+	MigrationStatement int `yaml:"migration-statement-seconds"`
+
+	// BootstrapReadiness bounds the deployed bootstrap container's wait for the
+	// database to accept connections before it exits nonzero.
+	BootstrapReadiness int `yaml:"bootstrap-readiness-seconds"`
+
+	// BootstrapJob is the bootstrap Job's activeDeadlineSeconds: the elapsed
+	// wall clock the whole Job gets, retries included. backoffLimit counts
+	// failures and cannot stop a container that is still running.
+	BootstrapJob int `yaml:"bootstrap-job-seconds"`
+}
+
+const (
+	defaultConnectSeconds            = 5
+	defaultReadinessSeconds          = 90
+	defaultMigrationLockSeconds      = 30
+	defaultMigrationStatementSeconds = 600
+	defaultBootstrapReadinessSeconds = 300
+	defaultBootstrapJobSeconds       = 1800
+
+	// maxTimeoutSeconds is one day: longer than any budget a database bootstrap
+	// justifies, and small enough that every derived value — nanosecond
+	// durations, millisecond GUCs, the shell arithmetic rendered into the
+	// bootstrap image — stays far inside its own range.
+	maxTimeoutSeconds = 86400
+)
+
+// validate rejects a configured budget that cannot describe a finite wait.
+// Zero is not rejected: it is how an unset YAML field asks for the default.
+func (t Timeouts) validate() error {
+	for _, budget := range []struct {
+		name    string
+		seconds int
+	}{
+		{name: "connect-seconds", seconds: t.Connect},
+		{name: "readiness-seconds", seconds: t.Readiness},
+		{name: "migration-lock-seconds", seconds: t.MigrationLock},
+		{name: "migration-statement-seconds", seconds: t.MigrationStatement},
+		{name: "bootstrap-readiness-seconds", seconds: t.BootstrapReadiness},
+		{name: "bootstrap-job-seconds", seconds: t.BootstrapJob},
+	} {
+		if budget.seconds < 0 {
+			return fmt.Errorf("timeouts.%s must be positive, got %d", budget.name, budget.seconds)
+		}
+		if budget.seconds > maxTimeoutSeconds {
+			return fmt.Errorf("timeouts.%s must not exceed %d seconds, got %d", budget.name, maxTimeoutSeconds, budget.seconds)
+		}
+	}
+	// A Job killed by its own deadline reports "DeadlineExceeded" and nothing
+	// else; the readiness loop's message only survives if the loop is allowed
+	// to finish first.
+	if t.BootstrapJobSeconds() < t.BootstrapReadinessSeconds() {
+		return fmt.Errorf("timeouts.bootstrap-job-seconds (%d) must not be below timeouts.bootstrap-readiness-seconds (%d)",
+			t.BootstrapJobSeconds(), t.BootstrapReadinessSeconds())
+	}
+	return nil
+}
+
+func (t Timeouts) connect() time.Duration { return budget(t.Connect, defaultConnectSeconds) }
+
+func (t Timeouts) readiness() time.Duration { return budget(t.Readiness, defaultReadinessSeconds) }
+
+func (t Timeouts) migrationLock() time.Duration {
+	return budget(t.MigrationLock, defaultMigrationLockSeconds)
+}
+
+func (t Timeouts) migrationStatement() time.Duration {
+	return budget(t.MigrationStatement, defaultMigrationStatementSeconds)
+}
+
+// BootstrapReadinessSeconds and BootstrapJobSeconds are rendered into the
+// bootstrap image and the bootstrap Job, which speak seconds rather than Go
+// durations.
+func (t Timeouts) BootstrapReadinessSeconds() int {
+	return seconds(t.BootstrapReadiness, defaultBootstrapReadinessSeconds)
+}
+
+func (t Timeouts) BootstrapJobSeconds() int {
+	return seconds(t.BootstrapJob, defaultBootstrapJobSeconds)
+}
+
+func budget(configured, fallback int) time.Duration {
+	return time.Duration(seconds(configured, fallback)) * time.Second
+}
+
+func seconds(configured, fallback int) int {
+	if configured == 0 {
+		return fallback
+	}
+	return configured
+}
+
+// withConnectTimeout returns dsn carrying libpq's connect_timeout, so every
+// connection the agent opens gives up on establishment within one budget
+// instead of parking on a peer that accepts TCP and never completes startup.
+func withConnectTimeout(dsn string, budget time.Duration) (string, error) {
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse postgres connection string: %w", err)
+	}
+	query := parsed.Query()
+	query.Set("connect_timeout", strconv.Itoa(int(budget/time.Second)))
+	parsed.RawQuery = query.Encode()
+	return parsed.String(), nil
+}

--- a/timeouts_test.go
+++ b/timeouts_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestTimeoutsYAMLRoundTripAndDefaults(t *testing.T) {
+	var configured Settings
+	if err := yaml.Unmarshal([]byte(`
+database-name: app
+timeouts:
+  connect-seconds: 3
+  readiness-seconds: 45
+  migration-lock-seconds: 10
+  migration-statement-seconds: 120
+  bootstrap-readiness-seconds: 60
+  bootstrap-job-seconds: 240
+`), &configured); err != nil {
+		t.Fatal(err)
+	}
+	if err := configured.Timeouts.validate(); err != nil {
+		t.Fatal(err)
+	}
+	for _, check := range []struct {
+		name string
+		got  any
+		want any
+	}{
+		{name: "connect", got: configured.Timeouts.connect(), want: 3 * time.Second},
+		{name: "readiness", got: configured.Timeouts.readiness(), want: 45 * time.Second},
+		{name: "migration lock", got: configured.Timeouts.migrationLock(), want: 10 * time.Second},
+		{name: "migration statement", got: configured.Timeouts.migrationStatement(), want: 120 * time.Second},
+		{name: "bootstrap readiness", got: configured.Timeouts.BootstrapReadinessSeconds(), want: 60},
+		{name: "bootstrap job", got: configured.Timeouts.BootstrapJobSeconds(), want: 240},
+	} {
+		if check.got != check.want {
+			t.Errorf("%s budget = %v, want %v", check.name, check.got, check.want)
+		}
+	}
+
+	// An omitted block is how a service that never thought about budgets is
+	// configured, and it must still get finite ones.
+	var omitted Settings
+	if err := yaml.Unmarshal([]byte("database-name: app\n"), &omitted); err != nil {
+		t.Fatal(err)
+	}
+	if err := omitted.Timeouts.validate(); err != nil {
+		t.Fatal(err)
+	}
+	for _, check := range []struct {
+		name string
+		got  any
+		want any
+	}{
+		{name: "connect", got: omitted.Timeouts.connect(), want: time.Duration(defaultConnectSeconds) * time.Second},
+		{name: "readiness", got: omitted.Timeouts.readiness(), want: time.Duration(defaultReadinessSeconds) * time.Second},
+		{name: "migration lock", got: omitted.Timeouts.migrationLock(), want: time.Duration(defaultMigrationLockSeconds) * time.Second},
+		{name: "migration statement", got: omitted.Timeouts.migrationStatement(), want: time.Duration(defaultMigrationStatementSeconds) * time.Second},
+		{name: "bootstrap readiness", got: omitted.Timeouts.BootstrapReadinessSeconds(), want: defaultBootstrapReadinessSeconds},
+		{name: "bootstrap job", got: omitted.Timeouts.BootstrapJobSeconds(), want: defaultBootstrapJobSeconds},
+	} {
+		if check.got != check.want {
+			t.Errorf("default %s budget = %v, want %v", check.name, check.got, check.want)
+		}
+	}
+}
+
+func TestTimeoutsRejectBudgetsThatCannotDescribeAFiniteWait(t *testing.T) {
+	tests := []struct {
+		name     string
+		timeouts Timeouts
+		want     string
+	}{
+		{
+			name:     "negative connect",
+			timeouts: Timeouts{Connect: -1},
+			want:     "timeouts.connect-seconds must be positive",
+		},
+		{
+			name:     "negative readiness",
+			timeouts: Timeouts{Readiness: -30},
+			want:     "timeouts.readiness-seconds must be positive",
+		},
+		{
+			name:     "migration lock beyond the maximum",
+			timeouts: Timeouts{MigrationLock: maxTimeoutSeconds + 1},
+			want:     "timeouts.migration-lock-seconds must not exceed 86400 seconds",
+		},
+		{
+			name:     "migration statement overflow",
+			timeouts: Timeouts{MigrationStatement: 1 << 40},
+			want:     "timeouts.migration-statement-seconds must not exceed 86400 seconds",
+		},
+		{
+			name:     "bootstrap readiness beyond the maximum",
+			timeouts: Timeouts{BootstrapReadiness: maxTimeoutSeconds + 1, BootstrapJob: maxTimeoutSeconds},
+			want:     "timeouts.bootstrap-readiness-seconds must not exceed 86400 seconds",
+		},
+		{
+			// A Job killed by its own deadline reports DeadlineExceeded and
+			// nothing else, so the readiness wait must be able to finish first.
+			name:     "job deadline below the readiness wait it contains",
+			timeouts: Timeouts{BootstrapReadiness: 600, BootstrapJob: 60},
+			want:     "timeouts.bootstrap-job-seconds (60) must not be below timeouts.bootstrap-readiness-seconds (600)",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.timeouts.validate()
+			if err == nil {
+				t.Fatalf("%+v was accepted", test.timeouts)
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %v, want it to contain %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestDefaultTimeoutsAreConsistent(t *testing.T) {
+	if err := (Timeouts{}).validate(); err != nil {
+		t.Fatalf("the shipped defaults do not validate: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #80.

## Summary

- Every wait this agent performs or renders now runs against an explicit operation budget instead of an unbounded loop: readiness probing, connection establishment, migration locking and statements, the deployed bootstrap container's readiness wait, and the bootstrap `Job` itself.
- The two migration budgets are enforced **server-side** because they have to be. The pinned `golang-migrate` postgres driver (v4.19.1) takes its advisory lock, reads and writes the version row, and drops tables under `context.Background()` — cancelling the caller does not cancel that SQL, so the budgets are session `lock_timeout` and `statement_timeout` set on the connection before the driver takes ownership of it. The driver's own `Config.StatementTimeout` is kept as a client-side backstop, deliberately given a grace period so the backend wins the race and reports the real Postgres error.
- Budgets are settings (`timeouts:`) validated at load with documented defaults, so a bad value fails when the service loads rather than at the moment the wait would have run.

## Before / after

| | Before | After |
| --- | --- | --- |
| `Runtime.WaitForReady` | `db.Ping()` / `db.Exec()` + `time.Sleep(3s)` × 30, ignoring cancellation | `PingContext`/`ExecContext` raced against one `readiness-seconds` deadline; `select` on ticker vs. context; the last *database-side* error is retained separately from the budget expiry |
| Connection establishment | unbounded — libpq reads the startup handshake off a raw socket with no deadline | agent-internal DSN carries `connect_timeout` (`connect-seconds`) |
| `Init` / `Start` on cancellation | never returned | returns; `InitError`/`StartError` carry `"database readiness wait cancelled"` |
| Migration handshake retries | 3 fixed attempts, each able to block forever on `pg_advisory_lock` | retries share one `migration-lock-seconds` budget; `lock_timeout` bounds the advisory-lock wait |
| Migration statements | unbounded | `statement_timeout` (`migration-statement-seconds`) server-side, client-side deadline as backstop |
| Bootstrap container | `until pg_isready …; do sleep 2; done` — infinite | deadline; exit `1` when the budget is spent (with the last `pg_isready` status), exit `78` immediately on invalid connection parameters |
| Bootstrap `Job` | `backoffLimit: 4` only | `activeDeadlineSeconds` (`bootstrap-job-seconds`) — `backoffLimit` counts failed pods and cannot stop a container that is still running |

Terminal errors name the phase and the last failure and never include the connection string.

**Defaults** (`timeouts:` in service settings, whole seconds; omitted = default, negative or `> 86400` rejected): `connect-seconds` 5, `readiness-seconds` 90 (preserving today's effective 30 × 3s), `migration-lock-seconds` 30, `migration-statement-seconds` 600, `bootstrap-readiness-seconds` 300, `bootstrap-job-seconds` 1800. Documented in `templates/agent/README.md.tmpl`.

**Touched paths:** `timeouts.go` (new), `runtime.go`, `migrations.go`, `builder.go`, `main.go`, `templates/builder/Dockerfile.tmpl`, `templates/deployment/kustomize/base/job.yaml.tmpl`, `templates/agent/README.md.tmpl`, plus `timeouts_test.go`, `runtime_readiness_test.go`, `migrations_budget_test.go`, `bootstrap_readiness_test.go` (new) and updates to `bootstrap_template_test.go` / `deployment_test.go`.

Adding `activeDeadlineSeconds` does not churn the content-addressed bootstrap Job name — `immutableBootstrapJobName` digests `spec.template`, and `activeDeadlineSeconds` sits on the Job spec, which is one of the few mutable Job fields.

## Test plan

Backends: Postgres 17 (`runtime-image.json`, the pgvector image the service ships), `golang-migrate/migrate` v4.19.1, `lib/pq` v1.12.3, Go 1.27.1, Docker 29.4.0, k3d/k3s (disposable single-node cluster). Every behavioral assertion below was checked to fail against the unfixed code.

- [x] **Real TCP endpoint that accepts and never speaks Postgres** — `TestWaitForReadyEndsWhenBudgetExpires` / `TestWaitForReadyReturnsWhenCallerCancels` (`net.Listen` on loopback, accepting and holding connections). Budget case: 2s budget, returns in ~2.0s naming the phase and carrying the last probe error. Cancellation case: 600s budget, returns 0.31s after `cancel()`. Against the old `Ping`/`Sleep` loop both park indefinitely.
- [x] **Cancellation reaches the lifecycle status** — `TestStartReportsACancelledReadinessWaitAsAnError` asserts `StartStatus_ERROR` with `"readiness wait cancelled"`, i.e. not swallowed by the deferred recovery helper.
- [x] **Real Postgres holds the migration lock** — `TestMigrationLockBudgetExpiresWhilePeerHoldsTheLock` starts a disposable container, takes the same advisory lock from an independent session, then runs `applySource` with a 3s lock budget. Fails at **3.005s** with `pq: canceling statement due to lock timeout (55P03)`; `pg_stat_activity` shows no surviving backend. Without the session GUCs the test binary hangs to its 110s timeout — `pg_advisory_lock` under `context.Background()` never returns.
- [x] **Real Postgres executes a long SQL statement** — `TestMigrationStatementBudgetExpiresAndPreservesTheLedger` runs `SELECT pg_sleep(120)` with a 3s statement budget. Fails at **3.037s** with `pq: canceling statement due to statement timeout (57014)`, `schema_migrations` is left at `version 1, dirty true` for inspection, and no backend survives. Without the server-side GUC only the client-side backstop fires, at 18.03s.
- [x] **Bootstrap with an unreachable database** — `TestBootstrapReadinessWaitEndsWithinItsBudget` extracts the rendered `CMD` and runs it as a real `sh` subprocess against client stubs. Unavailable (status 2): exits `1` after the budget with `did not accept connections within 4s (last pg_isready status 2)`, and `psql` never runs. Invalid parameters (status 3): exits `78` in 0.88s, well inside the budget. Available: exits `0` and reconciles. The DSN password appears in no output.
- [x] **Disposable k3d Job reaches a terminal deadline failure** — built the rendered bootstrap image, imported it into a throwaway k3d cluster, applied the rendered `job.yaml` (`activeDeadlineSeconds: 40`, `bootstrap-readiness-seconds: 30`, DSN pointing at an unroutable address). Job `startTime 00:26:41` → `Failed/DeadlineExceeded "Job was active longer than specified deadline"` at `00:27:21` — exactly 40s, with `failed: 1` against `backoffLimit: 4`, i.e. the elapsed-time bound fired while retries were still available. Cluster deleted afterwards. This is a manual run, not a CI test: k3d is not available on the CI runner.
- [x] **Template and settings contracts** — `TestTimeoutsYAMLRoundTripAndDefaults`, `TestTimeoutsRejectBudgetsThatCannotDescribeAFiniteWait` (negative, over-maximum, overflow, and a Job deadline below the readiness wait it must contain), `TestDefaultTimeoutsAreConsistent`; `assertBootstrapJobDeadline` parses the rendered Job and pins both `activeDeadlineSeconds` and the retained `backoffLimit`; `TestEphemeralDeploymentRetainsValueBasedConfigurationAndSecret` asserts a service configuring no budget still deploys a bounded Job.
- [x] `go vet ./...` and `go test ./... -skip '^TestCreateToRun'` pass.
- [x] `go test -run '^TestCreateToRunDocker$'` (the full Load → Init → Start → migrate → connect lifecycle against real Docker Postgres, skipped in CI) passes.

## Limitations and cross-repository dependencies

- **`GetFreePort` / file-descriptor exhaustion is not in this repo.** That half of F13 is `codefly-dev/core#420`, shipping as codefly-dev/core#425 (`AllocateTemporaryPort`, with the isolated-subprocess `RLIMIT_NOFILE` acceptance test). Nothing here depends on it and it is not vendored in; this PR needs no core pin bump.
- **Aggregate migration time is bounded per statement, not per lineage.** `migration-statement-seconds` is the driver-supported granularity; a lineage of many statements can exceed it in total. The deployed path gets a true elapsed-time bound from the Job's `activeDeadlineSeconds`; the local agent does not have an equivalent aggregate bound.
- **The deployed bootstrap's SQL is bounded by the Job deadline, not by per-statement GUCs.** Threading `statement_timeout` into the `migrate` CLI and `psql` inside the container would mean asserting behavior of the pinned release binary that this change does not exercise, so it was left out rather than claimed.
- **Cross-run dirty-ledger recovery is unchanged and still automatic.** A budget expiry preserves the dirty ledger within the failing run (asserted above), but the *next* run's `runUp` still self-heals a dirty state with `Force`/`Drop`. Removing that is #76 (F01) and is deliberately out of scope here.
- **Risk:** `statement_timeout` is now enforced on migrations that previously had none, so a legitimately long-running migration (a large `CREATE INDEX`, say) will be aborted at 600s unless `migration-statement-seconds` is raised. This is the intended contract, and the knob is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
