### PR TITLE
feat: package one schema plan for local and deployed Postgres (#78)

### DIFF
--- a/bootstrap_image_test.go
+++ b/bootstrap_image_test.go
@@ -262,7 +262,7 @@ func lockArchives(document map[string]any) []any {
 
 func TestBootstrapDockerfileLocksEveryInput(t *testing.T) {
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
 	})
 
 	require.Contains(t, dockerfile, "FROM "+bootstrapLock.Base.Reference())
@@ -394,7 +394,7 @@ func TestBootstrapImageLabelsCannotBeOverriddenAtBuildTime(t *testing.T) {
 func TestBootstrapImageRejectsTamperedMigrateArchive(t *testing.T) {
 	requireDocker(t)
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
 	})
 	script := bootstrapMigrateInstallScript(t, dockerfile)
 
@@ -421,14 +421,19 @@ func bootstrapBuildContext(t *testing.T) string {
 	t.Helper()
 	context := t.TempDir()
 	parameters := DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		RuntimeAccessLockID:          runtimeAccessLockID,
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
+		RuntimeAccessLockID:            runtimeAccessLockID,
+		ReadinessTimeoutSeconds:        defaultBootstrapReadinessSeconds,
 	}
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)
 	require.NoError(t, os.WriteFile(filepath.Join(context, "Dockerfile"), []byte(dockerfile), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(context, "runtime-access.sql"), []byte("SELECT 1;\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(context, "bootstrap.sql"),
 		[]byte(renderBootstrapTemplate(t, parameters)), 0o644))
+	staged := filepath.Join(context, bootstrapDirectory)
+	require.NoError(t, os.MkdirAll(staged, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(staged, "bootstrap.sh"),
+		[]byte(renderStagedTemplate(t, "templates/bootstrap/bootstrap.sh.tmpl", parameters)), 0o644))
 	return context
 }
 

--- a/bootstrap_parity_test.go
+++ b/bootstrap_parity_test.go
@@ -1,0 +1,308 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/codefly-dev/core/agents/services"
+	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
+	"github.com/codefly-dev/core/resources"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	parityOwnerUser        = "postgres"
+	parityOwnerPassword    = "owner-secret"
+	parityReadOnlyPassword = "read-only-secret"
+	parityReadWritePasword = "read-write-secret"
+	parityDatabase         = "store"
+)
+
+// TestBootstrapImageMatchesLocalRuntimeSchema is the acceptance test for the
+// local/deployed schema contract: the same fixture is applied by the local
+// runtime and by the built bootstrap image, against two fresh Postgres
+// clusters, and the resulting tables, migration ledgers, extensions, and
+// runtime-role grants must be identical. Each path runs twice, so the
+// comparison also proves both are idempotent.
+func TestBootstrapImageMatchesLocalRuntimeSchema(t *testing.T) {
+	requireDocker(t)
+
+	scenarios := map[string]func(t *testing.T, location string) *Settings{
+		"sibling sources without own migrations": func(t *testing.T, location string) *Settings {
+			writeFixtureMigration(t, filepath.Join(location, "..", "api", "migrations"), "1_api",
+				`CREATE TABLE api_widget (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), attributes HSTORE NOT NULL DEFAULT ''::hstore);`,
+				`DROP TABLE api_widget;`)
+			writeFixtureMigration(t, filepath.Join(location, "..", "billing", "db", "migrations"), "1_billing",
+				`CREATE TABLE billing_invoice (id UUID PRIMARY KEY, cents BIGINT NOT NULL);`,
+				`DROP TABLE billing_invoice;`)
+			return &Settings{
+				DatabaseName: parityDatabase,
+				Extensions:   []Extension{{Name: "hstore"}},
+				MigrationSources: []MigrationSource{
+					{Name: "api"},
+					{Name: "billing", Path: "../billing/db/migrations"},
+				},
+			}
+		},
+		"own and sibling sources": func(t *testing.T, location string) *Settings {
+			writeFixtureMigration(t, filepath.Join(location, "migrations"), "1_store",
+				`CREATE TABLE store_item (id UUID PRIMARY KEY);`,
+				`DROP TABLE store_item;`)
+			writeFixtureMigration(t, filepath.Join(location, "..", "api", "migrations"), "1_api",
+				`CREATE TABLE api_widget (id UUID PRIMARY KEY, attributes HSTORE NOT NULL DEFAULT ''::hstore);`,
+				`DROP TABLE api_widget;`)
+			writeFixtureMigration(t, filepath.Join(location, "..", "api", "migrations"), "2_api_index",
+				`CREATE INDEX api_widget_attributes ON api_widget USING GIN (attributes);`,
+				`DROP INDEX api_widget_attributes;`)
+			return &Settings{
+				DatabaseName:     parityDatabase,
+				Extensions:       []Extension{{Name: "hstore"}},
+				MigrationSources: []MigrationSource{{Name: "api"}},
+			}
+		},
+		"extension-only bootstrap": func(t *testing.T, location string) *Settings {
+			writeFixtureMigration(t, filepath.Join(location, "migrations"), "1_ignored",
+				`CREATE TABLE never_applied (id UUID PRIMARY KEY);`,
+				`DROP TABLE never_applied;`)
+			return &Settings{
+				DatabaseName: parityDatabase,
+				NoMigration:  true,
+				Extensions:   []Extension{{Name: "hstore"}},
+			}
+		},
+	}
+
+	for name, fixture := range scenarios {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+
+			location := filepath.Join(t.TempDir(), "module", "store")
+			require.NoError(t, os.MkdirAll(location, 0o755))
+			settings := fixture(t, location)
+
+			network := startParityNetwork(t)
+			local := startParityPostgres(t, network, "local")
+			deployed := startParityPostgres(t, network, "deployed")
+
+			applyLocally(ctx, t, location, settings, local.hostDSN)
+			applyLocally(ctx, t, location, settings, local.hostDSN)
+
+			bootstrapImage := buildBootstrapImage(ctx, t, location, settings)
+			runBootstrapImage(t, network, bootstrapImage, deployed.networkDSN)
+			runBootstrapImage(t, network, bootstrapImage, deployed.networkDSN)
+
+			readOnlyRole, readWriteRole := runtimeRoleNames(parityDatabase)
+			localSchema := snapshotSchema(ctx, t, local.hostDSN, readOnlyRole, readWriteRole)
+			deployedSchema := snapshotSchema(ctx, t, deployed.hostDSN, readOnlyRole, readWriteRole)
+			require.Equal(t, localSchema, deployedSchema,
+				"the bootstrap image and the local runtime disagree on the schema contract")
+
+			// The comparison is only meaningful if both actually did the work.
+			require.Contains(t, localSchema, "extension: hstore")
+			require.Contains(t, localSchema, "role: "+readOnlyRole+" login=t super=f bypassrls=f")
+			switch name {
+			case "extension-only bootstrap":
+				require.NotContains(t, strings.Join(localSchema, "\n"), "ledger:")
+				require.NotContains(t, strings.Join(localSchema, "\n"), "table: never_applied")
+			case "sibling sources without own migrations":
+				require.Contains(t, localSchema, "table: api_widget")
+				require.Contains(t, localSchema, "table: billing_invoice")
+				require.Contains(t, localSchema, "ledger: schema_migrations_api version=1 dirty=f")
+				require.Contains(t, localSchema, "ledger: schema_migrations_billing version=1 dirty=f")
+				require.NotContains(t, strings.Join(localSchema, "\n"), "ledger: schema_migrations ")
+			case "own and sibling sources":
+				require.Contains(t, localSchema, "table: store_item")
+				require.Contains(t, localSchema, "ledger: schema_migrations version=1 dirty=f")
+				require.Contains(t, localSchema, "ledger: schema_migrations_api version=2 dirty=f")
+			}
+		})
+	}
+}
+
+// applyLocally runs the local half of the contract: the plan is resolved once
+// and then executed exactly as Init does.
+func applyLocally(ctx context.Context, t *testing.T, location string, settings *Settings, dsn string) {
+	t.Helper()
+	runtime := NewRuntime()
+	runtime.Location = location
+	runtime.Settings = settings
+	runtime.postgresUser = parityOwnerUser
+	runtime.postgresPassword = parityOwnerPassword
+	runtime.readOnlyPassword = parityReadOnlyPassword
+	runtime.readWritePassword = parityReadWritePasword
+	runtime.connection = dsn
+
+	prerequisites, err := runtime.resolveSchemaPrerequisites()
+	require.NoError(t, err)
+	require.NoError(t, runtime.applySchema(ctx, prerequisites))
+	require.NoError(t, runtime.ensureRuntimeAccess(ctx))
+}
+
+// buildBootstrapImage emits the CLI-owned build recipe and builds it exactly as
+// the CLI would: from the recipe tree, which must be a self-contained context.
+func buildBootstrapImage(ctx context.Context, t *testing.T, location string, settings *Settings) string {
+	t.Helper()
+	builder := NewBuilder()
+	require.NoError(t, builder.HeadlessLoad(ctx, &basev0.ServiceIdentity{
+		Workspace: "workspace", Module: "module", Name: "store", Version: "1.2.3",
+	}))
+	builder.Information = &services.Information{
+		Service: resources.ToServiceWithCase(builder.Identity),
+		Module:  resources.ToModuleWithCase(builder.Identity),
+	}
+	builder.Location = location
+	builder.Settings = settings
+
+	outputDirectory := t.TempDir()
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
+
+	tag := fmt.Sprintf("service-postgres-parity:%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = exec.Command("docker", "image", "rm", "--force", tag).Run() })
+	runDocker(t, "build", "--file", filepath.Join(outputDirectory, "builder", "Dockerfile"),
+		"--tag", tag, outputDirectory)
+	return tag
+}
+
+func runBootstrapImage(t *testing.T, network, tag, dsn string) {
+	t.Helper()
+	runDocker(t, "run", "--rm", "--network", network,
+		"--env", migrationConnectionEnvironmentKey+"="+dsn,
+		"--env", "POSTGRES_USER="+parityOwnerUser,
+		"--env", "POSTGRES_READ_ONLY_PASSWORD="+parityReadOnlyPassword,
+		"--env", "POSTGRES_READ_WRITE_PASSWORD="+parityReadWritePasword,
+		tag)
+}
+
+// snapshotSchema renders every externally visible part of the schema contract
+// as sorted text, so a mismatch between the two paths reads as a diff.
+func snapshotSchema(ctx context.Context, t *testing.T, dsn, readOnlyRole, readWriteRole string) []string {
+	t.Helper()
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+
+	var snapshot []string
+	snapshot = append(snapshot, queryLines(ctx, t, db,
+		`SELECT format('table: %s', table_name) FROM information_schema.tables
+		 WHERE table_schema = 'public' ORDER BY table_name`)...)
+	snapshot = append(snapshot, queryLines(ctx, t, db,
+		`SELECT format('extension: %s', extname) FROM pg_extension ORDER BY extname`)...)
+	snapshot = append(snapshot, queryLines(ctx, t, db,
+		`SELECT format('role: %s login=%s super=%s bypassrls=%s', rolname, rolcanlogin, rolsuper, rolbypassrls)
+		 FROM pg_roles WHERE rolname IN ($1, $2) ORDER BY rolname`, readOnlyRole, readWriteRole)...)
+	snapshot = append(snapshot, queryLines(ctx, t, db,
+		`SELECT format('grant: %s on %s %s', grantee, table_name, privilege_type)
+		 FROM information_schema.role_table_grants WHERE grantee IN ($1, $2)
+		 ORDER BY grantee, table_name, privilege_type`, readOnlyRole, readWriteRole)...)
+
+	// Every migration ledger the plan may own, whichever path created it.
+	ledgers := queryLines(ctx, t, db,
+		`SELECT table_name FROM information_schema.tables
+		 WHERE table_schema = 'public' AND table_name LIKE 'schema_migrations%' ORDER BY table_name`)
+	for _, ledger := range ledgers {
+		snapshot = append(snapshot, queryLines(ctx, t, db,
+			`SELECT format('ledger: `+ledger+` version=%s dirty=%s', version, dirty) FROM "`+ledger+`"`)...)
+	}
+	return snapshot
+}
+
+func queryLines(ctx context.Context, t *testing.T, db *sql.DB, query string, args ...any) []string {
+	t.Helper()
+	rows, err := db.QueryContext(ctx, query, args...)
+	require.NoError(t, err)
+	defer rows.Close()
+	var lines []string
+	for rows.Next() {
+		var line string
+		require.NoError(t, rows.Scan(&line))
+		lines = append(lines, line)
+	}
+	require.NoError(t, rows.Err())
+	return lines
+}
+
+type parityPostgres struct {
+	hostDSN    string
+	networkDSN string
+}
+
+// startParityPostgres runs one disposable cluster on the shared network. The
+// local runtime reaches it through the published host port and the bootstrap
+// container through the network alias, mirroring how each really connects.
+func startParityPostgres(t *testing.T, network, role string) parityPostgres {
+	t.Helper()
+	alias := fmt.Sprintf("postgres-%s-%d", role, time.Now().UnixNano())
+	t.Cleanup(func() { _ = exec.Command("docker", "rm", "--force", alias).Run() })
+	runDocker(t, "run", "--detach", "--name", alias,
+		"--network", network, "--network-alias", alias,
+		"--publish", "127.0.0.1::5432",
+		"--env", "POSTGRES_USER="+parityOwnerUser,
+		"--env", "POSTGRES_PASSWORD="+parityOwnerPassword,
+		"--env", "POSTGRES_DB="+parityDatabase,
+		image.FullName())
+
+	published := strings.TrimSpace(runDocker(t, "port", alias, "5432/tcp"))
+	published = strings.TrimSpace(strings.Split(published, "\n")[0])
+	port := published[strings.LastIndex(published, ":")+1:]
+
+	postgres := parityPostgres{
+		hostDSN:    fmt.Sprintf("postgresql://%s:%s@127.0.0.1:%s/%s?sslmode=disable", parityOwnerUser, parityOwnerPassword, port, parityDatabase),
+		networkDSN: fmt.Sprintf("postgresql://%s:%s@%s:5432/%s?sslmode=disable", parityOwnerUser, parityOwnerPassword, alias, parityDatabase),
+	}
+	waitForParityPostgres(t, alias, postgres.hostDSN)
+	return postgres
+}
+
+func waitForParityPostgres(t *testing.T, container, dsn string) {
+	t.Helper()
+	db, err := sql.Open("postgres", dsn)
+	require.NoError(t, err)
+	defer db.Close()
+	deadline := time.Now().Add(90 * time.Second)
+	for {
+		if err = db.Ping(); err == nil {
+			return
+		}
+		if time.Now().After(deadline) {
+			logs, _ := exec.Command("docker", "logs", "--tail", "40", container).CombinedOutput()
+			t.Fatalf("postgres %s never became ready: %v\n%s", container, err, logs)
+		}
+		time.Sleep(time.Second)
+	}
+}
+
+func startParityNetwork(t *testing.T) string {
+	t.Helper()
+	network := fmt.Sprintf("codefly-postgres-parity-%d", time.Now().UnixNano())
+	runDocker(t, "network", "create", network)
+	t.Cleanup(func() { _ = exec.Command("docker", "network", "rm", network).Run() })
+	return network
+}
+
+func runDocker(t *testing.T, args ...string) string {
+	t.Helper()
+	output, err := exec.Command("docker", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("docker %s: %v\n%s", strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func writeFixtureMigration(t *testing.T, dir, name, up, down string) {
+	t.Helper()
+	mustMkdir(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name+".up.sql"), []byte(up+"\n"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name+".down.sql"), []byte(down+"\n"), 0o644))
+}

--- a/bootstrap_parity_test.go
+++ b/bootstrap_parity_test.go
@@ -306,3 +306,126 @@ func writeFixtureMigration(t *testing.T, dir, name, up, down string) {
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name+".up.sql"), []byte(up+"\n"), 0o644))
 	require.NoError(t, os.WriteFile(filepath.Join(dir, name+".down.sql"), []byte(down+"\n"), 0o644))
 }
