### PR TITLE
fix: retry the runtime tag read-back before failing (#98)

### DIFF
--- a/.github/scripts/tag-runtime-image.sh
+++ b/.github/scripts/tag-runtime-image.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# ghcr.io does not promise read-your-writes on tags: the tag can be published
+# and still not resolve for a beat afterwards. Retry the read so propagation
+# lag stays distinguishable from the tag holding the wrong digest.
+resolve_tag_digest() {
+  local attempt
+  local digest
+  for attempt in 1 2 3 4 5; do
+    if ((attempt > 1)); then
+      sleep $(((attempt - 1) * 2))
+    fi
+    if digest=$(docker buildx imagetools inspect "$RUNTIME_TAG" |
+      awk '$1 == "Digest:" { print $2; exit }') && [[ -n "$digest" ]]; then
+      printf '%s\n' "$digest"
+      return 0
+    fi
+  done
+  return 1
+}
+
+: "${EXPECTED_DIGEST:?EXPECTED_DIGEST is required}"
+: "${RUNTIME_IMAGE:?RUNTIME_IMAGE is required}"
+: "${RUNTIME_TAG:?RUNTIME_TAG is required}"
+
+docker buildx imagetools create --tag "$RUNTIME_TAG" "$RUNTIME_IMAGE"
+
+if ! tagged_digest=$(resolve_tag_digest); then
+  echo "$RUNTIME_TAG was published but did not resolve to a digest" >&2
+  exit 1
+fi
+if [[ "$tagged_digest" != "$EXPECTED_DIGEST" ]]; then
+  echo "tagged digest $tagged_digest does not match $EXPECTED_DIGEST" >&2
+  exit 1
+fi

--- a/.github/scripts/tag-runtime-image.sh
+++ b/.github/scripts/tag-runtime-image.sh
@@ -2,36 +2,49 @@
 
 set -euo pipefail
 
-# ghcr.io does not promise read-your-writes on tags: the tag can be published
-# and still not resolve for a beat afterwards. Retry the read so propagation
-# lag stays distinguishable from the tag holding the wrong digest.
-resolve_tag_digest() {
-  local attempt
-  local digest
-  for attempt in 1 2 3 4 5; do
-    if ((attempt > 1)); then
-      sleep $(((attempt - 1) * 2))
-    fi
-    if digest=$(docker buildx imagetools inspect "$RUNTIME_TAG" |
-      awk '$1 == "Digest:" { print $2; exit }') && [[ -n "$digest" ]]; then
-      printf '%s\n' "$digest"
-      return 0
-    fi
-  done
-  return 1
-}
+# ghcr.io does not promise read-your-writes on tags, and a lagging read shows up
+# two ways: the read fails, or it serves the digest the tag held before this
+# push. Neither is a verdict until the budget below is spent. Seconds, summing
+# to two minutes; a read that lands on the first attempt costs none of it.
+readonly PROPAGATION_DELAYS=(2 4 8 16 30 30 30)
+
+# Bounds a hung read, which would otherwise stall the job until GitHub's
+# six-hour default, once per attempt.
+readonly READ_TIMEOUT=60
 
 : "${EXPECTED_DIGEST:?EXPECTED_DIGEST is required}"
 : "${RUNTIME_IMAGE:?RUNTIME_IMAGE is required}"
 : "${RUNTIME_TAG:?RUNTIME_TAG is required}"
 
+# Checked up front because the read below turns any failure into another
+# retry, which would report a missing timeout as an unresolvable tag.
+if ! command -v timeout >/dev/null; then
+  echo "timeout is required to bound registry reads" >&2
+  exit 1
+fi
+
 docker buildx imagetools create --tag "$RUNTIME_TAG" "$RUNTIME_IMAGE"
 
-if ! tagged_digest=$(resolve_tag_digest); then
+tagged_digest=""
+attempt=0
+while :; do
+  # The fallback keeps a failed read from aborting the script under errexit
+  # before the diagnosis below can run.
+  tagged_digest=$(timeout "$READ_TIMEOUT" docker buildx imagetools inspect "$RUNTIME_TAG" |
+    awk '$1 == "Digest:" { print $2; exit }') || tagged_digest=""
+  if [[ "$tagged_digest" == "$EXPECTED_DIGEST" ]]; then
+    exit 0
+  fi
+  if ((attempt >= ${#PROPAGATION_DELAYS[@]})); then
+    break
+  fi
+  sleep "${PROPAGATION_DELAYS[attempt]}"
+  attempt=$((attempt + 1))
+done
+
+if [[ -z "$tagged_digest" ]]; then
   echo "$RUNTIME_TAG was published but did not resolve to a digest" >&2
-  exit 1
+else
+  echo "$RUNTIME_TAG resolves to $tagged_digest, want $EXPECTED_DIGEST" >&2
 fi
-if [[ "$tagged_digest" != "$EXPECTED_DIGEST" ]]; then
-  echo "tagged digest $tagged_digest does not match $EXPECTED_DIGEST" >&2
-  exit 1
-fi
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,12 +207,4 @@ jobs:
           EXPECTED_DIGEST: ${{ steps.runtime.outputs.digest }}
           RUNTIME_IMAGE: ${{ steps.runtime.outputs.reference }}
           RUNTIME_TAG: ${{ steps.runtime.outputs.tag_reference }}
-        run: |
-          set -euo pipefail
-          docker buildx imagetools create --tag "$RUNTIME_TAG" "$RUNTIME_IMAGE"
-          tagged_digest=$(docker buildx imagetools inspect "$RUNTIME_TAG" |
-            awk '$1 == "Digest:" { print $2; exit }')
-          if [[ "$tagged_digest" != "$EXPECTED_DIGEST" ]]; then
-            echo "tagged digest $tagged_digest does not match $EXPECTED_DIGEST" >&2
-            exit 1
-          fi
+        run: .github/scripts/tag-runtime-image.sh

--- a/tag_runtime_image_test.go
+++ b/tag_runtime_image_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	taggedImage  = "ghcr.io/codefly-dev/service-postgres@sha256:d8847e56"
+	taggedDigest = "sha256:d8847e56"
+	taggedTag    = "ghcr.io/codefly-dev/service-postgres:postgres-17.10-pgvector-0.8.5-alpine3.24"
+)
+
+func TestTagRuntimeImageRetriesUntilTheTagResolves(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, 2, taggedDigest)
+
+	require.NoErrorf(t, err, "output: %s", output)
+	calls := readCalls(t, log)
+	require.Equal(t, "buildx imagetools create --tag "+taggedTag+" "+taggedImage+" ", calls[0])
+	require.Len(t, calls, 4)
+}
+
+func TestTagRuntimeImageFailsWhenTheTagNeverResolves(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, 5, taggedDigest)
+
+	require.Error(t, err)
+	require.Contains(t, output, taggedTag+" was published but did not resolve to a digest")
+	require.Len(t, readCalls(t, log), 6)
+}
+
+func TestTagRuntimeImageFailsWhenTheTagHoldsAnotherDigest(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, 0, "sha256:0ther")
+
+	require.Error(t, err)
+	require.Contains(t, output, "tagged digest sha256:0ther does not match "+taggedDigest)
+	require.Len(t, readCalls(t, log), 2)
+}
+
+// runTagRuntimeImage runs the tagging script against a docker whose reads of the
+// tag fail the first inspectFailures times, standing in for a registry that has
+// not propagated the tag yet.
+func runTagRuntimeImage(t *testing.T, log string, inspectFailures int, digest string) (string, error) {
+	t.Helper()
+	command := exec.Command("bash", ".github/scripts/tag-runtime-image.sh")
+	command.Env = append(os.Environ(),
+		"PATH="+fakeDocker(t)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOCKER_LOG="+log,
+		"DOCKER_INSPECT_DIGEST="+digest,
+		"DOCKER_INSPECT_FAILURES="+strconv.Itoa(inspectFailures),
+		"EXPECTED_DIGEST="+taggedDigest,
+		"RUNTIME_IMAGE="+taggedImage,
+		"RUNTIME_TAG="+taggedTag,
+	)
+	output, err := command.CombinedOutput()
+	return string(output), err
+}
+
+// fakeDocker also shadows sleep so the backoff does not slow the test down.
+func fakeDocker(t *testing.T) string {
+	t.Helper()
+	bin := t.TempDir()
+	for name, source := range map[string]string{
+		"docker": `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s ' "$@" >>"$DOCKER_LOG"
+printf '\n' >>"$DOCKER_LOG"
+if [[ "$3" != inspect ]]; then
+  exit 0
+fi
+if (($(grep -c 'imagetools inspect' "$DOCKER_LOG") <= DOCKER_INSPECT_FAILURES)); then
+  echo "ERROR: unexpected status from HEAD request to $4: 404 Not Found" >&2
+  exit 1
+fi
+printf 'Name:      %s\nDigest:    %s\n' "$4" "$DOCKER_INSPECT_DIGEST"
+`,
+		"sleep": "#!/usr/bin/env bash\n",
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(bin, name), []byte(source), 0o755))
+	}
+	return bin
+}

