### PR TITLE
feat: add service-owned maintenance transactions to Go SDK

### DIFF
--- a/bootstrap_template_test.go
+++ b/bootstrap_template_test.go
@@ -137,6 +137,7 @@ func TestBootstrapImageAppliesOnlyRealMigrations(t *testing.T) {
 		MigrationConnectionKeyHolder: "{" + migrationConnectionEnvironmentKey + "}",
 		WithMigration:                true,
 		MigrationFileNamePattern:     migrationFileNamePattern,
+		ReadinessTimeoutSeconds:      defaultBootstrapReadinessSeconds,
 	}
 	dockerfile := renderBuilderTemplate(t, "templates/builder/Dockerfile.tmpl", parameters)
 	// One definition of a migration filename: a prune that drifts from the
@@ -270,7 +271,9 @@ func startBootstrapPostgres(t *testing.T) string {
 		t.Fatalf("start disposable postgres: %v\n%s", err, output)
 	}
 	for range 60 {
-		if exec.Command("docker", "exec", name, "pg_isready", "--username", "postgres").Run() == nil {
+		// The bootstrap connects over TCP; the initialization server can accept
+		// Unix-socket connections before the final TCP listener is available.
+		if exec.Command("docker", "exec", name, "pg_isready", "--host", "127.0.0.1", "--username", "postgres").Run() == nil {
 			return name
 		}
 		time.Sleep(time.Second)

--- a/libs/go/README.md
+++ b/libs/go/README.md
@@ -25,3 +25,28 @@ Privileged migration qualification is deliberately separate at
 migration inventories and owns isolated database create/clone/drop mechanics.
 It requires the plugin-private owner connection explicitly and is never exposed
 through the authenticated application `Factory`.
+
+## Service-owned maintenance
+
+`OpenMaintenance(ctx, connection, applicationRole, options...)` opens a separate
+capability for background cleanup, queue discovery or reconciliation. It uses the
+same Reader/Writer transaction implementation, clears tenant/user settings locally,
+and does not invent a tenant or grant database privileges. Application migrations
+own table grants and any explicit maintenance RLS policy. Every new connection
+checks that the selected role cannot log in, that neither the login nor selected
+role has elevated role flags, and that neither directly owns the database. These
+checks do not audit inherited memberships, table grants or application policies.
+Raw pools and migration APIs are not exposed. Keep Maintenance out of request
+handlers; they continue to receive only the authenticated Factory.
+
+`NewMaintenance` supports trusted preconfigured pool compositions and tests, just
+as `NewFactory` does; that caller owns pool closure and privilege qualification.
+`OpenMaintenance` owns an idempotent closer and accepts the existing token-provider
+and operation-timeout options. Neither constructor issues a new login credential
+or makes a request writer's credential less privileged. Separate process/secret
+identities must be provisioned by the platform when that isolation is required.
+
+`WithReadIsolation(pgx.RepeatableRead)` preserves a consistent snapshot across
+multiple queries. It affects readers only; writers keep their existing isolation
+semantics and application-owned row locking. Failed callbacks roll back as in the
+existing scoped Factory. Without this option, existing read isolation is unchanged.

--- a/libs/go/maintenance.go
+++ b/libs/go/maintenance.go
@@ -1,0 +1,130 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// WithReadIsolation selects the snapshot semantics of read transactions only.
+// Writer isolation remains unchanged; applications retain their locking rules.
+func WithReadIsolation(level pgx.TxIsoLevel) Option {
+	return func(c *config) error {
+		switch level {
+		case pgx.ReadCommitted, pgx.RepeatableRead, pgx.Serializable:
+			c.readIsolation = level
+			return nil
+		default:
+			return errors.New("unsupported Postgres read isolation")
+		}
+	}
+}
+
+// Maintenance is a service-owned capability for cross-tenant coordination.
+// It is wired separately from authenticated request Factories and must never be
+// passed to request handlers. It grants no privileges: application migrations
+// and the owning service's role reconciler define its exact database access.
+// There is no synthetic tenant and no admin/migration API or exposed pool.
+type Maintenance struct {
+	backend transactionBeginner
+	config  config
+}
+
+// NewMaintenance binds a preconfigured pool at a trusted composition boundary,
+// like NewFactory. The caller owns its lifecycle and privilege qualification.
+// Deployments should prefer OpenMaintenance, which validates the login and role.
+func NewMaintenance(pool *pgxpool.Pool, options ...Option) (*Maintenance, error) {
+	if pool == nil {
+		return nil, errors.New("maintenance Postgres pool is required")
+	}
+	c, err := configured(options...)
+	if err != nil {
+		return nil, err
+	}
+	return &Maintenance{backend: poolBeginner{pool: pool}, config: c}, nil
+}
+
+// OpenMaintenance selects an explicit application group through a service-owned
+// connection capability. It rejects privileged logins, login-enabled application
+// roles and database owners. It never creates roles or changes memberships.
+func OpenMaintenance(ctx context.Context, connection, applicationRole string, options ...Option) (*Maintenance, func(), error) {
+	if ctx == nil || strings.TrimSpace(connection) == "" || strings.TrimSpace(applicationRole) == "" {
+		return nil, nil, errors.New("maintenance context, connection and application role are required")
+	}
+	c, err := configured(options...)
+	if err != nil {
+		return nil, nil, err
+	}
+	if c.operationTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.operationTimeout)
+		defer cancel()
+	}
+	pc, err := pgxpool.ParseConfig(connection)
+	if err != nil {
+		return nil, nil, errors.New("invalid maintenance Postgres connection")
+	}
+	if role := pc.ConnConfig.RuntimeParams["role"]; role != "" && role != applicationRole {
+		return nil, nil, errors.New("maintenance application role conflicts with connection")
+	}
+	pc.ConnConfig.RuntimeParams["role"] = applicationRole
+	if c.accessTokenProvider != nil {
+		installAccessTokenProvider(pc, c.accessTokenProvider)
+	}
+	// Qualify each new backend, including after a reconnect or credential rotation.
+	pc.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		var safe bool
+		err := conn.QueryRow(ctx, `SELECT current_user=$1 AND NOT a.rolcanlogin
+		 AND NOT (a.rolsuper OR a.rolcreatedb OR a.rolcreaterole OR a.rolreplication OR a.rolbypassrls)
+		 AND NOT (l.rolsuper OR l.rolcreatedb OR l.rolcreaterole OR l.rolreplication OR l.rolbypassrls)
+		 AND d.datdba NOT IN (a.oid,l.oid)
+		 FROM pg_roles a, pg_roles l, pg_database d
+		 WHERE a.rolname=current_user AND l.rolname=session_user AND d.datname=current_database()`, applicationRole).Scan(&safe)
+		if err != nil {
+			return errors.New("cannot qualify maintenance Postgres role")
+		}
+		if !safe {
+			return errors.New("maintenance requires a restricted login and non-owner application group")
+		}
+		return nil
+	}
+	pool, err := pgxpool.NewWithConfig(ctx, pc)
+	if err != nil {
+		return nil, nil, errors.New("cannot open maintenance Postgres capability")
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, nil, err
+	}
+	maintenance, err := NewMaintenance(pool, options...)
+	if err != nil {
+		pool.Close()
+		return nil, nil, err
+	}
+	var once sync.Once
+	return maintenance, func() { once.Do(pool.Close) }, nil
+}
+
+func (m *Maintenance) scope() transactionScope {
+	// Clear tenant/user settings transaction-locally, including when a connection
+	// arrived with session defaults. RLS can authorize only the explicit role.
+	return transactionScope{tenantSetting: m.config.tenantSetting, userSetting: m.config.userSetting}
+}
+
+func (m *Maintenance) Reader(ctx context.Context) (*Reader, error) {
+	if m == nil || m.backend == nil || ctx == nil {
+		return nil, ErrUnauthenticated
+	}
+	return &Reader{beginner: m.backend, scope: m.scope(), operationTimeout: m.config.operationTimeout, isolation: m.config.readIsolation}, nil
+}
+
+func (m *Maintenance) Writer(ctx context.Context) (*Writer, error) {
+	if m == nil || m.backend == nil || ctx == nil {
+		return nil, ErrUnauthorized
+	}
+	return &Writer{beginner: m.backend, scope: m.scope(), operationTimeout: m.config.operationTimeout}, nil
+}