+
+// TestBootstrapImageRefusesDriftedStagedSources is the behavioral half of the
+// staging guarantee. The image is built from the service directory by a
+// separate process, long after the plan was emitted, so staged content can
+// drift or be only partly written. Without verification the run applies fewer
+// migrations and exits successfully — a silently under-migrated database. The
+// check runs before the database is even contacted, so no cluster is needed.
+func TestBootstrapImageRefusesDriftedStagedSources(t *testing.T) {
+	requireDocker(t)
+	ctx := context.Background()
+
+	location := filepath.Join(t.TempDir(), "module", "store")
+	require.NoError(t, os.MkdirAll(location, 0o755))
+	writeFixtureMigration(t, filepath.Join(location, "migrations"), "1_store",
+		`CREATE TABLE store_item (id UUID PRIMARY KEY);`, `DROP TABLE store_item;`)
+	settings := &Settings{DatabaseName: parityDatabase}
+
+	builder := NewBuilder()
+	require.NoError(t, builder.HeadlessLoad(ctx, &basev0.ServiceIdentity{
+		Workspace: "workspace", Module: "module", Name: "store", Version: "1.2.3",
+	}))
+	builder.Information = &services.Information{
+		Service: resources.ToServiceWithCase(builder.Identity),
+		Module:  resources.ToModuleWithCase(builder.Identity),
+	}
+	builder.Location = location
+	builder.Settings = settings
+
+	outputDirectory := t.TempDir()
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	// Exactly what a concurrent build, a stray editor write, or a partly copied
+	// context leaves behind.
+	drifted := filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_store.up.sql")
+	require.NoError(t, os.WriteFile(drifted, []byte("CREATE TABLE something_else (id UUID PRIMARY KEY);\n"), 0o644))
+
+	tag := fmt.Sprintf("service-postgres-drift:%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = exec.Command("docker", "image", "rm", "--force", tag).Run() })
+	runDocker(t, "build", "--file", filepath.Join(outputDirectory, "builder", "Dockerfile"),
+		"--tag", tag, outputDirectory)
+
+	// A reachable database, so the run gets past the readiness gate and the
+	// verification is what stops it.
+	database := startBootstrapPostgres(t)
+	output, err := exec.Command("docker", "run", "--rm",
+		"--network", "container:"+database,
+		"--env", migrationConnectionEnvironmentKey+"=postgres://postgres:bootstrap-test@127.0.0.1:5432/postgres?sslmode=disable",
+		"--env", "POSTGRES_USER=postgres",
+		"--env", "POSTGRES_READ_ONLY_PASSWORD=read-only-secret",
+		"--env", "POSTGRES_READ_WRITE_PASSWORD=read-write-secret",
+		tag).CombinedOutput()
+	require.Error(t, err, "the bootstrap applied drifted migration content instead of failing:\n%s", output)
+	require.Contains(t, string(output), "1_store.up.sql")
+
+	// Nothing may reach the database: not the drifted statement, not the
+	// migration it replaced.
+	for _, relation := range []string{"public.something_else", "public.store_item"} {
+		require.Equal(t, "f",
+			queryBootstrapPostgres(t, database, fmt.Sprintf("SELECT to_regclass('%s') IS NOT NULL", relation)),
+			"a drifted staged source reached the database")
+	}
+}
+
+// TestBootstrapImageBuildsTheWayTheCLIBuildsIt exercises the recipe the way the
+// CLI consumes it: the build context is the service directory, not the recipe
+// tree, and the recipe's declared ignore is staged next to the Dockerfile
+// first. Building only from the recipe tree would never apply that ignore, so
+// an ignore that excluded something the Dockerfile copies would break every
+// deploy while the suite stayed green.
+func TestBootstrapImageBuildsTheWayTheCLIBuildsIt(t *testing.T) {
+	requireDocker(t)
+	ctx := context.Background()
+
+	location := filepath.Join(t.TempDir(), "module", "store")
+	require.NoError(t, os.MkdirAll(location, 0o755))
+	writeFixtureMigration(t, filepath.Join(location, "migrations"), "1_store",
+		`CREATE TABLE store_item (id UUID PRIMARY KEY);`, `DROP TABLE store_item;`)
+	secrets := filepath.Join(location, "configurations", "local")
+	require.NoError(t, os.MkdirAll(secrets, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(secrets, "postgres.secret.env"),
+		[]byte("POSTGRES_PASSWORD=super-secret\n"), 0o600))
+
+	builder := NewBuilder()
+	require.NoError(t, builder.HeadlessLoad(ctx, &basev0.ServiceIdentity{
+		Workspace: "workspace", Module: "module", Name: "store", Version: "1.2.3",
+	}))
+	builder.Information = &services.Information{
+		Service: resources.ToServiceWithCase(builder.Identity),
+		Module:  resources.ToModuleWithCase(builder.Identity),
+	}
+	builder.Location = location
+	builder.Settings = &Settings{DatabaseName: parityDatabase}
+
+	outputDirectory := t.TempDir()
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	recipe := response.GetResult().GetDockerBuildPlan().GetRecipes()[0]
+	require.NotEmpty(t, recipe.GetDockerignore())
+	dockerfile := filepath.Join(outputDirectory, filepath.FromSlash(recipe.GetDockerfile()))
+	ignore := filepath.Join(outputDirectory, filepath.FromSlash(recipe.GetDockerignore()))
+	require.NoError(t, os.WriteFile(dockerfile+".dockerignore", mustReadFile(t, ignore), 0o644))
+
+	tag := fmt.Sprintf("service-postgres-cli-shape:%d", time.Now().UnixNano())
+	t.Cleanup(func() { _ = exec.Command("docker", "image", "rm", "--force", tag).Run() })
+	runDocker(t, "build", "--file", dockerfile, "--tag", tag, location)
+
+	listing := runDocker(t, "run", "--rm", "--entrypoint", "/bin/sh", tag,
+		"-c", "ls -A /app && ls -A /app/bootstrap")
+	require.Contains(t, listing, "runtime-access.sql")
+	require.Contains(t, listing, "sources.sha256")
+	require.NotContains(t, listing, "configurations")
+
+	// /app is the whole of what this build adds to the base image, so scanning it
+	// is exhaustive for content the build could have leaked. Scanning from / would
+	// descend into /proc and /dev and block on their pseudo-files.
+	secretSearch := runDocker(t, "run", "--rm", "--entrypoint", "/bin/sh", tag,
+		"-c", "grep -rl super-secret /app 2>/dev/null; exit 0")
+	require.Empty(t, strings.TrimSpace(secretSearch), "the image carries the service directory's local secret")
+}

--- a/bootstrap_readiness_test.go
+++ b/bootstrap_readiness_test.go
@@ -107,20 +107,18 @@ func TestBootstrapReadinessWaitEndsWithinItsBudget(t *testing.T) {
 	}
 }
 
-// bootstrapCommand renders the Dockerfile and returns its CMD as the single
-// shell string Docker would hand to /bin/sh -c.
+// bootstrapCommand renders the bootstrap program the image's CMD runs, so a
+// regression in the rendered text fails here rather than in a cluster.
 func bootstrapCommand(t *testing.T, readinessSeconds int, withMigration bool) string {
 	t.Helper()
-	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		WithMigration:                withMigration,
-		ReadinessTimeoutSeconds:      readinessSeconds,
-	})
-	_, command, found := strings.Cut(dockerfile, "\nCMD ")
-	if !found {
-		t.Fatalf("rendered Dockerfile has no CMD:\n%s", dockerfile)
+	parameters := DockerTemplating{
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
+		ReadinessTimeoutSeconds:        readinessSeconds,
 	}
-	return strings.ReplaceAll(command, "\\\n", "")
+	if withMigration {
+		parameters.Lineages = []BootstrapLineage{{Label: "store", Stage: "00-store", Ledger: "schema_migrations"}}
+	}
+	return renderStagedTemplate(t, "templates/bootstrap/bootstrap.sh.tmpl", parameters)
 }
 
 // writeClientStub installs a postgres client the bootstrap CMD invokes,

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -12,62 +13,70 @@ import (
 	"testing"
 	"text/template"
 	"time"
+
+	builderv0 "github.com/codefly-dev/core/generated/go/codefly/services/builder/v0"
 )