--- a/tag_runtime_image_test.go
+++ b/tag_runtime_image_test.go
@@ -13,57 +13,109 @@ import (
 const (
 	taggedImage  = "ghcr.io/codefly-dev/service-postgres@sha256:d8847e56"
 	taggedDigest = "sha256:d8847e56"
+	staleDigest  = "sha256:5731ed01"
 	taggedTag    = "ghcr.io/codefly-dev/service-postgres:postgres-17.10-pgvector-0.8.5-alpine3.24"
 )
 
-func TestTagRuntimeImageRetriesUntilTheTagResolves(t *testing.T) {
+// readBackBudget is the number of reads the script spends before it rules on
+// the tag: one per propagation delay, plus the first read.
+const readBackBudget = 8
+
+// registry describes how ghcr.io answers reads of the tag just written: some
+// reads failing outright, then some serving whatever digest the tag held
+// before the push, then digest.
+type registry struct {
+	failedReads int
+	staleReads  int
+	digest      string
+}
+
+func TestTagRuntimeImagePublishesTheTagBeforeReadingItBack(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, 2, taggedDigest)
+	output, err := runTagRuntimeImage(t, log, registry{digest: taggedDigest})
 
 	require.NoErrorf(t, err, "output: %s", output)
 	calls := readCalls(t, log)
 	require.Equal(t, "buildx imagetools create --tag "+taggedTag+" "+taggedImage+" ", calls[0])
-	require.Len(t, calls, 4)
+	require.Len(t, calls, 2, "a tag that reads back correctly costs one read")
 }
 
-func TestTagRuntimeImageFailsWhenTheTagNeverResolves(t *testing.T) {
+func TestTagRuntimeImageRetriesWhileTheTagCannotBeRead(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, 5, taggedDigest)
+	output, err := runTagRuntimeImage(t, log, registry{failedReads: 2, digest: taggedDigest})
+
+	require.NoErrorf(t, err, "output: %s", output)
+	require.Len(t, readCalls(t, log), 4)
+}
+
+// A propagation lag can serve the digest the tag held before the push just as
+// easily as it can fail the read, so a mismatch is no more final than an
+// unreadable tag until the budget is spent.
+func TestTagRuntimeImageRetriesWhileTheTagServesAStaleDigest(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, registry{staleReads: 2, digest: taggedDigest})
+
+	require.NoErrorf(t, err, "output: %s", output)
+	require.Len(t, readCalls(t, log), 4)
+}
+
+func TestTagRuntimeImageFailsWhenTheTagNeverBecomesReadable(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, registry{failedReads: readBackBudget + 1})
 
 	require.Error(t, err)
 	require.Contains(t, output, taggedTag+" was published but did not resolve to a digest")