--- a/libs/go/maintenance_test.go
+++ b/libs/go/maintenance_test.go
@@ -1,0 +1,60 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+)
+
+func TestMaintenanceUsesSharedTransactionsWithoutTenantImpersonation(t *testing.T) {
+	for _, fail := range []bool{false, true} {
+		backend := &fakeBeginner{tx: &fakeTransaction{}}
+		c, err := configured(WithReadIsolation(pgx.RepeatableRead))
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := &Maintenance{backend: backend, config: c}
+		reader, err := m.Reader(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		callbackErr := errors.New("callback failed")
+		err = reader.InTransaction(context.Background(), func(context.Context, ReadTx) error {
+			if fail {
+				return callbackErr
+			}
+			return nil
+		})
+		if fail != errors.Is(err, callbackErr) || backend.tx.committed == fail {
+			t.Fatalf("transaction result: %v, committed %v", err, backend.tx.committed)
+		}
+		if backend.options.AccessMode != pgx.ReadOnly || backend.options.IsoLevel != pgx.RepeatableRead {
+			t.Fatal("lost read snapshot semantics")
+		}
+		if !reflect.DeepEqual(backend.tx.executions[0].arguments, []any{"codefly.current_tenant_id", "", "codefly.current_user_id", ""}) {
+			t.Fatal("maintenance impersonated a tenant")
+		}
+	}
+}
+
+func TestMaintenanceInvalidCompositionFailsClosed(t *testing.T) {
+	var m *Maintenance
+	if _, err := m.Reader(context.Background()); err == nil {
+		t.Fatal("nil maintenance reader")
+	}
+	if _, err := m.Writer(context.Background()); err == nil {
+		t.Fatal("nil maintenance writer")
+	}
+	if _, err := NewMaintenance(nil); err == nil {
+		t.Fatal("nil maintenance pool")
+	}
+	if _, err := configured(WithReadIsolation("invalid")); err == nil {
+		t.Fatal("invalid isolation accepted")
+	}
+	if _, _, err := OpenMaintenance(context.Background(), "postgres://user@localhost/db?role=owner", "app_worker"); err == nil {
+		t.Fatal("conflicting role accepted")
+	}
+}

--- a/libs/go/store.go
+++ b/libs/go/store.go
@@ -152,6 +152,7 @@ type config struct {
 	tenantSetting       string
 	userSetting         string
 	operationTimeout    time.Duration
+	readIsolation       pgx.TxIsoLevel
 	accessTokenProvider AccessTokenProvider
 }
 
@@ -244,7 +245,7 @@ func (f *Factory) Reader(ctx context.Context) (*Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Reader{beginner: f.reader, scope: scope, operationTimeout: f.config.operationTimeout}, nil
+	return &Reader{beginner: f.reader, scope: scope, operationTimeout: f.config.operationTimeout, isolation: f.config.readIsolation}, nil
 }
 
 // Writer resolves the authenticated principal and requires an explicit
@@ -314,8 +315,10 @@ func (f *Factory) principal(ctx context.Context) (Principal, transactionScope, e
 	}, nil
 }
 