+
+// testBootstrapTemplating mirrors what Build derives from a resolved schema
+// plan, so the template tests exercise the same shape the builder renders.
+func testBootstrapTemplating(lineages ...BootstrapLineage) DockerTemplating {
+	return DockerTemplating{
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
+		RuntimeAccessLockID:            runtimeAccessLockID,
+		ReadOnlyRole:                   "codefly_app_ro",
+		ReadWriteRole:                  "codefly_app_rw",
+		Schemas:                        []string{"public", "audit"},
+		ReadinessTimeoutSeconds:        defaultBootstrapReadinessSeconds,
+		Extensions:                     []BootstrapExtension{{Name: "vector"}, {Name: "hstore", Required: true}},
+		Lineages:                       lineages,
+	}
+}
 
 func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 	tests := []struct {
-		name           string
-		withMigrations bool
+		name     string
+		lineages []BootstrapLineage
 	}{
-		{name: "with migrations", withMigrations: true},
-		{name: "without migrations", withMigrations: false},
+		{name: "with migrations", lineages: []BootstrapLineage{
+			{Label: "store", Stage: "00-store", Ledger: "schema_migrations"},
+		}},
+		{name: "without migrations"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			parameters := DockerTemplating{
-				MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-				RuntimeAccessLockID:          runtimeAccessLockID,
-				WithMigration:                test.withMigrations,
-				ReadinessTimeoutSeconds:      300,
-				ReadOnlyRole:                 "codefly_app_ro",
-				ReadWriteRole:                "codefly_app_rw",
-				Schemas:                      []string{"public", "audit"},
-			}
+			parameters := testBootstrapTemplating(test.lineages...)
+			program := renderStagedTemplate(t, "templates/bootstrap/bootstrap.sh.tmpl", parameters)
 			dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)
-			if strings.Contains(dockerfile, `CMD set -eu; \ /`) {
-				t.Fatal("bootstrap command escaped a space instead of continuing onto the next shell command")
+
+			// The program gates the run and then hands every database step to
+			// the one locked psql session.
+			if !strings.Contains(program, "psql \"${connection}\" --no-psqlrc --set=ON_ERROR_STOP=1 --file=/app/bootstrap.sql") {
+				t.Fatal("bootstrap program does not run the locked bootstrap session")
 			}
-			if !strings.Contains(dockerfile, "psql \"${"+migrationConnectionEnvironmentKey+"}\"") {
-				t.Fatal("bootstrap image does not always reconcile runtime roles")
-			}
-			if !strings.Contains(dockerfile, "pg_isready -q -d \"${"+migrationConnectionEnvironmentKey+"}\"") {
-				t.Fatal("bootstrap image does not wait for Postgres readiness")
+			if !strings.Contains(program, "pg_isready -q -d \"${connection}\"") {
+				t.Fatal("bootstrap program does not wait for Postgres readiness")
 			}
 			for _, required := range []string{
-				"readiness_deadline=$(($(date +%s) + 300))",
-				"did not accept connections within 300s",
+				fmt.Sprintf("readiness_deadline=$(($(date +%%s) + %d))", defaultBootstrapReadinessSeconds),
+				fmt.Sprintf("did not accept connections within %ds", defaultBootstrapReadinessSeconds),
 				"exit 1",
 				"exit 78",
 			} {
-				if !strings.Contains(dockerfile, required) {
+				if !strings.Contains(program, required) {
 					t.Fatalf("bootstrap readiness wait is not bounded: missing %q", required)
 				}
 			}
-			for _, required := range []string{
-				"ARG TARGETARCH",
-				`architecture="${TARGETARCH:-$(apk --print-arch)}"`,
-				"x86_64) architecture=amd64",
-				"aarch64) architecture=arm64",
-				`case "${architecture}" in`,
-				"amd64) checksum=",
-				"arm64) checksum=",
-				`*) echo "unsupported target architecture: ${architecture}" >&2; exit 1 ;;`,
-				"/releases/download/" + bootstrapLock.Migrate.Version + "/migrate.linux-${architecture}.tar.gz",
-			} {
-				if !strings.Contains(dockerfile, required) {
-					t.Fatalf("bootstrap image is not target-architecture portable: missing %q", required)
-				}
+			if !strings.Contains(program, "connection=\"${"+migrationConnectionEnvironmentKey+":-}\"") {
+				t.Fatalf("bootstrap program does not read the connection from %s", migrationConnectionEnvironmentKey)
 			}
+			// The image is built from the service directory by a separate
+			// process, so staged content that drifted must stop the run rather
+			// than apply fewer migrations and report success.
+			verifies := strings.Contains(program, "sha256sum -c sources.sha256")
+			if verifies != (len(test.lineages) > 0) {
+				t.Fatalf("staged-source verification present = %t, want %t", verifies, len(test.lineages) > 0)
+			}
+
 			// The migration no longer runs from the Dockerfile CMD. It runs as a
 			// child of the psql session holding the runtime-access advisory
 			// lock, so both bootstrap steps share ONE lock domain instead of
@@ -77,7 +86,7 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 				t.Fatal("migrate must not run as its own process outside the locked psql session")
 			}
 
-			// The orchestration script holds the lock across both steps and
+			// The orchestration script holds the lock across every step and
 			// includes the access script rather than absorbing it: a consumer
 			// substituting runtime-access.sql must not silently lose the
 			// migration with it.
@@ -88,16 +97,20 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 			if !strings.Contains(bootstrapSQL, `\i /app/runtime-access.sql`) {
 				t.Fatal("bootstrap does not include the runtime-access script")
 			}
+			if !strings.Contains(bootstrapSQL, `\i /app/bootstrap/extensions.sql`) {
+				t.Fatal("bootstrap does not always create the required extensions")
+			}
 			hasMigration := strings.Contains(bootstrapSQL, `/usr/local/bin/migrate -path`)
-			if hasMigration != test.withMigrations {
-				t.Fatalf("migration command present = %t, want %t", hasMigration, test.withMigrations)
+			if hasMigration != (len(test.lineages) > 0) {
+				t.Fatalf("migration command present = %t, want %t", hasMigration, len(test.lineages) > 0)
+			}
+			// ON_ERROR_STOP does not cover \!, so a failed migration must be
+			// caught explicitly or the grants would run over an unmigrated schema.
+			if strings.Count(bootstrapSQL, `\if :SHELL_ERROR`) != len(test.lineages) {
+				t.Fatalf("each migration must check its child exit status:\n%s", bootstrapSQL)
 			}
 
 			accessSQL := renderRuntimeAccessTemplate(t, parameters)
-			// runtime-access.sql stays purely about access.
-			if strings.Contains(accessSQL, "/usr/local/bin/migrate") {
-				t.Fatal("runtime-access.sql must not run migrations; a substituted copy would drop them")
-			}
 			for _, required := range []string{
 				"NOBYPASSRLS",
 				"NOCREATEROLE",
@@ -121,16 +134,126 @@ func TestBootstrapImageAlwaysReconcilesRuntimeAccess(t *testing.T) {
 	}
 }
 
+// TestBootstrapProgramAppliesEveryLineageToItsOwnLedger is the deployed half of
+// the local multi-source contract: each source is applied to its own ledger, in
+// TestBootstrapProgramAppliesEveryLineageToItsOwnLedger is the deployed half of
+// the local multi-source contract: each source is applied to its own ledger, in
+// declared order, inside the one session holding the runtime-access lock, and
+// the own source keeps golang-migrate's default table name.
+func TestBootstrapProgramAppliesEveryLineageToItsOwnLedger(t *testing.T) {
+	parameters := testBootstrapTemplating(
+		BootstrapLineage{Label: "store", Stage: "00-store", Ledger: "schema_migrations"},
+		BootstrapLineage{Label: "api", Stage: "01-api", Ledger: "schema_migrations_api"},
+		BootstrapLineage{Label: "billing", Stage: "02-billing", Ledger: "schema_migrations_billing"},
+	)
+	bootstrapSQL := renderBootstrapTemplate(t, parameters)
+
+	previous := -1
+	for _, expected := range []string{
+		`-path /app/bootstrap/sources/00-store -database "${` + migrationConnectionEnvironmentKey + `}${CODEFLY_LEDGER_SEPARATOR}x-migrations-table=schema_migrations"`,
+		`-path /app/bootstrap/sources/01-api -database "${` + migrationConnectionEnvironmentKey + `}${CODEFLY_LEDGER_SEPARATOR}x-migrations-table=schema_migrations_api"`,
+		`-path /app/bootstrap/sources/02-billing -database "${` + migrationConnectionEnvironmentKey + `}${CODEFLY_LEDGER_SEPARATOR}x-migrations-table=schema_migrations_billing"`,
+	} {
+		at := strings.Index(bootstrapSQL, expected)
+		if at < 0 {
+			t.Fatalf("bootstrap does not apply %q:\n%s", expected, bootstrapSQL)
+		}
+		if at < previous {
+			t.Fatalf("bootstrap applies %q out of declared order", expected)
+		}
+		previous = at
+	}
+	// Every lineage runs between the lock and the grants, or a concurrent pod
+	// could migrate while this one rewrites the same tracking table.
+	lock := strings.Index(bootstrapSQL, "pg_advisory_lock(")
+	grants := strings.Index(bootstrapSQL, `\i /app/runtime-access.sql`)
+	if lock < 0 || grants < 0 || lock > previous || previous > grants {
+		t.Fatalf("migrations do not run between the lock and the grants:\n%s", bootstrapSQL)
+	}
+	// The ledger is a DSN query parameter, so the separator is resolved by the
+	// program against a connection string that may already carry a query.
+	program := renderStagedTemplate(t, "templates/bootstrap/bootstrap.sh.tmpl", parameters)
+	if !strings.Contains(program, `*\?*) CODEFLY_LEDGER_SEPARATOR="&"`) {
+		t.Fatal("bootstrap program overwrites an existing DSN query instead of appending the ledger")
+	}
+	if !strings.Contains(program, "export CODEFLY_LEDGER_SEPARATOR") {
+		t.Fatal("the ledger separator does not reach the migrate child process")
+	}
+}
+
+// TestBootstrapExtensionsAreCreatedBestEffort keeps the deployed extension
+// behavior identical to the local runtimes: a missing shared library warns and
+// the bootstrap continues, while every other failure still stops the run.
+func TestBootstrapExtensionsAreCreatedBestEffort(t *testing.T) {
+	extensions := renderStagedTemplate(t, "templates/bootstrap/extensions.sql.tmpl", testBootstrapTemplating())
+
+	for _, required := range []string{
+		`\set ON_ERROR_STOP on`,
+		`CREATE EXTENSION IF NOT EXISTS "vector";`,
+		`CREATE EXTENSION IF NOT EXISTS "hstore";`,
+		"EXCEPTION WHEN OTHERS THEN",
+		"RAISE WARNING",
+	} {
+		if !strings.Contains(extensions, required) {
+			t.Fatalf("generated extensions program missing %q", required)
+		}
+	}
+	// A required extension must abort the bootstrap exactly as it fails the local
+	// runtime's readiness, so it may not be wrapped in the tolerant DO block.
+	optional, _, found := strings.Cut(extensions, `CREATE EXTENSION IF NOT EXISTS "hstore";`)
+	if !found {
+		t.Fatal("required extension is not created")
+	}
+	if strings.Count(optional, "EXCEPTION WHEN OTHERS THEN") != 1 {
+		t.Fatalf("required extension is created best-effort instead of failing closed:\n%s", extensions)
+	}
+}
+
+// TestBootstrapImageCopiesOnlyTheStagedArtifact guards the image contents: the
+// build context is the whole service directory, which carries local
+// configuration and secrets, so a wholesale copy would bake them into the image.
+func TestBootstrapImageCopiesOnlyTheStagedArtifact(t *testing.T) {
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", testBootstrapTemplating())
+
+	if strings.Contains(dockerfile, "COPY . .") {
+		t.Fatal("bootstrap image copies the whole service directory, including local secrets")
+	}
+	for _, required := range []string{
+		"COPY bootstrap /app/bootstrap",
+		"COPY runtime-access.sql /app/runtime-access.sql",
+		`CMD ["/bin/sh", "/app/bootstrap/bootstrap.sh"]`,
+	} {
+		if !strings.Contains(dockerfile, required) {
+			t.Fatalf("bootstrap image is missing %q", required)
+		}
+	}
+}
+
+func TestBootstrapImageIsTargetArchitecturePortable(t *testing.T) {
+	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", testBootstrapTemplating())
+	for _, required := range []string{
+		"ARG TARGETARCH",
+		`architecture="${TARGETARCH:-$(apk --print-arch)}"`,
+		"x86_64) architecture=amd64",
+		"aarch64) architecture=arm64",
+		`case "${architecture}" in`,
+		"amd64) checksum=",
+		"arm64) checksum=",
+		`*) echo "unsupported target architecture: ${architecture}" >&2; exit 1 ;;`,
+		"/releases/download/" + bootstrapLock.Migrate.Version + "/migrate.linux-${architecture}.tar.gz",
+	} {
+		if !strings.Contains(dockerfile, required) {
+			t.Fatalf("bootstrap image is not target-architecture portable: missing %q", required)
+		}
+	}
+}
+
 func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	if _, err := exec.LookPath("docker"); err != nil {
 		t.Fatal(err)
 	}
 	root := t.TempDir()
-	parameters := DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		RuntimeAccessLockID:          runtimeAccessLockID,
-		ReadinessTimeoutSeconds:      defaultBootstrapReadinessSeconds,
-	}
+	parameters := testBootstrapTemplating()
 	if err := os.WriteFile(
 		filepath.Join(root, "Dockerfile"),
 		[]byte(renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)),
@@ -145,6 +268,12 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 		[]byte(renderBootstrapTemplate(t, parameters)), 0o644); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(filepath.Join(root, "bootstrap"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "bootstrap", "bootstrap.sh"), []byte("set -eu\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
 	tag := fmt.Sprintf("service-postgres-bootstrap-targetarch-test:%d", time.Now().UnixNano())
 	t.Cleanup(func() {
 		_ = exec.Command("docker", "image", "rm", tag).Run()
@@ -155,45 +284,26 @@ func TestBootstrapImageBuildsWhenDockerOmitsTargetArchitecture(t *testing.T) {
 	}
 }
 
-// TestBootstrapImageAppliesOnlyRealMigrations drives the deployed bootstrap end
-// to end against a disposable Postgres: the image must prune exactly what the
-// runtime filter hides — nothing more — and then apply every real migration,
-// whatever extension it carries.
+// TestBootstrapImageAppliesOnlyRealMigrations covers the leftovers a migrations
+// directory accumulates. An editor backup kept beside a migration parses as the
+// same version and direction as the file it shadows, so migrate rejects the
+// whole lineage as a duplicate. Staging recognizes a migration with the one
+// runtime filename definition, so a leftover never reaches the build context at
+// all — this proves it end to end, against a real database.
 func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
-	if _, err := exec.LookPath("docker"); err != nil {
-		t.Fatal(err)
-	}
-	parameters := DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		RuntimeAccessLockID:          runtimeAccessLockID,
-		WithMigration:                true,
-		MigrationFileNamePattern:     migrationFileNamePattern,
-		ReadinessTimeoutSeconds:      defaultBootstrapReadinessSeconds,
-	}
-	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)
-	// One definition of a migration filename: a prune that drifts from the
-	// runtime filter deletes files the runtime would have applied.
-	if !strings.Contains(dockerfile, migrationFileNamePattern) {
-		t.Fatalf("bootstrap prune does not use the runtime filename pattern %q", migrationFileNamePattern)
-	}
+	requireDocker(t)
+	ctx := context.Background()
 
-	root := t.TempDir()
-	if err := os.WriteFile(filepath.Join(root, "Dockerfile"), []byte(dockerfile), 0o644); err != nil {
+	builder := newBuildTestBuilder(t)
+	migrations := builder.Local("migrations")
+	if err := os.RemoveAll(migrations); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(root, "runtime-access.sql"), []byte("SELECT 1;\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(root, "bootstrap.sql"),
-		[]byte(renderBootstrapTemplate(t, parameters)), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	migrations := filepath.Join(root, "migrations")
 	if err := os.MkdirAll(migrations, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	// Version 3 deliberately uses a non-.sql extension: golang-migrate applies it,
-	// so pruning it would leave the bootstrap reporting success over an
+	// so dropping it would leave the bootstrap reporting success over an
 	// unmigrated database.
 	kept := map[string]string{
 		"1_init.up.sql":         "CREATE TABLE deployed_one (id INT PRIMARY KEY);",
@@ -216,9 +326,37 @@ func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
 		}
 	}
 	for _, name := range stray {
-		body := "CREATE TABLE stray_must_not_apply (id INT);\n"
-		if err := os.WriteFile(filepath.Join(migrations, name), []byte(body), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(migrations, name),
+			[]byte("CREATE TABLE stray_must_not_apply (id INT);\n"), 0o644); err != nil {
 			t.Fatal(err)
+		}
+	}
+
+	outputDirectory := t.TempDir()
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state := response.GetState().GetState(); state != builderv0.BuildStatus_SUCCESS {
+		t.Fatalf("build state = %v: %s", state, response.GetState().GetMessage())
+	}
+
+	entries, err := os.ReadDir(filepath.Join(outputDirectory, "bootstrap", "sources", "00-store"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var packaged []string
+	for _, entry := range entries {
+		packaged = append(packaged, entry.Name())
+	}
+	for name := range kept {
+		if !slices.Contains(packaged, name) {
+			t.Errorf("staging dropped migration %q: %v", name, packaged)
+		}
+	}
+	for _, name := range stray {
+		if slices.Contains(packaged, name) {
+			t.Errorf("staging packaged stray file %q, which blocks the whole lineage", name)
 		}
 	}
 
@@ -226,24 +364,11 @@ func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
 	t.Cleanup(func() {
 		_ = exec.Command("docker", "image", "rm", tag).Run()
 	})
-	if output, err := exec.Command("docker", "build", "--tag", tag, root).CombinedOutput(); err != nil {
+	build := exec.Command("docker", "build",
+		"--file", filepath.Join(outputDirectory, "builder", "Dockerfile"),
+		"--tag", tag, outputDirectory)
+	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("bootstrap image build failed: %v\n%s", err, output)
-	}
-
-	output, err := exec.Command("docker", "run", "--rm", tag, "ls", "-A", "/app/migrations").CombinedOutput()
-	if err != nil {
-		t.Fatalf("list packaged migrations: %v\n%s", err, output)
-	}
-	packaged := strings.Fields(string(output))
-	for name := range kept {
-		if !slices.Contains(packaged, name) {
-			t.Errorf("bootstrap image dropped migration %q: %v", name, packaged)
-		}
-	}
-	for _, name := range stray {
-		if slices.Contains(packaged, name) {
-			t.Errorf("bootstrap image packaged stray file %q, which blocks the whole lineage", name)
-		}
 	}
 
 	database := startBootstrapPostgres(t)
@@ -274,8 +399,6 @@ func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
 	}
 }
 
-// startBootstrapPostgres runs the Postgres image this repository already pins
-// for its runtime and returns the container name, ready for connections.
 func startBootstrapPostgres(t *testing.T) string {
 	t.Helper()
 	dockerfile, err := os.ReadFile("Dockerfile")
@@ -331,13 +454,9 @@ func queryBootstrapPostgres(t *testing.T, container string, query string) string
 }
 
 func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *testing.T) {
-	parameters := DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		ReadOnlyRole:                 "codefly_app_ro",
-		ReadWriteRole:                "codefly_app_rw",
-		Schemas:                      []string{"public"},
-		ReadWriteRoles:               []string{"app_tenant", "app_worker"},
-	}
+	parameters := testBootstrapTemplating()
+	parameters.Schemas = []string{"public"}
+	parameters.ReadWriteRoles = []string{"app_tenant", "app_worker"}
 
 	accessSQL := renderRuntimeAccessTemplate(t, parameters)
 	for _, forbidden := range []string{
@@ -364,12 +483,8 @@ func TestRuntimeAccessTemplateUsesDelegatedRolesAsExclusiveWriteAuthority(t *tes
 }
 
 func TestRuntimeAccessTemplatePreservesDirectWriterWithoutDelegatedRoles(t *testing.T) {
-	parameters := DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		ReadOnlyRole:                 "codefly_app_ro",
-		ReadWriteRole:                "codefly_app_rw",
-		Schemas:                      []string{"public"},
-	}
+	parameters := testBootstrapTemplating()
+	parameters.Schemas = []string{"public"}
 
 	accessSQL := renderRuntimeAccessTemplate(t, parameters)
 	for _, required := range []string{
@@ -386,6 +501,10 @@ func TestRuntimeAccessTemplatePreservesDirectWriterWithoutDelegatedRoles(t *test
 
 func renderBuilderTemplate(t *testing.T, name string, parameters DockerTemplating) string {
 	return renderTemplate(t, builderFS, name, parameters)
+}
+
+func renderStagedTemplate(t *testing.T, name string, parameters DockerTemplating) string {
+	return renderTemplate(t, bootstrapFS, name, parameters)
 }
 
 func renderRuntimeAccessTemplate(t *testing.T, parameters DockerTemplating) string {

--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -376,6 +376,11 @@ func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
 		"docker", "run", "--rm",
 		"--network", "container:"+database,
 		"--env", migrationConnectionEnvironmentKey+"=postgres://postgres:bootstrap-test@127.0.0.1:5432/postgres?sslmode=disable",
+		// The recipe renders the real runtime-access program, which reconciles
+		// the runtime roles from these; only a hand-stubbed context can omit them.
+		"--env", "POSTGRES_USER=postgres",
+		"--env", "POSTGRES_READ_ONLY_PASSWORD=read-only-secret",
+		"--env", "POSTGRES_READ_WRITE_PASSWORD=read-write-secret",
 		tag,
 	)
 	if output, err := bootstrap.CombinedOutput(); err != nil {

--- a/build_bootstrap_lock_test.go
+++ b/build_bootstrap_lock_test.go
@@ -42,7 +42,7 @@ func TestBootstrapRunsMigrationInsideRuntimeAccessLock(t *testing.T) {
 
 	// The migration must be invoked from inside the locked psql session...
 	lockAt := strings.Index(bootstrap, "pg_advisory_lock("+runtimeAccessLockSQL+")")
-	migrateAt := strings.Index(bootstrap, `/usr/local/bin/migrate -path /app/migrations`)
+	migrateAt := strings.Index(bootstrap, `/usr/local/bin/migrate -path /app/bootstrap/sources/00-store`)
 	includeAt := strings.Index(bootstrap, `\i /app/runtime-access.sql`)
 	require.NotEqual(t, -1, lockAt, "bootstrap must take the runtime-access advisory lock")
 	require.NotEqual(t, -1, migrateAt, "bootstrap must run the migration inside that session")
@@ -77,7 +77,11 @@ func TestBootstrapRunsMigrationInsideRuntimeAccessLock(t *testing.T) {
 	// INSTALLS the binary, so the assertion is on the invocation form only.
 	require.NotContains(t, dockerfile, "migrate -path",
 		"migrate must not run outside the locked psql session")
-	require.Contains(t, dockerfile, "--file=/app/bootstrap.sql")
+	// The image's CMD runs the bootstrap program, which gates on readiness and
+	// on verifying the staged sources before opening that one locked session.
+	require.Contains(t, dockerfile, `CMD ["/bin/sh", "/app/bootstrap/bootstrap.sh"]`)
+	require.Contains(t, readRendered(t, outputDirectory, "bootstrap/bootstrap.sh"),
+		"--file=/app/bootstrap.sql")
 }
 
 // TestBootstrapOmitsMigrationWhenDisabled keeps the lock unconditional while the

--- a/build_test.go
+++ b/build_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -81,8 +82,12 @@ func TestBuildRejectsUnresolvableSchemaDeclaration(t *testing.T) {
 // TestBuildDoesNotClaimSchemaItDoesNotPackage locks the other half: the build
 // validates declared sources but packages only this service's own migrations,
 // so reporting the resolved plan here would tell an operator the bootstrap
-// image carries schema it does not.
-func TestBuildDoesNotClaimSchemaItDoesNotPackage(t *testing.T) {
+// TestBuildPackagesTheSchemaItReports inverts a constraint this build used to
+// carry: it packaged only the service's own migrations, so reporting a resolved
+// plan would have claimed image content that did not exist. The build now stages
+// every resolved source, so the report is truthful — and the assertion is that
+// the sibling's migration is actually in the tree, not merely mentioned.
+func TestBuildPackagesTheSchemaItReports(t *testing.T) {
 	ctx := context.Background()
 	builder := newBuildTestBuilder(t)
 	sibling := filepath.Join(filepath.Dir(builder.Location), "api", "migrations")
@@ -96,11 +101,14 @@ func TestBuildDoesNotClaimSchemaItDoesNotPackage(t *testing.T) {
 	// against a line the level filter dropped rather than one never emitted.
 	builder.Wool.WithLoglevel(wool.DEBUG)
 
-	response, err := builder.Build(ctx, buildRequest(t.TempDir()))
+	outputDirectory := t.TempDir()
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
 	require.NoError(t, err)
 	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
-	require.False(t, sink.saw("schema prerequisites resolved"),
-		"the build reported a resolved plan for schema it does not package")
+	require.True(t, sink.saw("schema prerequisites resolved"),
+		"the build no longer reports what it resolved")
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources", "01-api", "1_init.up.sql"),
+		"the build reported a declared source it did not package")
 }
 
 func TestBuildEmitsRecipeToOutputDirectory(t *testing.T) {
@@ -126,17 +134,21 @@ func TestBuildEmitsRecipeToOutputDirectory(t *testing.T) {
 	// The rendered tree is a self-contained context: a consumer with no codefly
 	// toolchain can build it from the emitted files alone.
 	require.FileExists(t, filepath.Join(outputDirectory, "builder", "Dockerfile"))
-	require.FileExists(t, filepath.Join(outputDirectory, "migrations", "1_create_table.up.sql"))
-	require.FileExists(t, filepath.Join(outputDirectory, "migrations", "1_create_table.down.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "bootstrap.sh"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "extensions.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "plan.json"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_create_table.up.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_create_table.down.sql"))
 
-	// The CLI resolves the recipe's "." context to the service directory, so the
-	// runtime-access.sql the Dockerfile COPYs root-relative must sit at the service
-	// directory root beside the committed migrations/ — otherwise the COPY the CLI
-	// runs against that context fails to resolve.
+	// The CLI resolves the recipe's "." context to the service directory, so
+	// everything the Dockerfile COPYs root-relative must also sit at the service
+	// directory root — otherwise the COPY the CLI runs fails to resolve.
 	require.FileExists(t, filepath.Join(builder.Location, "runtime-access.sql"))
+	require.FileExists(t, filepath.Join(builder.Location, "bootstrap", "bootstrap.sh"))
+	require.FileExists(t, filepath.Join(builder.Location, "bootstrap", "sources", "00-store", "1_create_table.up.sql"))
 
-	// It is also rendered into the recipe tree (never under builder/) so the emitted
-	// artifact stays a self-contained context a consumer can build directly.
+	// runtime-access.sql is also rendered into the recipe tree (never under
+	// builder/) so the emitted artifact stays a self-contained context.
 	require.FileExists(t, filepath.Join(outputDirectory, "runtime-access.sql"))
 	require.NoFileExists(t, filepath.Join(outputDirectory, "builder", "runtime-access.sql"))
 
@@ -163,6 +175,7 @@ func TestFactoryScaffoldsGitignoreForGeneratedRuntimeAccess(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join(builder.Location, ".gitignore"))
 	require.NoError(t, err, "Create must scaffold a .gitignore at the service root")
 	require.Contains(t, string(data), "/runtime-access.sql")
+	require.Contains(t, string(data), "/bootstrap.sql")
 }
 
 func TestBuildRecipeOmitsMigrationsWhenDisabled(t *testing.T) {
@@ -175,7 +188,18 @@ func TestBuildRecipeOmitsMigrationsWhenDisabled(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
 
-	require.NoDirExists(t, filepath.Join(outputDirectory, "migrations"))
+	// Extension-only bootstrap: the artifact is still emitted and the image
+	// still reconciles runtime grants, but no lineage is staged or applied.
+	require.NoDirExists(t, filepath.Join(outputDirectory, "bootstrap", "sources"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "extensions.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "runtime-access.sql"))
+	program, err := os.ReadFile(filepath.Join(outputDirectory, "bootstrap", "bootstrap.sh"))
+	require.NoError(t, err)
+	require.NotContains(t, readRendered(t, outputDirectory, "bootstrap.sql"), "/usr/local/bin/migrate")
+	require.Contains(t, string(program), "/app/bootstrap.sql")
+
+	require.Empty(t, readPlanArtifact(t, outputDirectory).Lineages)
+
 	require.NotNil(t, response.GetResult().GetDockerBuildPlan())
 	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
 }
@@ -202,7 +226,7 @@ func TestBuildRecipePurgesPreexistingOutputDirectory(t *testing.T) {
 
 	require.NoFileExists(t, filepath.Join(outputDirectory, "stale-root.txt"))
 	require.NoFileExists(t, filepath.Join(outputDirectory, "migrations", "9_stale.up.sql"))
-	require.FileExists(t, filepath.Join(outputDirectory, "migrations", "1_create_table.up.sql"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_create_table.up.sql"))
 
 	plan := response.GetResult().GetDockerBuildPlan()
 	require.NotNil(t, plan)
@@ -212,22 +236,173 @@ func TestBuildRecipePurgesPreexistingOutputDirectory(t *testing.T) {
 	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, plan))
 }
 
-// TestBuildRecipeCreatesEmptyMigrationsDirectory covers migrations enabled with
-// none authored yet: the recipe must still carry a migrations directory so the
-// Dockerfile's COPY migrations resolves, matching the legacy in-agent build.
-func TestBuildRecipeCreatesEmptyMigrationsDirectory(t *testing.T) {
+// TestBuildRecipeTreatsOwnSourceAbsenceAndEmptinessAlike covers the two ways a
+// service can carry no own migrations. Both must bootstrap identically, and
+// neither may emit a migrate invocation: golang-migrate reports an empty source
+// as a missing first version, not as "no change", so applying one would fail the
+// bootstrap Job.
+func TestBuildRecipeTreatsOwnSourceAbsenceAndEmptinessAlike(t *testing.T) {
+	ctx := context.Background()
+	programs := map[string]string{}
+	for name, prepare := range map[string]func(*Builder){
+		"absent": func(builder *Builder) {
+			require.NoError(t, os.RemoveAll(builder.Local("migrations")))
+		},
+		"empty": func(builder *Builder) {
+			require.NoError(t, os.RemoveAll(builder.Local("migrations")))
+			require.NoError(t, os.MkdirAll(builder.Local("migrations"), 0o755))
+		},
+	} {
+		builder := newBuildTestBuilder(t)
+		prepare(builder)
+		outputDirectory := t.TempDir()
+
+		response, err := builder.Build(ctx, buildRequest(outputDirectory))
+		require.NoError(t, err)
+		require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+		program, err := os.ReadFile(filepath.Join(outputDirectory, "bootstrap", "bootstrap.sh"))
+		require.NoError(t, err)
+		require.NotContains(t, readRendered(t, outputDirectory, "bootstrap.sql"), "/usr/local/bin/migrate", name)
+		require.Contains(t, string(program), "/app/bootstrap.sql", name)
+		require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
+		require.Empty(t, readPlanArtifact(t, outputDirectory).Lineages, name)
+		programs[name] = string(program)
+	}
+	require.Equal(t, programs["absent"], programs["empty"],
+		"an absent and an empty own migrations directory must bootstrap identically")
+}
+
+// TestBuildStagesSiblingSourcesIntoTheBuildContext is the packaging half of the
+// local multi-source contract: a service whose tables come from sibling
+// directories must ship those bytes, since a Dockerfile COPY cannot reach
+// outside its context.
+func TestBuildStagesSiblingSourcesIntoTheBuildContext(t *testing.T) {
 	ctx := context.Background()
 	builder := newBuildTestBuilder(t)
-	require.NoError(t, os.RemoveAll(builder.Local("migrations")))
-	require.NoError(t, os.MkdirAll(builder.Local("migrations"), 0o755))
+	writeMigration(t, filepath.Join(filepath.Dir(builder.Location), "api", "migrations"), "1_api.up.sql")
+	writeMigration(t, filepath.Join(filepath.Dir(builder.Location), "billing", "migrations"), "1_billing.up.sql")
+	builder.Settings.MigrationSources = []MigrationSource{{Name: "api"}, {Name: "billing"}}
 	outputDirectory := t.TempDir()
 
 	response, err := builder.Build(ctx, buildRequest(outputDirectory))
 	require.NoError(t, err)
 	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
 
-	require.DirExists(t, filepath.Join(outputDirectory, "migrations"))
+	for _, contextRoot := range []string{builder.Location, outputDirectory} {
+		require.FileExists(t, filepath.Join(contextRoot, "bootstrap", "sources", "00-store", "1_create_table.up.sql"))
+		require.FileExists(t, filepath.Join(contextRoot, "bootstrap", "sources", "01-api", "1_api.up.sql"))
+		require.FileExists(t, filepath.Join(contextRoot, "bootstrap", "sources", "02-billing", "1_billing.up.sql"))
+	}
+
+	// The migrate invocations live in the locked psql session, one per lineage.
+	bootstrapSQL := readRendered(t, outputDirectory, "bootstrap.sql")
+	require.Contains(t, bootstrapSQL, `-path /app/bootstrap/sources/01-api`)
+	require.Contains(t, bootstrapSQL, `x-migrations-table=schema_migrations_api`)
+	require.Contains(t, bootstrapSQL, `-path /app/bootstrap/sources/02-billing`)
+	require.Contains(t, bootstrapSQL, `x-migrations-table=schema_migrations_billing`)
+
+	artifact := readPlanArtifact(t, outputDirectory)
+	require.Len(t, artifact.Lineages, 3)
+	require.Equal(t,
+		[]string{"schema_migrations", "schema_migrations_api", "schema_migrations_billing"},
+		[]string{artifact.Lineages[0].Ledger, artifact.Lineages[1].Ledger, artifact.Lineages[2].Ledger})
+	// The artifact must stay machine-independent so its digest is reproducible.
+	require.NotContains(t, string(mustReadFile(t, filepath.Join(outputDirectory, "bootstrap", "plan.json"))), builder.Location)
+
 	require.NoError(t, services.VerifyDockerBuildPlan(outputDirectory, response.GetResult().GetDockerBuildPlan()))
+}
+
+// TestBuildRejectsUnresolvedDeclaredSource covers the required-declaration rule:
+// local development tolerates a sibling that has not shipped migrations yet, but
+// a build that cannot stage the bytes must fail rather than emit an image that
+// silently leaves those tables out.
+func TestBuildRejectsUnresolvedDeclaredSource(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	builder.Settings.MigrationSources = []MigrationSource{{Name: "api"}}
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_ERROR, response.GetState().GetState())
+	require.Contains(t, response.GetState().GetMessage(), "api")
+}
+
+// TestBuildPlanDigestTracksMigrationContent proves the emitted evidence follows
+// the bytes: mutating one migration changes the plan digest, the staged content,
+// and the recipe digest the Job identity is derived from.
+func TestBuildPlanDigestTracksMigrationContent(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+	before := readPlanArtifact(t, outputDirectory)
+	recipeDigestBefore := response.GetResult().GetDockerBuildPlan().GetDigest()
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(builder.Location, "migrations", "1_create_table.up.sql"),
+		[]byte("CREATE TABLE example (id UUID PRIMARY KEY);\n"), 0o644))
+
+	response, err = builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+	after := readPlanArtifact(t, outputDirectory)
+
+	require.NotEqual(t, before.Digest, after.Digest)
+	require.NotEqual(t, before.Lineages[0].Files[1].Digest, after.Lineages[0].Files[1].Digest)
+	require.NotEqual(t, recipeDigestBefore, response.GetResult().GetDockerBuildPlan().GetDigest())
+	require.Contains(t,
+		string(mustReadFile(t, filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_create_table.up.sql"))),
+		"id UUID PRIMARY KEY")
+}
+
+// TestBuildRecipeCarriesNoSecrets guards the emitted artifact and the image
+// contents: the build context is the whole service directory, which holds the
+// generated local secret file every scaffolded service carries.
+func TestBuildRecipeCarriesNoSecrets(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	secretDirectory := filepath.Join(builder.Location, "configurations", "local")
+	require.NoError(t, os.MkdirAll(secretDirectory, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(secretDirectory, "postgres.secret.env"),
+		[]byte("POSTGRES_PASSWORD=super-secret\n"), 0o600))
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	require.NoError(t, filepath.WalkDir(outputDirectory, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() {
+			return walkErr
+		}
+		require.NotContains(t, string(mustReadFile(t, path)), "super-secret", path)
+		return nil
+	}))
+
+	dockerfile := string(mustReadFile(t, filepath.Join(outputDirectory, "builder", "Dockerfile")))
+	require.NotContains(t, dockerfile, "COPY . .",
+		"a wholesale copy would bake the service directory's local secrets into the image")
+}
+
+func readPlanArtifact(t *testing.T, contextRoot string) schemaPlanArtifact {
+	t.Helper()
+	var artifact schemaPlanArtifact
+	require.NoError(t, json.Unmarshal(mustReadFile(t, filepath.Join(contextRoot, "bootstrap", "plan.json")), &artifact))
+	require.Equal(t, schemaPlanContractVersion, artifact.ContractVersion)
+	return artifact
+}
+
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	return content
 }
 
 // TestBuildRecipeLocksBootstrapInputs covers the recipe a consumer builds without

--- a/build_test.go
+++ b/build_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/codefly-dev/core/agents/services"
@@ -137,6 +139,9 @@ func TestBuildEmitsRecipeToOutputDirectory(t *testing.T) {
 	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "bootstrap.sh"))
 	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "extensions.sql"))
 	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "plan.json"))
+	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources.sha256"))
+	require.Equal(t, "bootstrap/dockerignore", recipe.GetDockerignore(),
+		"the build context is the service directory, so the recipe must declare an ignore that keeps local secrets out of it")
 	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_create_table.up.sql"))
 	require.FileExists(t, filepath.Join(outputDirectory, "bootstrap", "sources", "00-store", "1_create_table.down.sql"))
 
@@ -403,6 +408,145 @@ func mustReadFile(t *testing.T, path string) []byte {
 	content, err := os.ReadFile(path)
 	require.NoError(t, err)
 	return content
+}
+
+// TestBuildRefusesToReplaceAForeignBootstrapDirectory covers the staging root
+// living in the user's service directory: "bootstrap" is a plausible name for
+// hand-authored seed SQL, and staging deletes the directory it claims.
+func TestBuildRefusesToReplaceAForeignBootstrapDirectory(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	handAuthored := filepath.Join(builder.Location, "bootstrap", "seed.sql")
+	require.NoError(t, os.MkdirAll(filepath.Dir(handAuthored), 0o755))
+	require.NoError(t, os.WriteFile(handAuthored, []byte("INSERT INTO example VALUES (1);\n"), 0o644))
+
+	response, err := builder.Build(ctx, buildRequest(t.TempDir()))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_ERROR, response.GetState().GetState())
+	require.FileExists(t, handAuthored, "the build destroyed a directory it did not generate")
+
+	// A directory the agent generated is replaced without complaint.
+	require.NoError(t, os.RemoveAll(filepath.Join(builder.Location, "bootstrap")))
+	response, err = builder.Build(ctx, buildRequest(t.TempDir()))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+	response, err = builder.Build(ctx, buildRequest(t.TempDir()))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+}
+
+// TestBuildStagesTreeThatGitIgnoresItself covers services that already exist:
+// they never re-render the factory .gitignore, so the staged tree — which is
+// regenerated every build and holds copies of sibling migrations — has to carry
+// its own ignore rule or it gets committed as a second source of truth.
+func TestBuildStagesTreeThatGitIgnoresItself(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+
+	response, err := builder.Build(ctx, buildRequest(t.TempDir()))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	ignore := string(mustReadFile(t, filepath.Join(builder.Location, "bootstrap", ".gitignore")))
+	require.Contains(t, ignore, "*")
+	require.Contains(t, ignore, "codefly-generated postgres bootstrap")
+}
+
+// TestBuildStagesModesIndependentOfUmask covers two failures with one cause: the
+// recipe digest covers each file's mode, so a umask would otherwise make the
+// published digest machine-dependent, and the bootstrap Job reads this tree as
+// uid 65534, which cannot read a 0600 root-owned file.
+func TestBuildStagesModesIndependentOfUmask(t *testing.T) {
+	ctx := context.Background()
+	previous := syscall.Umask(0o077)
+	builder := newBuildTestBuilder(t)
+	outputDirectory := t.TempDir()
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	syscall.Umask(previous)
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	require.NoError(t, filepath.WalkDir(filepath.Join(outputDirectory, "bootstrap"), func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		info, infoErr := entry.Info()
+		require.NoError(t, infoErr)
+		expected := os.FileMode(0o644)
+		if entry.IsDir() {
+			expected = 0o755
+		}
+		require.Equal(t, expected, info.Mode().Perm(), path)
+		return nil
+	}))
+	runtimeAccess, err := os.Stat(filepath.Join(outputDirectory, "runtime-access.sql"))
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o644), runtimeAccess.Mode().Perm())
+}
+
+// TestBuildArtifactIsIdenticalAcrossCheckouts covers the published identity: two
+// machines building one commit must emit the same plan and the same recipe
+// digest, or every deploy from a different machine churns the bootstrap Job.
+// An absolutely declared source is the case that breaks it.
+func TestBuildArtifactIsIdenticalAcrossCheckouts(t *testing.T) {
+	ctx := context.Background()
+	emit := func() (string, string) {
+		t.Helper()
+		builder := newBuildTestBuilder(t)
+		external := filepath.Join(t.TempDir(), "external", "migrations")
+		writeMigration(t, external, "1_external.up.sql")
+		builder.Settings.MigrationSources = []MigrationSource{{Name: "external", Path: external}}
+		outputDirectory := t.TempDir()
+		response, err := builder.Build(ctx, buildRequest(outputDirectory))
+		require.NoError(t, err)
+		require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+		return string(mustReadFile(t, filepath.Join(outputDirectory, "bootstrap", "plan.json"))),
+			response.GetResult().GetDockerBuildPlan().GetDigest()
+	}
+
+	firstPlan, firstDigest := emit()
+	secondPlan, secondDigest := emit()
+	require.Equal(t, firstPlan, secondPlan, "the published plan carries the emitting machine's paths")
+	require.Equal(t, firstDigest, secondDigest, "the recipe digest depends on where the sources happen to live")
+	require.NotContains(t, firstPlan, t.TempDir())
+	require.NotContains(t, firstPlan, "declared-path")
+}
+
+// TestBuildChecksumManifestCoversEveryStagedSource is what makes a drifted or
+// partly written context loud: the bootstrap program verifies this manifest
+// before it applies anything.
+func TestBuildChecksumManifestCoversEveryStagedSource(t *testing.T) {
+	ctx := context.Background()
+	builder := newBuildTestBuilder(t)
+	writeMigration(t, filepath.Join(filepath.Dir(builder.Location), "api", "migrations"), "1_api.up.sql")
+	builder.Settings.MigrationSources = []MigrationSource{{Name: "api"}}
+	outputDirectory := t.TempDir()
+
+	response, err := builder.Build(ctx, buildRequest(outputDirectory))
+	require.NoError(t, err)
+	require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+
+	manifest := string(mustReadFile(t, filepath.Join(outputDirectory, "bootstrap", "sources.sha256")))
+	for _, staged := range []string{
+		"sources/00-store/1_create_table.up.sql",
+		"sources/00-store/1_create_table.down.sql",
+		"sources/01-api/1_api.up.sql",
+	} {
+		require.Contains(t, manifest, staged)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(manifest), "\n") {
+		digest, path, found := strings.Cut(line, "  ")
+		require.True(t, found, line)
+		require.Len(t, digest, 64, "sha256sum -c expects a bare hex digest")
+		require.Equal(t, "sha256:"+digest, mustFileDigest(t, filepath.Join(outputDirectory, "bootstrap", path)))
+	}
+}
+
+func mustFileDigest(t *testing.T, path string) string {
+	t.Helper()
+	digest, err := fileDigest(path)
+	require.NoError(t, err)
+	return digest
 }
 
 // TestBuildRecipeLocksBootstrapInputs covers the recipe a consumer builds without

--- a/builder.go
+++ b/builder.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"embed"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io/fs"
 	"os"
@@ -26,6 +27,11 @@ import (
 	"github.com/codefly-dev/core/shared"
 	"gopkg.in/yaml.v3"
 )
+
+// bootstrapDirectory is the agent-owned staging root written into the build
+// context. It carries the generated bootstrap program, the plan identity, and
+// one immutable copy of every packaged migration source.
+const bootstrapDirectory = "bootstrap"
 
 type Builder struct {
 	services.BuilderServer
@@ -103,21 +109,24 @@ func (s *Builder) Upgrade(ctx context.Context, req *builderv0.UpgradeRequest) (*
 	return s.Builder.UpgradeResponse(res.Changes, res.LockfileDiff)
 }
 
+// DockerTemplating renders the bootstrap image: the Dockerfile, the generated
+// bootstrap program, and the SQL it applies. Every field is derived from the
+// schema plan, so the image can only carry what the plan declares.
 type DockerTemplating struct {
-	MigrationConnectionKeyHolder string
+	MigrationConnectionEnvironment string
 	// RuntimeAccessLockID is the advisory-lock expression the bootstrap script
 	// takes, shared verbatim with the agent so the two cannot drift apart.
-	RuntimeAccessLockID      string
-	WithMigration            bool
-	MigrationFileNamePattern string // rendered so the image prunes exactly what the runtime filter hides
-	ReadinessTimeoutSeconds  int
-	ReadOnlyRole             string
-	ReadWriteRole            string
-	Schemas                  []string
-	ReadWriteRoles           []string
+	RuntimeAccessLockID     string
+	ReadinessTimeoutSeconds int
+	ReadOnlyRole            string
+	ReadWriteRole           string
+	Schemas                 []string
+	ReadWriteRoles          []string
 	// DefaultReadWriteRole is the application role the managed read-write login
 	// selects on connect. See defaultRuntimeReadWriteRole.
 	DefaultReadWriteRole string
+	Extensions           []BootstrapExtension
+	Lineages             []BootstrapLineage
 }
 
 // Bootstrap resolves the locked bootstrap inputs the Dockerfile renders from. A
@@ -127,8 +136,42 @@ func (DockerTemplating) Bootstrap() *bootstrapImageLock {
 	return bootstrapLock
 }
 
-func (s *Builder) WithMigration() bool {
-	return !s.Settings.NoMigration
+// BootstrapLineage is one migration lineage as the generated bootstrap program
+// sees it: the staged directory inside the image and the ledger it owns.
+type BootstrapLineage struct {
+	Label  string
+	Stage  string
+	Ledger string
+}
+
+// bootstrapLineages projects the plan's lineages onto the staged layout the
+// image carries, in declared order.
+func bootstrapLineages(plan *schemaPlan) []BootstrapLineage {
+	lineages := make([]BootstrapLineage, 0, len(plan.lineages))
+	for _, lineage := range plan.lineages {
+		lineages = append(lineages, BootstrapLineage{
+			Label:  lineage.label(),
+			Stage:  lineage.stage,
+			Ledger: lineage.trackingTable(),
+		})
+	}
+	return lineages
+}
+
+// BootstrapExtension is one extension as the generated SQL sees it. A required
+// extension aborts the bootstrap when it cannot be created, exactly as it fails
+// the local runtime's readiness; an optional one is reported and skipped.
+type BootstrapExtension struct {
+	Name     string
+	Required bool
+}
+
+func bootstrapExtensions(plan *schemaPlan) []BootstrapExtension {
+	extensions := make([]BootstrapExtension, 0, len(plan.extensions))
+	for _, extension := range plan.extensions {
+		extensions = append(extensions, BootstrapExtension{Name: extension.name, Required: extension.required})
+	}
+	return extensions
 }
 
 func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*builderv0.BuildResponse, error) {
@@ -149,42 +192,41 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 		return s.Builder.BuildError(fmt.Errorf("invalid docker image name: %s", img.Name))
 	}
 
-	readOnlyRole, readWriteRole := runtimeRoleNames(s.DatabaseName)
-	schemas, err := normalizedRuntimeSchemas(s.RuntimeSchemas)
-	if err != nil {
-		return s.Builder.BuildError(err)
-	}
-	readWriteRoles, err := normalizedRuntimeReadWriteRoles(s.RuntimeReadWriteRoles, readOnlyRole, readWriteRole)
+	// The declared schema prerequisites are resolved here as well as at runtime,
+	// so a typo'd source path or a colliding lineage fails the build instead of
+	// producing a bootstrap image that quietly ships an incomplete schema. The
+	// build then packages exactly what that resolution returned, so the image
+	// applies the same lineages and extensions the runtime does.
+	prerequisites, err := s.resolveSchemaPrerequisites()
 	if err != nil {
 		return s.Builder.BuildError(err)
 	}
 	if err = s.Settings.Timeouts.validate(); err != nil {
 		return s.Builder.BuildError(err)
 	}
-	// The declared schema prerequisites are validated here as well as at runtime,
-	// so a typo'd source path or a colliding lineage fails the build instead of
-	// producing a bootstrap image that quietly ships an incomplete schema. The
-	// resolved plan is deliberately not reported here: this build packages only
-	// this service's own migrations, so listing the declared sources would claim
-	// an image content that does not exist.
-	if _, err := s.resolveSchemaPrerequisites(); err != nil {
+	plan, err := buildSchemaPlan(prerequisites, s.Settings)
+	if err != nil {
 		return s.Builder.BuildError(err)
 	}
+	if err = plan.attest(); err != nil {
+		return s.Builder.BuildError(err)
+	}
+	s.reportSchemaPrerequisites(prerequisites)
 	docker := DockerTemplating{
-		MigrationConnectionKeyHolder: fmt.Sprintf("{%s}", migrationConnectionEnvironmentKey),
-		RuntimeAccessLockID:          runtimeAccessLockID,
-		WithMigration:                s.WithMigration(),
-		MigrationFileNamePattern:     migrationFileNamePattern,
-		ReadinessTimeoutSeconds:      s.Settings.Timeouts.BootstrapReadinessSeconds(),
-		ReadOnlyRole:                 readOnlyRole,
-		ReadWriteRole:                readWriteRole,
-		Schemas:                      schemas,
-		ReadWriteRoles:               readWriteRoles,
-		DefaultReadWriteRole:         defaultRuntimeReadWriteRole(readWriteRoles),
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
+		RuntimeAccessLockID:            runtimeAccessLockID,
+		ReadinessTimeoutSeconds:        s.Settings.Timeouts.BootstrapReadinessSeconds(),
+		ReadOnlyRole:                   plan.access.readOnlyRole,
+		ReadWriteRole:                  plan.access.readWriteRole,
+		Schemas:                        plan.access.schemas,
+		ReadWriteRoles:                 plan.access.readWriteRoles,
+		DefaultReadWriteRole:           defaultRuntimeReadWriteRole(plan.access.readWriteRoles),
+		Extensions:                     bootstrapExtensions(plan),
+		Lineages:                       bootstrapLineages(plan),
 	}
 
 	if outputDirectory := req.GetOutputDirectory(); outputDirectory != "" {
-		return s.buildRecipe(ctx, outputDirectory, img, docker)
+		return s.buildRecipe(ctx, outputDirectory, img, plan, docker)
 	}
 
 	err = shared.DeleteFile(ctx, s.Local("builder/Dockerfile"))
@@ -197,7 +239,7 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 		return s.Builder.BuildError(err)
 	}
 
-	if err = s.renderRuntimeAccess(ctx, docker, s.Location); err != nil {
+	if err = s.stageBootstrapContext(ctx, plan, docker, s.Location); err != nil {
 		return s.Builder.BuildError(err)
 	}
 
@@ -220,19 +262,27 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 	return s.Builder.BuildResponse()
 }
 
-// buildRecipe renders the bootstrap image's Dockerfile into the caller-owned
-// output directory and returns a reproducible build plan instead of running
-// docker itself. The CLI builds the emitted recipe multi-arch and pushes a
-// manifest list, so a consumer can rebuild the image without the agent toolchain.
-// The CLI resolves the recipe's "." context to the service directory (s.Location),
-// not the recipe tree, so the files the Dockerfile COPYs must be staged there:
-// migrations/ is already committed and runtime-access.sql is rendered in below.
-// They are mirrored into the recipe tree so it also builds standalone.
-func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *resources.DockerImage, docker DockerTemplating) (*builderv0.BuildResponse, error) {
-	// The plan inventories the whole output directory and the recipe context is
-	// its root, so any pre-existing content the caller left here would be
-	// digested into the plan and copied into the image. Empty the directory the
-	// agent fully owns before rendering, as the deployment emitter does.
+// buildRecipe renders the bootstrap image's recipe into the caller-owned output
+// directory and returns a reproducible build plan instead of running docker
+// itself. The CLI builds the emitted recipe multi-arch and pushes a manifest
+// list, so a consumer can rebuild the image without the agent toolchain.
+// The CLI resolves the recipe's "." context to the service directory
+// (s.Location), not the recipe tree, so the bootstrap tree the Dockerfile COPYs
+// is staged into both: into the service directory for the build the CLI runs,
+// and into the recipe tree so the emitted artifact is a self-contained context
+// a consumer can build directly. Both stagings write identical bytes.
+func (s *Builder) buildRecipe(
+	ctx context.Context,
+	outputDirectory string,
+	img *resources.DockerImage,
+	plan *schemaPlan,
+	docker DockerTemplating,
+) (*builderv0.BuildResponse, error) {
+	// The build plan inventories the whole output directory and the recipe
+	// context is its root, so any pre-existing content the caller left here
+	// would be digested into the plan and copied into the image. Empty the
+	// directory the agent fully owns before rendering, as the deployment
+	// emitter does.
 	if err := shared.EmptyDir(ctx, outputDirectory); err != nil {
 		return s.Builder.BuildError(err)
 	}
@@ -241,33 +291,13 @@ func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *
 		return s.Builder.BuildError(err)
 	}
 
-	// The Dockerfile COPYs runtime-access.sql from the build context root. The CLI
-	// resolves the recipe's "." context to the service directory (s.Location) — not
-	// to the recipe tree — so render it there, beside the already-committed
-	// migrations/, for the build the CLI runs to resolve the COPY. Also render it
-	// into the recipe tree so the emitted artifact stays a self-contained context a
-	// consumer can build directly, mirroring how migrations/ lives in both places.
-	if err := s.renderRuntimeAccess(ctx, docker, s.Location); err != nil {
-		return s.Builder.BuildError(err)
-	}
-	if err := s.renderRuntimeAccess(ctx, docker, outputDirectory); err != nil {
-		return s.Builder.BuildError(err)
-	}
-
-	if s.WithMigration() {
-		// The Dockerfile's COPY migrations needs the directory to exist even when
-		// no migrations are authored yet, so create it before copying rather than
-		// letting copyTree leave it absent for an empty source.
-		migrationsDirectory := filepath.Join(outputDirectory, "migrations")
-		if err := os.MkdirAll(migrationsDirectory, 0o755); err != nil {
-			return s.Builder.BuildError(err)
-		}
-		if err := copyTree(ctx, s.Local("migrations"), migrationsDirectory); err != nil {
+	for _, contextRoot := range []string{s.Location, outputDirectory} {
+		if err := s.stageBootstrapContext(ctx, plan, docker, contextRoot); err != nil {
 			return s.Builder.BuildError(err)
 		}
 	}
 
-	plan, err := services.BuildDockerBuildPlan(outputDirectory, []*builderv0.DockerBuildRecipe{{
+	buildPlan, err := services.BuildDockerBuildPlan(outputDirectory, []*builderv0.DockerBuildRecipe{{
 		Name:       "bootstrap",
 		Dockerfile: "builder/Dockerfile",
 		Context:    ".",
@@ -282,34 +312,75 @@ func (s *Builder) buildRecipe(ctx context.Context, outputDirectory string, img *
 		return s.Builder.BuildError(err)
 	}
 
-	s.Builder.WithBuildPlan(plan)
+	s.Builder.WithBuildPlan(buildPlan)
 	return s.Builder.BuildResponse()
+}
+
+// stageBootstrapContext writes the complete bootstrap artifact into a build
+// context root: the generated bootstrap program and SQL, the plan identity, and
+// one immutable copy of every resolved migration source under its own staged
+// directory. Sibling sources live outside the build context, so staging is what
+// makes them reachable at all — a Dockerfile COPY cannot leave its context.
+func (s *Builder) stageBootstrapContext(
+	ctx context.Context,
+	plan *schemaPlan,
+	docker DockerTemplating,
+	contextRoot string,
+) error {
+	root := filepath.Join(contextRoot, bootstrapDirectory)
+	// A source removed from the settings must disappear from the image, so the
+	// agent-owned staging root is rebuilt rather than merged into.
+	if err := os.RemoveAll(root); err != nil {
+		return err
+	}
+	if err := s.Templates(ctx, docker, services.WithTemplate(bootstrapFS, "bootstrap", "").WithDestination("%s", root)); err != nil {
+		return err
+	}
+	// Every resolved lineage is staged, including one that carries no migration
+	// yet, so the plan artifact's staged paths always describe real directories.
+	for _, lineage := range plan.lineages {
+		if err := stageLineage(ctx, lineage, filepath.Join(root, "sources", lineage.stage)); err != nil {
+			return fmt.Errorf("stage migration source %q: %w", lineage.label(), err)
+		}
+	}
+	artifact, err := json.MarshalIndent(plan.artifact(), "", "  ")
+	if err != nil {
+		return err
+	}
+	if err = os.WriteFile(filepath.Join(root, "plan.json"), append(artifact, '\n'), 0o644); err != nil {
+		return err
+	}
+	return s.renderRuntimeAccess(ctx, docker, contextRoot)
+}
+
+// stageLineage copies one lineage's inventoried files into its staged directory
+// and re-checks each digest, so the plan artifact describes exactly the bytes
+// the image carries even if a file changed while the build was running.
+func stageLineage(ctx context.Context, lineage schemaLineage, destination string) error {
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		return err
+	}
+	for _, file := range lineage.files {
+		staged := filepath.Join(destination, file.name)
+		if err := shared.CopyFile(ctx, filepath.Join(lineage.dir, file.name), staged); err != nil {
+			return err
+		}
+		digest, err := fileDigest(staged)
+		if err != nil {
+			return err
+		}
+		if digest != file.digest {
+			return fmt.Errorf("%s changed while it was being staged", file.name)
+		}
+	}
+	return nil
 }
 
 // renderRuntimeAccess renders runtime-access.sql into the build context root, the
 // directory docker builds from. The Dockerfile COPYs it from there, so it must
-// sit beside migrations/ rather than under builder/.
+// sit beside the staged bootstrap tree rather than under builder/.
 func (s *Builder) renderRuntimeAccess(ctx context.Context, docker DockerTemplating, contextRoot string) error {
 	return s.Templates(ctx, docker, services.WithTemplate(runtimeFS, "runtime", "").WithDestination("%s", contextRoot))
-}
-
-// copyTree copies every regular file under from into to, preserving the relative
-// layout. Directory entries themselves are not created here; the caller
-// provisions any directory a build step requires to exist.
-func copyTree(ctx context.Context, from, to string) error {
-	return filepath.WalkDir(from, func(entryPath string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if entry.IsDir() {
-			return nil
-		}
-		relative, err := filepath.Rel(from, entryPath)
-		if err != nil {
-			return err
-		}
-		return shared.CopyFile(ctx, entryPath, filepath.Join(to, relative))
-	})
 }
 
 func (s *Builder) Deploy(ctx context.Context, req *builderv0.DeploymentRequest) (*builderv0.DeploymentResponse, error) {
@@ -596,6 +667,9 @@ var factoryFS embed.FS
 
 //go:embed templates/builder
 var builderFS embed.FS
+
+//go:embed templates/bootstrap
+var bootstrapFS embed.FS
 
 //go:embed templates/runtime
 var runtimeFS embed.FS

--- a/builder.go
+++ b/builder.go
@@ -28,10 +28,31 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// bootstrapDirectory is the agent-owned staging root written into the build
-// context. It carries the generated bootstrap program, the plan identity, and
-// one immutable copy of every packaged migration source.
-const bootstrapDirectory = "bootstrap"
+const (
+	// bootstrapDirectory is the agent-owned staging root written into the build
+	// context. It carries the generated bootstrap program, the plan identity, and
+	// one immutable copy of every packaged migration source.
+	bootstrapDirectory = "bootstrap"
+	// stagedChecksumFile is the sha256sum manifest the bootstrap program verifies
+	// before it applies anything.
+	stagedChecksumFile = "sources.sha256"
+	// bootstrapMarkerFile doubles as the staged tree's git ignore rule: the
+	// directory is regenerated on every build, so it must never be committed,
+	// and existing services get that for free without editing their own
+	// .gitignore.
+	bootstrapMarkerFile = ".gitignore"
+	// bootstrapMarker identifies a bootstrap directory this agent generated and
+	// may therefore replace.
+	bootstrapMarker = "# codefly-generated postgres bootstrap"
+	// runtimeAccessFile is rendered at the build context root, beside the staged
+	// bootstrap tree, because the Dockerfile COPYs it root-relative.
+	runtimeAccessFile = "runtime-access.sql"
+	// bootstrapIgnoreFile keeps the build context down to what the image
+	// actually copies. The context is the whole service directory, which carries
+	// local configuration and secrets, and a context is transferred to the
+	// daemon and cached whether or not the Dockerfile copies from it.
+	bootstrapIgnoreFile = "dockerignore"
+)
 
 type Builder struct {
 	services.BuilderServer
@@ -246,6 +267,7 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 	builder, err := dockerhelpers.NewBuilder(dockerhelpers.BuilderConfiguration{
 		Root:        s.Location,
 		Dockerfile:  "builder/Dockerfile",
+		Ignorefile:  bootstrapDirectory + "/" + bootstrapIgnoreFile,
 		Destination: img,
 		Output:      s.Wool,
 	})
@@ -298,11 +320,12 @@ func (s *Builder) buildRecipe(
 	}
 
 	buildPlan, err := services.BuildDockerBuildPlan(outputDirectory, []*builderv0.DockerBuildRecipe{{
-		Name:       "bootstrap",
-		Dockerfile: "builder/Dockerfile",
-		Context:    ".",
-		Image:      img.FullName(),
-		Platforms:  bootstrapRecipePlatforms(),
+		Name:         "bootstrap",
+		Dockerfile:   "builder/Dockerfile",
+		Context:      ".",
+		Dockerignore: bootstrapDirectory + "/" + bootstrapIgnoreFile,
+		Image:        img.FullName(),
+		Platforms:    bootstrapRecipePlatforms(),
 		// The recipe carries the resolved bootstrap inputs it was rendered from, so a
 		// consumer reads the base, package and migrate identities off the plan
 		// instead of re-resolving them.
@@ -317,10 +340,15 @@ func (s *Builder) buildRecipe(
 }
 
 // stageBootstrapContext writes the complete bootstrap artifact into a build
-// context root: the generated bootstrap program and SQL, the plan identity, and
-// one immutable copy of every resolved migration source under its own staged
-// directory. Sibling sources live outside the build context, so staging is what
-// makes them reachable at all — a Dockerfile COPY cannot leave its context.
+// context root: the generated bootstrap program and SQL, the plan identity, the
+// checksum manifest, and one immutable copy of every resolved migration source
+// under its own staged directory. Sibling sources live outside the build
+// context, so staging is what makes them reachable at all — a Dockerfile COPY
+// cannot leave its context.
+//
+// The tree is built beside its destination and swapped in, never mutated in
+// place. The image is built later by a separate process reading this same
+// directory, so a reader must never observe a half-written tree.
 func (s *Builder) stageBootstrapContext(
 	ctx context.Context,
 	plan *schemaPlan,
@@ -328,18 +356,22 @@ func (s *Builder) stageBootstrapContext(
 	contextRoot string,
 ) error {
 	root := filepath.Join(contextRoot, bootstrapDirectory)
-	// A source removed from the settings must disappear from the image, so the
-	// agent-owned staging root is rebuilt rather than merged into.
-	if err := os.RemoveAll(root); err != nil {
+	if err := assertBootstrapDirectoryIsAgentOwned(root); err != nil {
 		return err
 	}
-	if err := s.Templates(ctx, docker, services.WithTemplate(bootstrapFS, "bootstrap", "").WithDestination("%s", root)); err != nil {
+	staging, err := os.MkdirTemp(contextRoot, ".bootstrap-staging-")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.RemoveAll(staging) }()
+
+	if err = s.Templates(ctx, docker, services.WithTemplate(bootstrapFS, "bootstrap", "").WithDestination("%s", staging)); err != nil {
 		return err
 	}
 	// Every resolved lineage is staged, including one that carries no migration
 	// yet, so the plan artifact's staged paths always describe real directories.
 	for _, lineage := range plan.lineages {
-		if err := stageLineage(ctx, lineage, filepath.Join(root, "sources", lineage.stage)); err != nil {
+		if err = stageLineage(ctx, lineage, filepath.Join(staging, "sources", lineage.stage)); err != nil {
 			return fmt.Errorf("stage migration source %q: %w", lineage.label(), err)
 		}
 	}
@@ -347,15 +379,69 @@ func (s *Builder) stageBootstrapContext(
 	if err != nil {
 		return err
 	}
-	if err = os.WriteFile(filepath.Join(root, "plan.json"), append(artifact, '\n'), 0o644); err != nil {
+	if err = os.WriteFile(filepath.Join(staging, "plan.json"), append(artifact, '\n'), 0o644); err != nil {
 		return err
 	}
-	return s.renderRuntimeAccess(ctx, docker, contextRoot)
+	if err = os.WriteFile(filepath.Join(staging, stagedChecksumFile), plan.stagedChecksums(), 0o644); err != nil {
+		return err
+	}
+	// The recipe digest covers each file's mode and the bootstrap Job reads this
+	// tree as a non-root user, so the emitting machine's umask must not decide
+	// either the published digest or whether the Job can read its own program.
+	if err = normalizeStagedModes(staging); err != nil {
+		return err
+	}
+
+	if err = os.RemoveAll(root); err != nil {
+		return err
+	}
+	if err = os.Rename(staging, root); err != nil {
+		return err
+	}
+	if err = s.renderRuntimeAccess(ctx, docker, contextRoot); err != nil {
+		return err
+	}
+	return os.Chmod(filepath.Join(contextRoot, runtimeAccessFile), 0o644)
+}
+
+// assertBootstrapDirectoryIsAgentOwned refuses to replace a bootstrap directory
+// the agent did not write. The staging root sits in the user's service
+// directory, where "bootstrap" is a plausible name for hand-authored seed SQL,
+// and staging deletes the directory it claims — so a directory without the
+// agent's marker fails the build instead of being destroyed.
+func assertBootstrapDirectoryIsAgentOwned(root string) error {
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	marker, err := os.ReadFile(filepath.Join(root, bootstrapMarkerFile))
+	if err == nil && strings.HasPrefix(string(marker), bootstrapMarker) {
+		return nil
+	}
+	return fmt.Errorf(
+		"%s already exists and was not generated by codefly; move it aside — the postgres build owns that directory and regenerates it on every build",
+		root)
+}
+
+// normalizeStagedModes gives every staged file and directory a fixed mode.
+func normalizeStagedModes(root string) error {
+	return filepath.WalkDir(root, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, 0o755)
+		}
+		return os.Chmod(path, 0o644)
+	})
 }
 
 // stageLineage copies one lineage's inventoried files into its staged directory
-// and re-checks each digest, so the plan artifact describes exactly the bytes
-// the image carries even if a file changed while the build was running.
+// and re-checks each digest, so the plan artifact and the checksum manifest
+// describe exactly the bytes the image carries even if a file changed while the
+// build was running.
 func stageLineage(ctx context.Context, lineage schemaLineage, destination string) error {
 	if err := os.MkdirAll(destination, 0o755); err != nil {
 		return err
@@ -668,7 +754,10 @@ var factoryFS embed.FS
 //go:embed templates/builder
 var builderFS embed.FS
 
-//go:embed templates/bootstrap
+// all: so the staged tree's .gitignore (a dotfile go:embed skips by default) is
+// carried into the bootstrap tree it marks as agent-generated.
+//
+//go:embed all:templates/bootstrap
 var bootstrapFS embed.FS
 
 //go:embed templates/runtime

--- a/main_test.go
+++ b/main_test.go
@@ -666,6 +666,26 @@ func assertSchemaPrerequisitesFailClosed(
 		requireNoMigrationSideEffect()
 	}
 
+	// An empty own migrations/ is documented as legal, and the builder creates one
+	// so the bootstrap image's COPY resolves. Applying must therefore succeed
+	// against a real database: golang-migrate reports an empty source as a
+	// missing first version rather than "no change", so a lineage with nothing to
+	// apply must never be handed to Up().
+	empty := newRuntimeForDatabase(t, ownerConnection, isolate.Name)
+	require.NoError(t, os.RemoveAll(empty.Local("migrations")))
+	require.NoError(t, os.MkdirAll(empty.Local("migrations"), 0o755))
+	writeMigrationDirectory(t, filepath.Join(empty.Location, "..", "sibling", "migrations"),
+		"CREATE TABLE IF NOT EXISTS prerequisite_sibling (id integer);")
+	empty.Settings.MigrationSources = []MigrationSource{{Name: "sibling"}}
+	emptyPrerequisites, err := empty.resolveSchemaPrerequisites()
+	require.NoError(t, err)
+	require.NoError(t, empty.applySchema(ctx, emptyPrerequisites),
+		"an empty own migrations directory must not fail the migration step")
+	var siblingApplied bool
+	require.NoError(t, isolate.DB.QueryRowContext(ctx,
+		`SELECT to_regclass('public.prerequisite_sibling') IS NOT NULL`).Scan(&siblingApplied))
+	require.True(t, siblingApplied, "the sibling lineage must still apply beside an empty own directory")
+
 	// A resolvable declaration applies: the own lineage keeps the legacy default
 	// ledger and the declared source gets its own.
 	accepted := newRuntimeForDatabase(t, ownerConnection, isolate.Name)

--- a/runtime_role_selection_test.go
+++ b/runtime_role_selection_test.go
@@ -65,10 +65,10 @@ func TestDefaultRuntimeReadWriteRoleIsStableWhenRolesAreAppended(t *testing.T) {
 // default role has to be established there too.
 func TestRuntimeAccessTemplateSetsTheDefaultReadWriteRole(t *testing.T) {
 	base := DockerTemplating{
-		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
-		ReadOnlyRole:                 "codefly_app_ro",
-		ReadWriteRole:                "codefly_app_rw",
-		Schemas:                      []string{"public"},
+		MigrationConnectionEnvironment: migrationConnectionEnvironmentKey,
+		ReadOnlyRole:                   "codefly_app_ro",
+		ReadWriteRole:                  "codefly_app_rw",
+		Schemas:                        []string{"public"},
 	}
 
 	delegated := base

--- a/schema.go
+++ b/schema.go
@@ -122,7 +122,17 @@ func (s *Service) resolveMigrationSources() ([]migrationSource, []skippedPrerequ
 			// A path that is a file, or a directory this process may not read, is
 			// a misconfiguration even for an optional source.
 			return nil, nil, fmt.Errorf("migration source %q: %w", lineage.name, err)
-		case count == 0 && !own:
+		case count == 0:
+			// A lineage with nothing to apply must not reach the apply list at
+			// all: golang-migrate reports an empty source as a MISSING FIRST
+			// VERSION, not as "no change", so applying one fails the whole run.
+			// Whether emptiness is also an ERROR is a separate question — it is,
+			// for a declared source that did not ask to be optional, and it is
+			// not for the own directory, whose emptiness is documented as legal.
+			if own {
+				s.Wool.Debug("own migration folder holds no migration", wool.DirField(lineage.dir))
+				continue
+			}
 			if !lineage.optional {
 				return nil, nil, fmt.Errorf(
 					"migration source %q declares directory %s, which holds no migration: add a <version>_<title>.up.sql file, or declare the source optional",

--- a/schema_test.go
+++ b/schema_test.go
@@ -238,8 +238,11 @@ func TestOwnMigrationLayoutIsValidated(t *testing.T) {
 	})
 
 	// The builder creates an empty migrations/ so the bootstrap image's COPY
-	// resolves; that must stay legal.
-	t.Run("empty directory stays legal", func(t *testing.T) {
+	// resolves; that must stay legal. It must also not be APPLIED: golang-migrate
+	// reports an empty source as a missing first version rather than "no change",
+	// so handing one to Up() fails the run that this emptiness is supposed to be
+	// legal for.
+	t.Run("empty directory stays legal and is not applied", func(t *testing.T) {
 		s := NewRuntime()
 		s.Location = t.TempDir()
 		if err := os.MkdirAll(filepath.Join(s.Location, "migrations"), 0o755); err != nil {
@@ -249,8 +252,8 @@ func TestOwnMigrationLayoutIsValidated(t *testing.T) {
 		if err != nil {
 			t.Fatalf("an empty own migrations directory must stay legal: %v", err)
 		}
-		if len(prerequisites.sources) != 1 {
-			t.Errorf("expected the own lineage to resolve, got %+v", prerequisites.sources)
+		if len(prerequisites.sources) != 0 {
+			t.Errorf("a lineage with no migration must not be applied, got %+v", prerequisites.sources)
 		}
 	})
 }

--- a/schemaplan.go
+++ b/schemaplan.go
@@ -62,11 +62,10 @@ type schemaAccess struct {
 // NoMigration packages no lineage at all, mirroring applySchema: extensions and
 // runtime grants still apply, so the image does exactly what the runtime does.
 //
-// A lineage holding no migration is not packaged either. Only the own
-// ./migrations directory can reach here empty — a declared source must hold one
-// or say it is optional — and golang-migrate reports an empty source as a
-// missing first version rather than "no change", so staging one would fail the
-// bootstrap Job.
+// Every resolved source is packaged as it comes. resolveSchemaPrerequisites
+// already excludes a lineage with no migration, and skipping one here as well
+// would hide a lineage from the image that the runtime still tried to apply —
+// the divergence this packaging exists to remove.
 func buildSchemaPlan(prerequisites *schemaPrerequisites, settings *Settings) (*schemaPlan, error) {
 	access, err := resolveSchemaAccess(settings)
 	if err != nil {
@@ -84,9 +83,6 @@ func buildSchemaPlan(prerequisites *schemaPrerequisites, settings *Settings) (*s
 		files, filesErr := stagedFiles(source.dir)
 		if filesErr != nil {
 			return nil, fmt.Errorf("cannot inventory migration source %q: %w", source.label(), filesErr)
-		}
-		if len(files) == 0 {
-			continue
 		}
 		plan.lineages = append(plan.lineages, schemaLineage{
 			migrationSource: source,

--- a/schemaplan.go
+++ b/schemaplan.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// schemaPlanContractVersion identifies the bootstrap artifact's plan format. A
+// consumer reading bootstrap/plan.json checks it before interpreting the fields.
+const schemaPlanContractVersion = "codefly.dev/postgres-schema-plan/v1"
+
+// schemaPlan is the packaged form of the resolved schema prerequisites: what the
+// bootstrap image carries, and what it applies. Resolving and validating the
+// declarations belongs to resolveSchemaPrerequisites, which the runtime and the
+// build share; this adds only what packaging needs — a staged location per
+// lineage, the files staged under it, and the content identity the artifact
+// publishes — so the image applies the same schema contract the runtime does.
+type schemaPlan struct {
+	database   string
+	lineages   []schemaLineage
+	extensions []extensionRequest
+	access     schemaAccess
+}
+
+// schemaLineage is one resolved migration lineage together with where the build
+// stages it and what it stages.
+type schemaLineage struct {
+	// migrationSource is what the runtime applies: the lineage's root and the
+	// ledger it owns.
+	migrationSource
+	// stage is the lineage's directory under bootstrap/sources in the build
+	// context. The ordinal prefix makes it collision-free by construction.
+	stage  string
+	files  []schemaFile
+	digest string
+}
+
+// schemaFile is one staged file's identity within a lineage.
+type schemaFile struct {
+	name   string
+	digest string
+}
+
+// schemaAccess carries the runtime-role grant inputs. Both the local reconciler
+// and the bootstrap image's runtime-access.sql are driven from these values.
+type schemaAccess struct {
+	readOnlyRole   string
+	readWriteRole  string
+	schemas        []string
+	readWriteRoles []string
+}
+
+// buildSchemaPlan packages already-resolved prerequisites for the build. It is
+// pure: it reads the migration files' names, never a database.
+//
+// NoMigration packages no lineage at all, mirroring applySchema: extensions and
+// runtime grants still apply, so the image does exactly what the runtime does.
+//
+// A lineage holding no migration is not packaged either. Only the own
+// ./migrations directory can reach here empty — a declared source must hold one
+// or say it is optional — and golang-migrate reports an empty source as a
+// missing first version rather than "no change", so staging one would fail the
+// bootstrap Job.
+func buildSchemaPlan(prerequisites *schemaPrerequisites, settings *Settings) (*schemaPlan, error) {
+	access, err := resolveSchemaAccess(settings)
+	if err != nil {
+		return nil, err
+	}
+	plan := &schemaPlan{
+		database:   settings.DatabaseName,
+		extensions: prerequisites.extensions,
+		access:     access,
+	}
+	if settings.NoMigration {
+		return plan, nil
+	}
+	for _, source := range prerequisites.sources {
+		files, filesErr := stagedFiles(source.dir)
+		if filesErr != nil {
+			return nil, fmt.Errorf("cannot inventory migration source %q: %w", source.label(), filesErr)
+		}
+		if len(files) == 0 {
+			continue
+		}
+		plan.lineages = append(plan.lineages, schemaLineage{
+			migrationSource: source,
+			stage:           fmt.Sprintf("%02d-%s", len(plan.lineages), source.label()),
+			files:           files,
+		})
+	}
+	return plan, nil
+}
+
+// stagedFiles lists the files of one source directory that the build stages,
+// sorted by name. A file is staged when migrationFileName recognizes it — the
+// same single definition the runtime's source driver filters on — so an editor
+// backup left beside a migration is neither applied locally nor carried into the
+// image. Contents are not read here: digests are filled in by attest, so a plan
+// can be assembled without reading every migration byte.
+//
+// A symlink is followed when its target stays inside the source root, so a
+// layout that works locally keeps working. One that leaves the root is rejected:
+// staging copies bytes, and content pulled from an arbitrary path would enter
+// the image with no record of where it came from. Declare such content as its
+// own migration source instead.
+func stagedFiles(dir string) ([]schemaFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	files := make([]schemaFile, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !migrationFileName.MatchString(entry.Name()) {
+			continue
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			contained, containedErr := symlinkStaysInside(dir, entry.Name())
+			if containedErr != nil {
+				return nil, containedErr
+			}
+			if !contained.Mode().IsRegular() {
+				continue
+			}
+		} else if !entry.Type().IsRegular() {
+			return nil, fmt.Errorf("entry %q is not a regular file", entry.Name())
+		}
+		files = append(files, schemaFile{name: entry.Name()})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].name < files[j].name })
+	return files, nil
+}
+
+// symlinkStaysInside resolves one symlinked entry and reports its target's file
+// information, rejecting a target that resolves outside the source root.
+func symlinkStaysInside(dir, name string) (os.FileInfo, error) {
+	root, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return nil, err
+	}
+	target, err := filepath.EvalSymlinks(filepath.Join(dir, name))
+	if err != nil {
+		return nil, fmt.Errorf("migration source entry %q does not resolve: %w", name, err)
+	}
+	relative, err := filepath.Rel(root, target)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return nil, fmt.Errorf(
+			"migration source entry %q links outside its source root; declare %s as its own migration source instead",
+			name, filepath.Dir(target))
+	}
+	return os.Stat(target)
+}
+
+// attest fills in the content identity the build artifact publishes: a digest
+// per staged file and per lineage.
+func (p *schemaPlan) attest() error {
+	for i := range p.lineages {
+		for j := range p.lineages[i].files {
+			digest, err := fileDigest(filepath.Join(p.lineages[i].dir, p.lineages[i].files[j].name))
+			if err != nil {
+				return fmt.Errorf("cannot digest migration source %q: %w", p.lineages[i].label(), err)
+			}
+			p.lineages[i].files[j].digest = digest
+		}
+		p.lineages[i].digest = lineageDigest(p.lineages[i])
+	}
+	return nil
+}
+
+// fileDigest streams the file through sha256 rather than buffering it whole, so
+// digesting a large data migration does not read it into memory.
+func fileDigest(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	hasher := sha256.New()
+	if _, err = io.Copy(hasher, file); err != nil {
+		return "", err
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// digest is the plan's content identity: a deterministic function of every
+// lineage's ledger, staged location and file contents, the required extensions,
+// and the runtime-role grant inputs. Mutating one migration file changes it.
+func (p *schemaPlan) digest() string {
+	hasher := sha256.New()
+	write := func(values ...string) {
+		for _, value := range values {
+			_, _ = hasher.Write([]byte(value))
+			_, _ = hasher.Write([]byte{0})
+		}
+	}
+	write(schemaPlanContractVersion, p.database)
+	for _, extension := range p.extensions {
+		write(extension.name, fmt.Sprint(extension.required))
+	}
+	write(p.access.readOnlyRole, p.access.readWriteRole)
+	write(p.access.schemas...)
+	write(p.access.readWriteRoles...)
+	for _, lineage := range p.lineages {
+		write(lineage.label(), lineage.trackingTable(), lineage.stage, lineage.digest)
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}
+
+func lineageDigest(lineage schemaLineage) string {
+	hasher := sha256.New()
+	_, _ = hasher.Write([]byte(lineage.label() + "\x00" + lineage.trackingTable() + "\x00"))
+	for _, file := range lineage.files {
+		_, _ = hasher.Write([]byte(file.name + "\x00" + file.digest + "\x00"))
+	}
+	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+}
+
+// stagedChecksums renders the staged content as a sha256sum manifest, relative
+// to the staging root. The bootstrap program verifies it before applying
+// anything: the image is built from the service directory by a later, separate
+// process, so a staged tree that drifted or was only partly written would
+// otherwise apply fewer migrations and report success.
+func (p *schemaPlan) stagedChecksums() []byte {
+	var manifest strings.Builder
+	for _, lineage := range p.lineages {
+		for _, file := range lineage.files {
+			manifest.WriteString(strings.TrimPrefix(file.digest, "sha256:"))
+			manifest.WriteString("  sources/")
+			manifest.WriteString(lineage.stage)
+			manifest.WriteString("/")
+			manifest.WriteString(file.name)
+			manifest.WriteString("\n")
+		}
+	}
+	return []byte(manifest.String())
+}
+
+func resolveSchemaAccess(settings *Settings) (schemaAccess, error) {
+	readOnlyRole, readWriteRole := runtimeRoleNames(settings.DatabaseName)
+	schemas, err := normalizedRuntimeSchemas(settings.RuntimeSchemas)
+	if err != nil {
+		return schemaAccess{}, err
+	}
+	readWriteRoles, err := normalizedRuntimeReadWriteRoles(settings.RuntimeReadWriteRoles, readOnlyRole, readWriteRole)
+	if err != nil {
+		return schemaAccess{}, err
+	}
+	return schemaAccess{
+		readOnlyRole:   readOnlyRole,
+		readWriteRole:  readWriteRole,
+		schemas:        schemas,
+		readWriteRoles: readWriteRoles,
+	}, nil
+}
+
+// schemaPlanArtifact is the bootstrap image's evidence of what it will apply.
+// It is deliberately machine-independent and secret-free: staged locations and
+// content digests rather than filesystem provenance, role names rather than
+// credentials. Two machines building one commit must publish identical bytes.
+type schemaPlanArtifact struct {
+	ContractVersion string                    `json:"contract-version"`
+	Database        string                    `json:"database"`
+	Extensions      []schemaExtensionArtifact `json:"extensions"`
+	Lineages        []schemaLineageArtifact   `json:"lineages"`
+	Access          schemaAccessArtifact      `json:"access"`
+	Digest          string                    `json:"digest"`
+}
+
+type schemaExtensionArtifact struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+type schemaLineageArtifact struct {
+	Label  string               `json:"label"`
+	Ledger string               `json:"ledger"`
+	Stage  string               `json:"stage"`
+	Digest string               `json:"digest"`
+	Files  []schemaFileArtifact `json:"files"`
+}
+
+type schemaFileArtifact struct {
+	Name   string `json:"name"`
+	Digest string `json:"digest"`
+}
+
+type schemaAccessArtifact struct {
+	ReadOnlyRole   string   `json:"read-only-role"`
+	ReadWriteRole  string   `json:"read-write-role"`
+	Schemas        []string `json:"schemas"`
+	ReadWriteRoles []string `json:"read-write-roles"`
+}
+
+func (p *schemaPlan) artifact() schemaPlanArtifact {
+	extensions := make([]schemaExtensionArtifact, 0, len(p.extensions))
+	for _, extension := range p.extensions {
+		extensions = append(extensions, schemaExtensionArtifact{Name: extension.name, Required: extension.required})
+	}
+	lineages := make([]schemaLineageArtifact, 0, len(p.lineages))
+	for _, lineage := range p.lineages {
+		files := make([]schemaFileArtifact, 0, len(lineage.files))
+		for _, file := range lineage.files {
+			files = append(files, schemaFileArtifact{Name: file.name, Digest: file.digest})
+		}
+		lineages = append(lineages, schemaLineageArtifact{
+			Label:  lineage.label(),
+			Ledger: lineage.trackingTable(),
+			Stage:  lineage.stage,
+			Digest: lineage.digest,
+			Files:  files,
+		})
+	}
+	return schemaPlanArtifact{
+		ContractVersion: schemaPlanContractVersion,
+		Database:        p.database,
+		Extensions:      extensions,
+		Lineages:        lineages,
+		Access: schemaAccessArtifact{
+			ReadOnlyRole:   p.access.readOnlyRole,
+			ReadWriteRole:  p.access.readWriteRole,
+			Schemas:        p.access.schemas,
+			ReadWriteRoles: p.access.readWriteRoles,
+		},
+		Digest: p.digest(),
+	}
+}

--- a/schemaplan_test.go
+++ b/schemaplan_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/codefly-dev/core/resources"
+	"github.com/stretchr/testify/require"
+)
+
+// writeMigration creates a migrations directory holding one named migration.
+func writeMigration(t *testing.T, dir, name string) {
+	t.Helper()
+	mustMkdir(t, dir)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte("SELECT 1;\n"), 0o644))
+}
+
+// newPlanFixture lays out a service with its own migrations and two sibling
+// sources, the shape the shared-database contract is written for.
+func newPlanFixture(t *testing.T) *Service {
+	t.Helper()
+	root := t.TempDir()
+	location := filepath.Join(root, "store")
+	writeMigration(t, filepath.Join(location, "migrations"), "1_store.up.sql")
+	writeMigration(t, filepath.Join(root, "api", "migrations"), "1_api.up.sql")
+	writeMigration(t, filepath.Join(root, "billing", "db", "migrations"), "1_billing.up.sql")
+	return newPlanService(t, location, &Settings{
+		DatabaseName: "app",
+		Extensions:   []Extension{{Name: "hstore"}},
+		MigrationSources: []MigrationSource{
+			{Name: "api"},
+			{Name: "billing", Path: "../billing/db/migrations"},
+		},
+	})
+}
+
+func newPlanService(t *testing.T, location string, settings *Settings) *Service {
+	t.Helper()
+	service := NewService()
+	service.Identity = &resources.ServiceIdentity{Name: "store", Module: "test"}
+	service.Settings = settings
+	service.Location = location
+	return service
+}
+
+// planFor packages what the shared resolver returned, the way Build does.
+func planFor(t *testing.T, service *Service) *schemaPlan {
+	t.Helper()
+	prerequisites, err := service.resolveSchemaPrerequisites()
+	require.NoError(t, err)
+	plan, err := buildSchemaPlan(prerequisites, service.Settings)
+	require.NoError(t, err)
+	return plan
+}
+
+func TestSchemaPlanStagesEveryLineageInACollisionFreeDirectory(t *testing.T) {
+	plan := planFor(t, newPlanFixture(t))
+	require.NoError(t, plan.attest())
+
+	require.Equal(t,
+		[]string{"00-store", "01-api", "02-billing"},
+		[]string{plan.lineages[0].stage, plan.lineages[1].stage, plan.lineages[2].stage})
+	require.Equal(t,
+		[]string{"schema_migrations", "schema_migrations_api", "schema_migrations_billing"},
+		[]string{plan.lineages[0].trackingTable(), plan.lineages[1].trackingTable(), plan.lineages[2].trackingTable()})
+	for _, lineage := range plan.lineages {
+		require.Len(t, lineage.files, 1)
+		require.True(t, strings.HasPrefix(lineage.files[0].digest, "sha256:"))
+	}
+}
+
+// TestSchemaPlanIdentityIsMachineIndependent keeps the emitted evidence
+// reproducible: two checkouts of the same sources at different absolute paths
+// must agree on the plan digest — including a source declared by absolute path,
+// which is where provenance would otherwise leak into the identity — while
+// changing a byte must not.
+func TestSchemaPlanIdentityIsMachineIndependent(t *testing.T) {
+	attested := func() (*schemaPlan, *Service) {
+		t.Helper()
+		service := newPlanFixture(t)
+		external := filepath.Join(t.TempDir(), "external", "migrations")
+		writeMigration(t, external, "1_external.up.sql")
+		service.Settings.MigrationSources = append(service.Settings.MigrationSources,
+			MigrationSource{Name: "external", Path: external})
+		plan := planFor(t, service)
+		require.NoError(t, plan.attest())
+		return plan, service
+	}
+
+	first, firstService := attested()
+	second, secondService := attested()
+
+	require.NotEqual(t, firstService.Location, secondService.Location)
+	require.Equal(t, first.digest(), second.digest())
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(secondService.Location, "migrations", "1_store.up.sql"),
+		[]byte("SELECT 2;\n"), 0o644))
+	mutated := planFor(t, secondService)
+	require.NoError(t, mutated.attest())
+	require.NotEqual(t, first.digest(), mutated.digest())
+}
+
+// TestSchemaPlanRejectsSymlinkEscapingSourceRoot covers the escape a lexical
+// path check cannot see: staging copies bytes, so this would pull content from
+// an arbitrary path into the image with no record of where it came from.
+func TestSchemaPlanRejectsSymlinkEscapingSourceRoot(t *testing.T) {
+	service := newPlanFixture(t)
+	outside := filepath.Join(t.TempDir(), "9_outside.up.sql")
+	require.NoError(t, os.WriteFile(outside, []byte("SELECT 'outside';\n"), 0o644))
+	require.NoError(t, os.Symlink(outside, filepath.Join(service.Location, "migrations", "9_outside.up.sql")))
+
+	prerequisites, err := service.resolveSchemaPrerequisites()
+	require.NoError(t, err)
+	_, err = buildSchemaPlan(prerequisites, service.Settings)
+	require.ErrorContains(t, err, "links outside")
+	require.ErrorContains(t, err, "migration source")
+}
+
+// TestSchemaPlanFollowsSymlinkInsideSourceRoot covers a layout that runs fine
+// locally — golang-migrate reads through a symlink — so packaging must not turn
+// it into a build failure. Its content is staged, never the link.
+func TestSchemaPlanFollowsSymlinkInsideSourceRoot(t *testing.T) {
+	service := newPlanFixture(t)
+	migrations := filepath.Join(service.Location, "migrations")
+	require.NoError(t, os.Symlink(
+		filepath.Join(migrations, "1_store.up.sql"),
+		filepath.Join(migrations, "2_store.up.sql")))
+
+	plan := planFor(t, service)
+	require.NoError(t, plan.attest())
+	require.Len(t, plan.lineages[0].files, 2)
+
+	staged := t.TempDir()
+	require.NoError(t, stageLineage(context.Background(), plan.lineages[0], staged))
+	linked, err := os.Lstat(filepath.Join(staged, "2_store.up.sql"))
+	require.NoError(t, err)
+	require.Zero(t, linked.Mode()&os.ModeSymlink, "a symlink in the recipe tree is rejected by the inventory")
+	require.Equal(t, "SELECT 1;\n", string(mustReadFile(t, filepath.Join(staged, "2_store.up.sql"))))
+}
+
+// TestSchemaPlanStagesOnlyMigrationFiles pins packaging to the one runtime
+// filename definition: an editor backup parses as the same version and direction
+// as the file it shadows, so shipping one would make migrate reject the lineage.
+func TestSchemaPlanStagesOnlyMigrationFiles(t *testing.T) {
+	service := newPlanFixture(t)
+	migrations := filepath.Join(service.Location, "migrations")
+	for _, name := range []string{
+		"1_store.up.sql~", "1_store.up.sql.bak", "1_store.up.sql.orig",
+		".1_store.up.sql.swp", "README.md", "2_flavored.up.pgsql",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(migrations, name), []byte("SELECT 1;\n"), 0o644))
+	}
+
+	plan := planFor(t, service)
+	staged := make([]string, 0, len(plan.lineages[0].files))
+	for _, file := range plan.lineages[0].files {
+		staged = append(staged, file.name)
+	}
+	require.Equal(t, []string{"1_store.up.sql", "2_flavored.up.pgsql"}, staged)
+}
+
+// TestSchemaPlanPackagesNothingWithoutMigrations mirrors applySchema: a
+// no-migration service still creates extensions and reconciles grants, and must
+// not ship a lineage the runtime would refuse to apply.
+func TestSchemaPlanPackagesNothingWithoutMigrations(t *testing.T) {
+	service := newPlanFixture(t)
+	service.Settings.NoMigration = true
+
+	plan := planFor(t, service)
+	require.Empty(t, plan.lineages)
+	require.NotEmpty(t, plan.extensions)
+	require.NotEmpty(t, plan.access.readWriteRole)
+}
+
+// TestSchemaPlanSkipsAnEmptyOwnLineage covers the one lineage that can resolve
+// empty. golang-migrate reports an empty source as a missing first version
+// rather than "no change", so staging it would fail the bootstrap Job.
+func TestSchemaPlanSkipsAnEmptyOwnLineage(t *testing.T) {
+	root := t.TempDir()
+	location := filepath.Join(root, "store")
+	mustMkdir(t, filepath.Join(location, "migrations"))
+	writeMigration(t, filepath.Join(root, "api", "migrations"), "1_api.up.sql")
+	service := newPlanService(t, location, &Settings{
+		DatabaseName:     "app",
+		MigrationSources: []MigrationSource{{Name: "api"}},
+	})
+
+	plan := planFor(t, service)
+	require.Len(t, plan.lineages, 1)
+	require.Equal(t, "api", plan.lineages[0].label())
+	require.Equal(t, "00-api", plan.lineages[0].stage)
+}
+
+// TestSchemaPlanCarriesRuntimeAccessInputs keeps grant reconciliation on the
+// same packaging as migrations, so the bootstrap image and the local runtime
+// reconcile identical roles.
+func TestSchemaPlanCarriesRuntimeAccessInputs(t *testing.T) {
+	service := newPlanFixture(t)
+	service.Settings.RuntimeSchemas = []string{"public", "audit"}
+	service.Settings.RuntimeReadWriteRoles = []string{"app_tenant"}
+
+	plan := planFor(t, service)
+	readOnlyRole, readWriteRole := runtimeRoleNames("app")
+	require.Equal(t, readOnlyRole, plan.access.readOnlyRole)
+	require.Equal(t, readWriteRole, plan.access.readWriteRole)
+	require.Equal(t, []string{"public", "audit"}, plan.access.schemas)
+	require.Equal(t, []string{"app_tenant"}, plan.access.readWriteRoles)
+}
+
+// TestSchemaPlanCarriesRequiredExtensions is the deployed half of the required
+// contract: a declared extension must be packaged as required so the image fails
+// on it exactly as the runtime fails readiness.
+func TestSchemaPlanCarriesRequiredExtensions(t *testing.T) {
+	service := newPlanFixture(t)
+	service.Settings.Extensions = []Extension{{Name: "hstore"}, {Name: "postgis", Optional: true}}
+
+	plan := planFor(t, service)
+	required := map[string]bool{}
+	for _, extension := range plan.extensions {
+		required[extension.name] = extension.required
+	}
+	require.True(t, required["hstore"], "a declared extension is required by default")
+	require.False(t, required["postgis"], "an explicitly optional extension stays best-effort")
+	require.False(t, required["vector"], "the convenience defaults stay best-effort")
+}

--- a/schemaplan_test.go
+++ b/schemaplan_test.go
@@ -176,10 +176,11 @@ func TestSchemaPlanPackagesNothingWithoutMigrations(t *testing.T) {
 	require.NotEmpty(t, plan.access.readWriteRole)
 }
 
-// TestSchemaPlanSkipsAnEmptyOwnLineage covers the one lineage that can resolve
-// empty. golang-migrate reports an empty source as a missing first version
-// rather than "no change", so staging it would fail the bootstrap Job.
-func TestSchemaPlanSkipsAnEmptyOwnLineage(t *testing.T) {
+// TestSchemaPlanPackagesNoEmptyLineage checks the packaging consequence of the
+// resolver excluding a lineage with no migration: the staged tree and the
+// numbering start at the first lineage that actually has one, so the image never
+// carries a source golang-migrate would reject as a missing first version.
+func TestSchemaPlanPackagesNoEmptyLineage(t *testing.T) {
 	root := t.TempDir()
 	location := filepath.Join(root, "store")
 	mustMkdir(t, filepath.Join(location, "migrations"))

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -11,28 +11,6 @@ The migration owner is private to the Postgres service and its bootstrap job. It
 
 The bootstrap job applies migrations and reconciles runtime roles and grants on every deployment. Local Docker and Nix runtimes enforce the same contract.
 
-## Migration sources
-
-Several services can share one database while each owns its migrations. The service resolves one schema plan — ordered lineages, their ledgers, the required extensions, and the runtime-role grant inputs — and the local runtimes and the deployed bootstrap image both execute that same plan.
-
-```yaml
-database-name: app
-extensions:
-  - hstore
-runtime-schemas:
-  - public
-migration-sources:
-  - name: api                          # ../api/migrations
-  - name: billing
-    path: ../billing/db/migrations     # relative to this service's directory
-```
-
-- **Paths** are relative to this service's directory, or absolute. An omitted `path` defaults to `../<name>/migrations`, the sibling layout used inside a module.
-- **Order** is this service's own `./migrations` first, then each declared source in the order it appears. Later sources may depend on relations earlier ones create.
-- **Ledgers** are independent: the own source keeps golang-migrate's `schema_migrations`, and each declared source gets `schema_migrations_<name>`. Per-source version counters therefore never collide, and a source's numbering is its own.
-- A source with **no own `./migrations`** directory is normal — a database whose tables all come from siblings declares none.
-- A declared source whose directory is **missing** is skipped with a warning while developing, and **fails the build**: the image stages each source's bytes, so a declaration that cannot be resolved would otherwise ship a database without those tables.
-
 Local database state survives ordinary stop/start and container recreation. In Docker mode, the agent mounts the official image's data directory from a Codefly-owned persistent runtime directory scoped by workspace, service, and naming scope. Stable and development scopes therefore keep independent databases even when they run from the same checkout.
 
 ## Lifecycle: stop, keep-running, destroy
@@ -83,6 +61,10 @@ A declared source is **required**: a directory that does not exist, cannot be re
 A declared extension is likewise **required**: if the configured image does not ship its shared library, or the migration owner may not install it, startup fails rather than reporting a ready database that silently lacks it. Mark it `optional: true` to get a reported skip instead. The always-on convenience extensions (`vector`, `pgcrypto`, `uuid-ossp`, `pg_trgm`, `citext`, `btree_gin`) remain best-effort; naming one under `extensions` makes it required.
 
 **Upgrading.** Declarations that were previously tolerated with a warning now fail. A `migration-sources` entry pointing at a path that never existed, or a duplicated name, was silently dropped before and must be corrected or marked optional. An extension the image does not ship was skipped before and must now be removed, marked optional, or supplied by pointing `docker-image` at an image that ships it. A file that claims to be a migration but has no version prefix, in any `migrations/` directory — including this service's own — was silently ignored before and now fails; rename it to `<version>_<title>.up.sql`.
+
+Each lineage keeps its **own** golang-migrate ledger: this service's `migrations/` uses `schema_migrations` and each declared source uses `schema_migrations_<name>`, so per-source version numbers never collide and a source's numbering is its own. They are applied in declared order, this service's own directory first, so a later source may depend on relations an earlier one creates.
+
+The deployed bootstrap image packages exactly what that resolution returned. Every resolved source's migration files are copied into the image under their own staged directory and applied to their own ledger, and the declared extensions are created with the same required/optional outcome as local startup — a service whose tables come from sibling sources therefore deploys with those tables. `bootstrap/plan.json` inside the image records the packaged lineages, their ledgers, and a content digest per staged file, and the image verifies those digests before it applies anything.
 
 ## External-identity mode
 

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -11,6 +11,28 @@ The migration owner is private to the Postgres service and its bootstrap job. It
 
 The bootstrap job applies migrations and reconciles runtime roles and grants on every deployment. Local Docker and Nix runtimes enforce the same contract.
 
+## Migration sources
+
+Several services can share one database while each owns its migrations. The service resolves one schema plan — ordered lineages, their ledgers, the required extensions, and the runtime-role grant inputs — and the local runtimes and the deployed bootstrap image both execute that same plan.
+
+```yaml
+database-name: app
+extensions:
+  - hstore
+runtime-schemas:
+  - public
+migration-sources:
+  - name: api                          # ../api/migrations
+  - name: billing
+    path: ../billing/db/migrations     # relative to this service's directory
+```
+
+- **Paths** are relative to this service's directory, or absolute. An omitted `path` defaults to `../<name>/migrations`, the sibling layout used inside a module.
+- **Order** is this service's own `./migrations` first, then each declared source in the order it appears. Later sources may depend on relations earlier ones create.
+- **Ledgers** are independent: the own source keeps golang-migrate's `schema_migrations`, and each declared source gets `schema_migrations_<name>`. Per-source version counters therefore never collide, and a source's numbering is its own.
+- A source with **no own `./migrations`** directory is normal — a database whose tables all come from siblings declares none.
+- A declared source whose directory is **missing** is skipped with a warning while developing, and **fails the build**: the image stages each source's bytes, so a declaration that cannot be resolved would otherwise ship a database without those tables.
+
 Local database state survives ordinary stop/start and container recreation. In Docker mode, the agent mounts the official image's data directory from a Codefly-owned persistent runtime directory scoped by workspace, service, and naming scope. Stable and development scopes therefore keep independent databases even when they run from the same checkout.
 
 ## Lifecycle: stop, keep-running, destroy

--- a/templates/bootstrap/.gitignore.tmpl
+++ b/templates/bootstrap/.gitignore.tmpl
@@ -1,0 +1,5 @@
+# codefly-generated postgres bootstrap
+# Regenerated on every `codefly build service`: the plan, the program it runs,
+# and an immutable copy of every resolved migration source. The sources are
+# copies — edit them where they are declared, never here.
+*

--- a/templates/bootstrap/bootstrap.sh.tmpl
+++ b/templates/bootstrap/bootstrap.sh.tmpl
@@ -1,0 +1,52 @@
+# Generated from the service's schema plan (see plan.json). This script gates
+# the run: it waits for the database within a budget and verifies the staged
+# migration sources. Everything that touches the database then happens in ONE
+# psql session over bootstrap.sql, so every lineage and the grants that describe
+# them are serialized by a single advisory lock.
+set -eu
+
+connection={{ printf "\"${%s:-}\"" .MigrationConnectionEnvironment }}
+if [ -z "${connection}" ]; then
+    echo "bootstrap: {{ .MigrationConnectionEnvironment }} is not set" >&2
+    exit 1
+fi
+
+# Each lineage is applied to its own ledger, which golang-migrate takes as a
+# query parameter -- and the connection string may already carry one.
+# bootstrap.sql builds each lineage's DSN with this separator.
+case "${connection}" in
+    *\?*) CODEFLY_LEDGER_SEPARATOR="&" ;;
+    *) CODEFLY_LEDGER_SEPARATOR="?" ;;
+esac
+export CODEFLY_LEDGER_SEPARATOR
+
+# Bounded readiness: an unreachable database must fail the Job within its
+# budget rather than block it, and invalid connection parameters are a
+# configuration fault (EX_CONFIG) no amount of waiting fixes.
+readiness_deadline=$(($(date +%s) + {{ .ReadinessTimeoutSeconds }}))
+while :; do
+    readiness=0
+    pg_isready -q -d "${connection}" || readiness=$?
+    if [ "${readiness}" -eq 0 ]; then break; fi
+    if [ "${readiness}" -eq 3 ]; then
+        echo "bootstrap: database connection parameters are invalid (pg_isready status 3)" >&2
+        exit 78
+    fi
+    if [ "$(date +%s)" -ge "${readiness_deadline}" ]; then
+        echo "bootstrap: database did not accept connections within {{ .ReadinessTimeoutSeconds }}s (last pg_isready status ${readiness})" >&2
+        exit 1
+    fi
+    sleep 2
+done
+{{- if .Lineages }}
+
+# The image is built from the service directory by a separate process, long
+# after this plan was emitted. Verify the staged sources against the manifest
+# before applying anything: a source that drifted or was only partly copied
+# would otherwise apply fewer migrations and exit successfully. This runs after
+# the readiness gate so a misconfigured Job still fails fast on it.
+cd /app/bootstrap
+sha256sum -c sources.sha256
+{{- end }}
+
+psql "${connection}" --no-psqlrc --set=ON_ERROR_STOP=1 --file=/app/bootstrap.sql

--- a/templates/bootstrap/dockerignore.tmpl
+++ b/templates/bootstrap/dockerignore.tmpl
@@ -1,0 +1,7 @@
+# The build context is the whole service directory. Send only what the image
+# copies, so local configuration and secrets never reach the daemon or its cache.
+*
+!bootstrap
+!runtime-access.sql
+!bootstrap.sql
+bootstrap/dockerignore

--- a/templates/bootstrap/extensions.sql.tmpl
+++ b/templates/bootstrap/extensions.sql.tmpl
@@ -1,0 +1,20 @@
+\set ON_ERROR_STOP on
+{{- range .Extensions }}
+{{- if .Required }}
+
+-- Declared as required: the bootstrap fails when this cannot be created, exactly
+-- as the local runtime fails readiness for it.
+CREATE EXTENSION IF NOT EXISTS "{{ .Name }}";
+{{- else }}
+
+-- Optional: reported and skipped when the server image does not ship its
+-- library, matching what the local runtime records as a skipped prerequisite.
+DO $codefly$
+BEGIN
+    CREATE EXTENSION IF NOT EXISTS "{{ .Name }}";
+EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'optional extension "{{ .Name }}" is unavailable in this server image: %', SQLERRM;
+END;
+$codefly$;
+{{- end }}
+{{- end }}

--- a/templates/builder/Dockerfile.tmpl
+++ b/templates/builder/Dockerfile.tmpl
@@ -36,41 +36,20 @@ RUN set -eu; \
     install -m 0755 /tmp/migrate /usr/local/bin/migrate; \
     rm -f /tmp/migrate.tar.gz /tmp/migrate
 
-COPY . .
-
-{{- if .WithMigration }}
-COPY migrations /app/migrations
-# An editor backup kept beside a migration (2_x.up.sql~, .bak, .orig) parses as
-# the same version and direction as the file it shadows, so migrate rejects the
-# whole directory as a duplicate. Drop exactly what the runtime filter hides:
-# the pattern is rendered from the single Go definition.
-RUN find /app/migrations -maxdepth 1 -type f | while read -r file; do \
-      echo "${file##*/}" | grep -qE '{{ .MigrationFileNamePattern }}' || rm -f "${file}"; \
-    done
-{{- end }}
-COPY runtime-access.sql /app/runtime-access.sql
+# Only the staged bootstrap artifact and the runtime-access program enter the
+# image. The build context is the whole service directory, which also holds
+# local configuration and secrets, so nothing is copied wholesale. The staged
+# tree carries only files matching the one migration-filename definition, so an
+# editor backup left beside a migration never reaches the image to be pruned.
+COPY bootstrap /app/bootstrap
 COPY bootstrap.sql /app/bootstrap.sql
+COPY runtime-access.sql /app/runtime-access.sql
 
 # The bootstrap is ONE psql session over bootstrap.sql: it takes the
 # runtime-access advisory lock, runs `migrate up` as a child process while still
 # holding it, then includes runtime-access.sql for the grants. migrate used to
 # run here as its own process, which left the two steps in different lock
 # domains -- see bootstrap.sql for the collision that allowed between concurrent
-# bootstrap pods.
-CMD set -eu; \
-    readiness_deadline=$(($(date +%s) + {{ .ReadinessTimeoutSeconds }})); \
-    while :; do \
-      readiness=0; \
-      pg_isready -q -d "${{.MigrationConnectionKeyHolder}}" || readiness=$?; \
-      if [ "$readiness" -eq 0 ]; then break; fi; \
-      if [ "$readiness" -eq 3 ]; then \
-        echo "bootstrap: database connection parameters are invalid (pg_isready status 3)" >&2; \
-        exit 78; \
-      fi; \
-      if [ "$(date +%s)" -ge "$readiness_deadline" ]; then \
-        echo "bootstrap: database did not accept connections within {{ .ReadinessTimeoutSeconds }}s (last pg_isready status $readiness)" >&2; \
-        exit 1; \
-      fi; \
-      sleep 2; \
-    done; \
-    psql "${{.MigrationConnectionKeyHolder}}" --no-psqlrc --set=ON_ERROR_STOP=1 --file=/app/bootstrap.sql
+# bootstrap pods. bootstrap.sh gates that session on readiness and on verifying
+# the staged migration sources.
+CMD ["/bin/sh", "/app/bootstrap/bootstrap.sh"]

--- a/templates/runtime/bootstrap.sql.tmpl
+++ b/templates/runtime/bootstrap.sql.tmpl
@@ -12,15 +12,22 @@
 -- concurrent bootstrap pods are reachable in production.
 --
 -- Session-scoped rather than transaction-scoped: it must be held across the
--- migrate child process below, which runs outside any transaction here.
+-- migrate child processes below, which run outside any transaction here.
 SELECT pg_advisory_lock({{ .RuntimeAccessLockID }});
-{{- if .WithMigration }}
 
--- Runs while the lock above is held: psql keeps this session, and therefore the
--- lock, open for the lifetime of the child process. ON_ERROR_STOP does NOT
--- cover \!, so the exit status is checked explicitly -- otherwise a failed
--- migration would fall through and grant access over a schema that was never
--- migrated.
+-- Extensions first, so migration files can rely on them. Same ordering, and the
+-- same required/optional outcome, as the local runtime's applySchema.
+\i /app/bootstrap/extensions.sql
+{{- range .Lineages }}
+
+-- Source {{ .Label }} into its own ledger {{ .Ledger }}. Every lineage is
+-- applied inside this one session, so they share the lock above with the grants
+-- rather than racing them.
+--
+-- Runs while the lock is held: psql keeps this session, and therefore the lock,
+-- open for the lifetime of the child process. ON_ERROR_STOP does NOT cover \!,
+-- so the exit status is checked explicitly -- otherwise a failed migration would
+-- fall through and grant access over a schema that was never migrated.
 --
 -- The libpq settings below are stripped from the child environment. psql
 -- exports PGSYSCONFDIR to its children, and migrate's driver (lib/pq) PANICS
@@ -28,10 +35,13 @@ SELECT pg_advisory_lock({{ .RuntimeAccessLockID }});
 -- PGSYSCONFDIR not supported" -- which running migrate as a psql child would
 -- otherwise turn into a crash. Exactly lib/pq's unsupported set is unset, so
 -- every setting it does honour (PGSSLROOTCERT and friends) still reaches it.
-\! env -u PGSERVICE -u PGSERVICEFILE -u PGREALM -u PGREQUIRESSL -u PGSSLCRL -u PGREQUIREPEER -u PGKRBSRVNAME -u PGGSSLIB -u PGSYSCONFDIR -u PGLOCALEDIR /usr/local/bin/migrate -path /app/migrations -database "${{ .MigrationConnectionKeyHolder }}" up
+--
+-- CODEFLY_LEDGER_SEPARATOR is exported by bootstrap.sh: the ledger is a query
+-- parameter and the connection string may already carry one.
+\! env -u PGSERVICE -u PGSERVICEFILE -u PGREALM -u PGREQUIRESSL -u PGSSLCRL -u PGREQUIREPEER -u PGKRBSRVNAME -u PGGSSLIB -u PGSYSCONFDIR -u PGLOCALEDIR /usr/local/bin/migrate -path /app/bootstrap/sources/{{ .Stage }} -database "{{ printf "${%s}" $.MigrationConnectionEnvironment }}${CODEFLY_LEDGER_SEPARATOR}x-migrations-table={{ .Ledger }}" up
 \if :SHELL_ERROR
 DO $codefly_bootstrap$ BEGIN
-    RAISE EXCEPTION 'schema migration failed; refusing to reconcile runtime access';
+    RAISE EXCEPTION 'schema migration failed for source {{ .Label }}; refusing to reconcile runtime access';
 END $codefly_bootstrap$;
 \endif
 {{- end }}


### PR DESCRIPTION
Closes #78.

## Summary

- Local startup resolved `migration-sources` and applied one ledger per source; the deployment builder ignored them, copied only the database service's own `migrations/`, and ran a single `/app/migrations` lineage. A service whose tables come from sibling sources worked locally and shipped without them. Runtime extensions had no representation in the bootstrap image at all.
- `resolveSchemaPrerequisites()` (#88) is the shared resolver and validator, and its build-side comment recorded the remaining gap: *"this build packages only this service's own migrations, so listing the declared sources would claim an image content that does not exist."* **This PR closes that gap** — the build packages exactly what that resolution returns.
- The bootstrap image no longer does `COPY . .` (which baked `configurations/local/postgres.secret.env` into the published image), and the recipe declares a `dockerignore` so those secrets never enter the build context either.

## Design

Resolution and validation stay entirely in `schema.go`. `schemaplan.go` adds **only packaging** on top of a `*schemaPrerequisites`:

- a collision-free staged directory per lineage (`bootstrap/sources/<NN>-<label>/`), because a Dockerfile `COPY` cannot reach a sibling directory outside its context;
- an immutable copy of each source's migration files, recognized with the same `migrationFileName` definition the runtime's source driver filters on, so editor leftovers never enter the image;
- `bootstrap/plan.json` — lineages, ledgers, extensions, grant inputs and a content digest per staged file;
- `bootstrap/sources.sha256`, which the image verifies before applying anything.

Execution follows the single-locked-session design from #96. `bootstrap.sh` gates the run — bounded readiness, staged-source verification — and then hands **all** database work to one psql session over `bootstrap.sql`, which holds the runtime-access advisory lock across every lineage and the grants. Each lineage keeps its own `\if :SHELL_ERROR` guard (`ON_ERROR_STOP` does not cover `\!`), its own `env -u …` stripping (lib/pq panics on `PGSYSCONFDIR`), and `runtime-access.sql` stays `\i`-included rather than absorbed, so a consumer may still substitute it.

Non-test footprint: `builder.go`, `schemaplan.go`, `schema.go` (a one-line fix, below) and templates.

## Before / after

| | before | after |
|---|---|---|
| sibling sources in the image | absent | staged under `bootstrap/sources/<NN>-<label>/` |
| deployed ledgers | one, `schema_migrations` | one per source (`x-migrations-table`), own keeps `schema_migrations` |
| deployed extensions | never created | created, with the **same required/optional outcome** as local startup |
| `no-migration` | image still copied `migrations/` | packages no lineage, mirroring `applySchema` |
| image contents | whole service directory | staged tree + `bootstrap.sql` + `runtime-access.sql` |
| build context | whole service directory, secrets included | filtered by the recipe's declared `dockerignore` |

A required extension aborts the bootstrap rather than warning: #88 made a declared extension fail local readiness, and without matching that in the generated SQL the required contract would hold locally and silently degrade in the image — the exact class of divergence this PR removes.

## Staging safety

The staging root lives in the service directory, because the CLI resolves a recipe's `.` context there (`cli/pkg/orchestration/build_plan.go:222`), not to the recipe tree. Consequences the first revision got wrong and this one fixes:

- **It refuses to replace a `bootstrap/` directory it did not generate**, identified by a marker it writes. That name is plausible for hand-authored seed SQL, and staging deletes what it claims.
- **The tree is built beside its destination and swapped in**, never mutated in place, and **the image verifies every staged source against a sha256 manifest before touching the database** — the image is built later by a separate process, so a partly-written or drifted tree would otherwise apply fewer migrations and exit 0.
- **Staged file modes are normalized.** The recipe digest covers per-file mode, so a umask made identical content publish different digests, and under a restrictive umask the Job (uid 65534) could not read its own program.
- **The artifact carries no filesystem provenance**, so an absolute `migration-sources` path cannot put a developer's layout into the published plan.
- **A symlink is followed when it stays inside its source root** and rejected when it escapes.

## Also fixed: an empty own lineage could not start (`0c22a0f`)

An empty own `./migrations` is documented as legal, and the builder creates one so the image's `COPY` resolves — but it could not start. `resolveMigrationSources` admitted the lineage, and golang-migrate reports an empty source as a missing first version rather than "no change", so `Up()` returned `first .: file does not exist`.

One guard was answering two questions: `count == 0 && !own` fused "is emptiness an *error*?" (yes for a required declared source, no for the own directory) with "should this lineage be *applied*?" (never). Dropping `!own` separates them. Only the own-empty case changes. `schema_test.go` asserted `len(sources) != 1` here, pinning the defect; the regression test is in `main_test.go` against a real database and fails without the change.

## Test plan

- [x] `TestBootstrapImageMatchesLocalRuntimeSchema` (real Docker): three fixtures — two sibling sources with no own migrations, own + sibling, extension-only — each applied by the local runtime (through `resolveSchemaPrerequisites` → `applySchema`) **and** by the recipe-built image, against two separate fresh Postgres clusters. Tables, extensions, role attributes, grants and every ledger's version/dirty flag compared; both run twice, proving idempotence. All byte-identical.
- [x] `TestBootstrapImageAppliesOnlyRealMigrations` — through `builder.Build`: editor leftovers excluded, `.pgsql` migrations applied, ledger reaches `3/false`, real runtime-access reconciliation exercised.
- [x] `TestBootstrapRunsMigrationInsideRuntimeAccessLock` (#96's guarantee) — retained against the staged path: lock → every migration → grants, session-scoped, with the `SHELL_ERROR` guard.
- [x] `TestBuildPackagesTheSchemaItReports` — inverts the constraint #88 recorded: the build now stages the declared sibling it reports.
- [x] `TestBootstrapImageRefusesDriftedStagedSources`, `TestBootstrapImageBuildsTheWayTheCLIBuildsIt`, `TestBuildRefusesToReplaceAForeignBootstrapDirectory`, `TestBuildStagesModesIndependentOfUmask`, `TestBuildArtifactIsIdenticalAcrossCheckouts`, `TestBuildChecksumManifestCoversEveryStagedSource`.
- [x] Full `go test ./...` green (236s), plus `go build`, `go vet`, `go mod tidy -diff`, `gofmt`.
- [ ] `TestCreateToRunNix` **skipped — unqualified, not passing**: no nix on this host.

## Risks and limitations

- The image's `CMD` is `["/bin/sh", "/app/bootstrap/bootstrap.sh"]` and `/app/migrations` no longer exists. Nothing in this repo references that path.
- `bootstrap/` is written into the service directory on every build, beside the generated `runtime-access.sql` and `bootstrap.sql`. It carries its own `.gitignore`, so existing services need no factory re-render.
- A migration symlink escaping its source root fails the build; the error names `migration-sources` as the supported alternative.
- No cross-repository dependency: packaging is agent-local and no core/proto contract changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