-	require.Len(t, readCalls(t, log), 6)
+	require.Len(t, readCalls(t, log), readBackBudget+1)
 }
 
-func TestTagRuntimeImageFailsWhenTheTagHoldsAnotherDigest(t *testing.T) {
+// The retry must still terminate: a tag that genuinely holds another digest —
+// a concurrent build moved it — has to redden the job, naming what it found.
+func TestTagRuntimeImageFailsWhenTheTagKeepsAnotherDigest(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, 0, "sha256:0ther")
+	output, err := runTagRuntimeImage(t, log, registry{digest: staleDigest})
 
 	require.Error(t, err)
-	require.Contains(t, output, "tagged digest sha256:0ther does not match "+taggedDigest)
-	require.Len(t, readCalls(t, log), 2)
+	require.Contains(t, output, taggedTag+" resolves to "+staleDigest+", want "+taggedDigest)
+	require.Len(t, readCalls(t, log), readBackBudget+1)
 }
 
-// runTagRuntimeImage runs the tagging script against a docker whose reads of the
-// tag fail the first inspectFailures times, standing in for a registry that has
-// not propagated the tag yet.
-func runTagRuntimeImage(t *testing.T, log string, inspectFailures int, digest string) (string, error) {
+// Without timeout every read fails, and the retry would report that as a tag
+// that never resolved rather than as the missing dependency it is.
+func TestTagRuntimeImageFailsLoudlyWithoutTimeout(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	command := tagRuntimeImageCommand(t, log, registry{digest: taggedDigest})
+	command.Env = append(command.Env, "PATH="+t.TempDir())
+	output, err := command.CombinedOutput()
+
+	require.Error(t, err)
+	require.Contains(t, string(output), "timeout is required to bound registry reads")
+}
+
+func runTagRuntimeImage(t *testing.T, log string, ghcr registry) (string, error) {
+	t.Helper()
+	output, err := tagRuntimeImageCommand(t, log, ghcr).CombinedOutput()
+	return string(output), err
+}
+
+func tagRuntimeImageCommand(t *testing.T, log string, ghcr registry) *exec.Cmd {
 	t.Helper()
 	command := exec.Command("bash", ".github/scripts/tag-runtime-image.sh")
 	command.Env = append(os.Environ(),
 		"PATH="+fakeDocker(t)+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"DOCKER_LOG="+log,
-		"DOCKER_INSPECT_DIGEST="+digest,
-		"DOCKER_INSPECT_FAILURES="+strconv.Itoa(inspectFailures),
+		"DOCKER_FAILED_READS="+strconv.Itoa(ghcr.failedReads),
+		"DOCKER_STALE_READS="+strconv.Itoa(ghcr.staleReads),
+		"DOCKER_STALE_DIGEST="+staleDigest,
+		"DOCKER_DIGEST="+ghcr.digest,
 		"EXPECTED_DIGEST="+taggedDigest,
 		"RUNTIME_IMAGE="+taggedImage,
 		"RUNTIME_TAG="+taggedTag,
 	)
-	output, err := command.CombinedOutput()
-	return string(output), err
+	return command
 }
 
-// fakeDocker also shadows sleep so the backoff does not slow the test down.
+// fakeDocker also shadows sleep, so the propagation budget does not become the
+// test's runtime.
 func fakeDocker(t *testing.T) string {
 	t.Helper()
 	bin := t.TempDir()
@@ -75,11 +127,16 @@ printf '\n' >>"$DOCKER_LOG"
 if [[ "$3" != inspect ]]; then
   exit 0
 fi
-if (($(grep -c 'imagetools inspect' "$DOCKER_LOG") <= DOCKER_INSPECT_FAILURES)); then
+read_number=$(grep -c 'imagetools inspect' "$DOCKER_LOG")
+if ((read_number <= DOCKER_FAILED_READS)); then
   echo "ERROR: unexpected status from HEAD request to $4: 404 Not Found" >&2
   exit 1
 fi
-printf 'Name:      %s\nDigest:    %s\n' "$4" "$DOCKER_INSPECT_DIGEST"
+digest=$DOCKER_DIGEST
+if ((read_number <= DOCKER_FAILED_READS + DOCKER_STALE_READS)); then
+  digest=$DOCKER_STALE_DIGEST
+fi
+printf 'Name:      %s\nDigest:    %s\n' "$4" "$digest"
 `,
 		"sleep": "#!/usr/bin/env bash\n",
 	} {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -107,7 +107,12 @@ func TestCIWorkflowValidatesLockedImageForEveryPullRequest(t *testing.T) {
 	require.Equal(t, false, candidate.With["sbom"])
 	require.Contains(t, verifyCandidate.Run, `"$ACTUAL_DIGEST" != "$EXPECTED_DIGEST"`)
 	require.Contains(t, scan.Run, `docker save --output /tmp/service-postgres-image.tar "$RUNTIME_IMAGE"`)
-	require.Contains(t, tag.Run, `docker buildx imagetools create --tag "$RUNTIME_TAG" "$RUNTIME_IMAGE"`)
+	require.Equal(t, ".github/scripts/tag-runtime-image.sh", strings.TrimSpace(tag.Run))
+	require.Equal(t, map[string]string{
+		"EXPECTED_DIGEST": "${{ steps.runtime.outputs.digest }}",
+		"RUNTIME_IMAGE":   "${{ steps.runtime.outputs.reference }}",
+		"RUNTIME_TAG":     "${{ steps.runtime.outputs.tag_reference }}",
+	}, tag.Env)
 
 	buildx := findWorkflowAction(t, imageJob, "docker/setup-buildx-action")
 	require.Equal(t,


### PR DESCRIPTION
Closes #98.

## Summary

- `Tag verified runtime image` published a ghcr.io tag and read it straight back to confirm its digest. Registry tags are not read-your-writes, so a slow propagation reddened a PR whose contents were fine — and reported nothing, because under `set -e` the failing command substitution aborted before the mismatch branch could run.
- A lagging read has two shapes, and both are now treated as lag: the read fails, or it succeeds and serves the digest the tag held before this push. The second one matters on any commit that relocks `runtime-image.json`, where accepting a stale read as final would fail with `does not match` — indistinguishable from a bad lock file, and an invitation to relock to the stale digest. The read retries until the digest matches or a two-minute budget is spent, then reports whichever state the tag ended in.
- A genuine mismatch still reddens the job, naming the digest actually found. Each read is bounded by `timeout` so a hung registry cannot hold the job to GitHub's six-hour default once per attempt.

## Why a script rather than inline shell

The step body moved to `.github/scripts/tag-runtime-image.sh` because inline `run:` shell cannot be tested, and untested inline shell is how this bug shipped. This is not quite the established pattern here — the two existing scripts are 90 and 200+ lines of real logic, and this job already carries an inline retry loop (the readiness poll in `Smoke test runtime image`) that was never extracted. Testability is the justification, not precedent. `workflow_test.go` pins the step to the script plus the three env vars it requires, so the wiring cannot drift.

## Risk

The retry budget is bounded and terminal, so the worst case is a job that spends two extra minutes before failing exactly as it would have. Nothing on the publish path changed: the tag is written by the same `imagetools create` as before, and the digest verification is unchanged — only the read tolerates lag.

## Follow-ups filed, not folded in

- #100 — `releaser.yml`'s `Publish release image tags` has the same create-then-inspect race over two tags.
- #101 — same-repo PR builds publish the shared runtime tag, so concurrent PRs can race on it. Pre-existing and a maintainer decision either way; this PR makes that case fail with an accurate message instead of a bare exit 255.

## Test plan

- [x] `go test . -run '^TestTagRuntimeImage' -count=1` — six cases: a clean read-back costing one read; retrying past failed reads; retrying past a stale digest; a tag that never becomes readable; a tag that keeps another digest (terminates, names it); and a missing `timeout` failing loudly rather than as an unresolvable tag.
- [x] Verified all four behavior-changing cases fail against the previous version of the script, so they capture the fixes rather than restate them.
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .`, and the full unit suite as CI runs it — green.
- [x] `shellcheck .github/scripts/tag-runtime-image.sh` — clean.
- [ ] The real read-back against ghcr.io only exercises on this PR's own `image` job, and a green run is not evidence the race is fixed — the original bug was also green on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)