-// Reader is an authenticated, principal-bound read capability.
+// Reader is a transaction-scoped read capability, bound to an authenticated
+// principal by Factory or to an explicit service-owned Maintenance capability.
 type Reader struct {
+	isolation        pgx.TxIsoLevel
 	beginner         transactionBeginner
 	scope            transactionScope
 	operationTimeout time.Duration
@@ -327,7 +330,7 @@ func (r *Reader) InTransaction(ctx context.Context, fn func(context.Context, Rea
 	if fn == nil {
 		return errors.New("read transaction callback is required")
 	}
-	return runTransaction(ctx, r.beginner, r.scope, r.operationTimeout, pgx.ReadOnly, func(ctx context.Context, tx transaction) error {
+	return runTransaction(ctx, r.beginner, r.scope, r.operationTimeout, pgx.ReadOnly, r.isolation, func(ctx context.Context, tx transaction) error {
 		return fn(ctx, readTx{tx: tx})
 	})
 }
@@ -345,7 +348,7 @@ func (w *Writer) InTransaction(ctx context.Context, fn func(context.Context, Wri
 	if fn == nil {
 		return errors.New("write transaction callback is required")
 	}
-	return runTransaction(ctx, w.beginner, w.scope, w.operationTimeout, pgx.ReadWrite, func(ctx context.Context, tx transaction) error {
+	return runTransaction(ctx, w.beginner, w.scope, w.operationTimeout, pgx.ReadWrite, "", func(ctx context.Context, tx transaction) error {
 		return fn(ctx, writeTx{tx: tx, tenantSetting: w.scope.tenantSetting})
 	})
 }
@@ -463,6 +466,7 @@ func runTransaction(
 	scope transactionScope,
 	operationTimeout time.Duration,
 	accessMode pgx.TxAccessMode,
+	isolation pgx.TxIsoLevel,
 	callback func(context.Context, transaction) error,
 ) error {
 	if ctx == nil {
@@ -473,7 +477,7 @@ func runTransaction(
 		ctx, cancel = context.WithTimeout(ctx, operationTimeout)
 		defer cancel()
 	}
-	tx, err := beginner.BeginTx(ctx, pgx.TxOptions{AccessMode: accessMode})
+	tx, err := beginner.BeginTx(ctx, pgx.TxOptions{AccessMode: accessMode, IsoLevel: isolation})
 	if err != nil {
 		return fmt.Errorf("begin scoped Postgres transaction: %w", err)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -267,6 +267,26 @@ func testCreateToRun(t *testing.T, runtimeContext *basev0.RuntimeContext) {
 	runtime.RuntimeReadWriteRoles = []string{delegatedWriter}
 	require.NoError(t, runtime.ensureRuntimeAccess(ctx))
 
+	maintenance, closeMaintenance, err := scoped.OpenMaintenance(ctx, readWriteConnection, delegatedWriter, scoped.WithOperationTimeout(5*time.Second))
+	require.NoError(t, err)
+	maintenanceWriter, err := maintenance.Writer(ctx)
+	require.NoError(t, err)
+	require.NoError(t, maintenanceWriter.InTransaction(ctx, func(ctx context.Context, tx scoped.WriteTx) error {
+		_, err := tx.Exec(ctx, "INSERT INTO "+pq.QuoteIdentifier(serviceName)+" (id) VALUES ($1)", "10000000-0000-0000-0000-000000000001")
+		return err
+	}))
+	require.Error(t, maintenanceWriter.InTransaction(ctx, func(ctx context.Context, tx scoped.WriteTx) error {
+		_, err := tx.Exec(ctx, "CREATE TABLE forbidden_maintenance(id integer)")
+		return err
+	}))
+	closeMaintenance()
+	closeMaintenance()
+	_, closeOwner, err := scoped.OpenMaintenance(ctx, runtime.connection, delegatedWriter, scoped.WithOperationTimeout(5*time.Second))
+	if err == nil {
+		closeOwner()
+	}
+	require.Error(t, err, "maintenance must not accept the migration owner")
+
 	assertExternalIdentityReconciliation(t, ctx, migrationControl)
 	assertExternalIdentityTokenAuthentication(t, ctx, readOnlyConnection, readWriteConnection)
 


### PR DESCRIPTION
Background cleanup and reconciliation need transactions outside an authenticated user request. Today those callers must open their own pools or manufacture request context to use the scoped SDK.

This adds an explicit service-owned `Maintenance` capability that reuses the existing Reader/Writer transaction implementation. `OpenMaintenance` selects a configured application role and checks every new connection for elevated login/role flags and direct database ownership. Transactions clear tenant/user settings locally; application grants and RLS policies remain authoritative. `NewMaintenance` supports trusted preconfigured pools, with lifecycle and privilege checks owned by the caller.

`WithReadIsolation` allows readers to select a consistent snapshot when several queries must agree. Default reader behavior and writer isolation remain unchanged. Documentation states the composition boundary and limits of the role checks; neither constructor provisions roles or credentials, audits inherited memberships, or exposes migration APIs.

The bootstrap migration integration fixture uses the configured default readiness budget and waits for TCP readiness, matching the bootstrap connection. This prevents a zero-second readiness deadline or the temporary Unix-socket initialization server from causing a startup race.

Validation:
- `go test -race ./... -count=1 -timeout 8m` passed, including the Docker create-to-run lifecycle with maintenance DML, DDL denial, owner rejection and repeated closure. Nix lifecycle was skipped because Nix is unavailable locally.
- `go vet ./...` passed.
- SDK tests cover cleared scope, read-only repeatable-read transactions, callback rollback and invalid composition.
- `TestBootstrapImageAppliesOnlyRealMigrations` passed three consecutive runs with disposable PostgreSQL containers.

No dependency, image, schema or generated-artifact changes.
