### PR TITLE
fix: reconcile safe groups with restricted role administrators

### DIFF
--- a/.github/workflows/controlplane.yml
+++ b/.github/workflows/controlplane.yml
@@ -1,0 +1,38 @@
+name: controlplane
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "libs/go/**"
+      - "go.mod"
+      - "go.sum"
+      - "scripts/qualify-controlplane.py"
+      - ".github/workflows/controlplane.yml"
+  push:
+    branches: [main]
+    paths:
+      - "libs/go/**"
+      - "go.mod"
+      - "go.sum"
+      - "scripts/qualify-controlplane.py"
+      - ".github/workflows/controlplane.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  restricted-postgres16:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      POSTGRES_TEST_IMAGE: postgres@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
+        with:
+          go-version-file: go.mod
+          cache: false
+      - run: go vet ./libs/go/controlplane
+      - run: docker pull "$POSTGRES_TEST_IMAGE"
+      - run: python3 scripts/qualify-controlplane.py

--- a/libs/go/README.md
+++ b/libs/go/README.md
@@ -50,3 +50,45 @@ identities must be provisioned by the platform when that isolation is required.
 multiple queries. It affects readers only; writers keep their existing isolation
 semantics and application-owned row locking. Failed callbacks roll back as in the
 existing scoped Factory. Without this option, existing read isolation is unchanged.
+
+## External-identity role administration
+
+`controlplane.ReconcileRuntimeAccess` is the privileged role-engine boundary for
+managed database compositions. Callers own the transaction and per-database
+advisory lock, and must roll back on any error. Identity providers create login
+principals; the engine never sets their passwords. It creates and hardens NOLOGIN
+groups and reconciles runtime grants and external membership separately.
+
+Group hardening changes only attributes that differ from the required safe
+values. PostgreSQL requires elevated authority for protected `ALTER ROLE`
+attributes even if their current value already matches. Avoiding those redundant
+updates allows a CREATEROLE administrator to reconcile ordinary groups; it does
+not authorize that administrator to repair an elevated role. Existing unsafe
+attributes are still hardened when authorized, or cause the transaction to fail.
+See [PostgreSQL's ALTER ROLE permission rules](https://www.postgresql.org/docs/16/sql-alterrole.html).
+
+The administrator also needs ownership/grant authority over the selected
+database, schema, existing objects and migration owner's default privileges.
+On PostgreSQL 16, role administration requires the appropriate ADMIN OPTION;
+the regression checks that the creator's administration-only membership remains
+available over repeated reconciliation. Login IAM alone supplies none of these
+SQL privileges. Exact managed-provider administration must be qualified separately.
+Keep the reconciliation identity stable. Switching the grantor can encounter
+dependent membership grants on PostgreSQL 16; this change does not implement
+administrator rotation, cascade revocation or privilege reassignment.
+
+Run the isolated regression with a locally available, digest-pinned official
+PostgreSQL fixture (the workflow pins the tested image):
+
+```sh
+POSTGRES_TEST_IMAGE=postgres@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54 \
+  python3 scripts/qualify-controlplane.py
+```
+
+The harness binds a disposable, trust-authenticated container to a random
+loopback port, uses temporary storage and removes only that container on exit.
+It loads no cloud credentials and accepts no managed endpoint. The dedicated
+`controlplaneintegration` tag fails if this fixture is missing. Tests cover
+restricted-admin replay and membership replacement, existing/default table and
+sequence grants, runtime DDL denial, preserved external passwords/unrelated
+memberships, rollback, elevated-role rejection and authorized hardening.

--- a/libs/go/controlplane/access.go
+++ b/libs/go/controlplane/access.go
@@ -208,7 +208,29 @@ func ensureGroupRole(ctx context.Context, tx *sql.Tx, role string) error {
 			return err
 		}
 	}
-	_, err := tx.ExecContext(ctx, `ALTER ROLE `+quotedRole+` WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION NOBYPASSRLS`)
+	// Reasserting NOSUPERUSER (even when already false) requires a superuser.
+	// Managed administrators must not need protected attributes just to reconcile
+	// already-safe groups. Only change attributes which actually differ; an
+	// elevated existing group still requires authority to remove those privileges.
+	var login, superuser, createDB, createRole, inherit, replication, bypassRLS bool
+	if err := tx.QueryRowContext(ctx, `
+		SELECT rolcanlogin, rolsuper, rolcreatedb, rolcreaterole, rolinherit, rolreplication, rolbypassrls
+		FROM pg_roles WHERE rolname = $1`, role).Scan(&login, &superuser, &createDB, &createRole, &inherit, &replication, &bypassRLS); err != nil {
+		return err
+	}
+	var changes []string
+	for _, attribute := range []struct {
+		set   bool
+		clear string
+	}{{login, "NOLOGIN"}, {superuser, "NOSUPERUSER"}, {createDB, "NOCREATEDB"}, {createRole, "NOCREATEROLE"}, {inherit, "NOINHERIT"}, {replication, "NOREPLICATION"}, {bypassRLS, "NOBYPASSRLS"}} {
+		if attribute.set {
+			changes = append(changes, attribute.clear)
+		}
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+	_, err := tx.ExecContext(ctx, `ALTER ROLE `+quotedRole+` WITH `+strings.Join(changes, " "))
 	return err
 }
 

--- a/libs/go/controlplane/access_integration_test.go
+++ b/libs/go/controlplane/access_integration_test.go
@@ -1,0 +1,193 @@
+//go:build controlplaneintegration
+
+package controlplane
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/url"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// Only a disposable loopback fixture is accepted. The dedicated workflow and
+// qualify-controlplane.py own its lifecycle; no managed/cloud DSN is accepted.
+func fixtureDB(t *testing.T, database, user string) *sql.DB {
+	t.Helper()
+	u, err := url.Parse(os.Getenv("SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"))
+	if err != nil || u == nil || u.Scheme != "postgres" || u.Hostname() != "127.0.0.1" || u.Port() == "" {
+		t.Fatal("use scripts/qualify-controlplane.py with an isolated PostgreSQL fixture")
+	}
+	u.Path, u.User, u.RawQuery = "/"+database, url.User(user), "sslmode=disable&connect_timeout=5"
+	db, err := sql.Open("postgres", u.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+
+func fixtureSQL(t *testing.T, db *sql.DB, statement string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, err := db.ExecContext(ctx, statement); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func fixtureValue(t *testing.T, db *sql.DB, statement string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	var value string
+	if err := db.QueryRowContext(ctx, statement).Scan(&value); err != nil {
+		t.Fatal(err)
+	}
+	return value
+}
+
+func reconcileFixture(db *sql.DB, access RuntimeAccess) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+	if _, err := tx.ExecContext(ctx, "SELECT pg_advisory_xact_lock(hashtext('codefly-runtime-access:' || current_database()))"); err != nil {
+		return err
+	}
+	if err := ReconcileRuntimeAccess(ctx, tx, access); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func TestExternalIdentityRestrictedAdministrator(t *testing.T) {
+	bootstrap := fixtureDB(t, "postgres", "postgres")
+	t.Log("fixture:", fixtureValue(t, bootstrap, "SHOW server_version"))
+	fixtureSQL(t, bootstrap, "CREATE ROLE access_owner LOGIN CREATEROLE CREATEDB")
+	for _, principal := range []string{"access_reader", "access_writer", "access_writer2"} {
+		fixtureSQL(t, bootstrap, "CREATE ROLE "+pq.QuoteIdentifier(principal)+" LOGIN INHERIT PASSWORD 'fixture-only'")
+	}
+	fixtureSQL(t, bootstrap, "CREATE ROLE unrelated NOLOGIN")
+	fixtureSQL(t, bootstrap, "GRANT unrelated TO access_writer")
+	fixtureSQL(t, bootstrap, "CREATE DATABASE access_proof OWNER access_owner")
+	owner := fixtureDB(t, "access_proof", "access_owner")
+	fixtureSQL(t, owner, "CREATE TABLE before_reconcile(id integer PRIMARY KEY, value text)")
+	access := RuntimeAccess{
+		Database: "access_proof", OwnerRole: "access_owner", Schemas: []string{"public"},
+		ReadOnlyRole: "proof_ro", ReadWriteRole: "proof_rw", AuthMode: AuthModeExternalIdentity,
+		ReadOnlyPrincipals: []string{"access_reader"}, ReadWritePrincipals: []string{"access_writer"},
+	}
+	password := fixtureValue(t, bootstrap, "SELECT rolpassword FROM pg_authid WHERE rolname='access_writer'")
+	for n := 0; n < 2; n++ {
+		if err := reconcileFixture(owner, access); err != nil {
+			t.Fatalf("restricted reconciliation %d: %v", n, err)
+		}
+	}
+	fixtureSQL(t, owner, "CREATE TABLE after_reconcile(id serial PRIMARY KEY, value text)")
+	writer := fixtureDB(t, "access_proof", "access_writer")
+	reader := fixtureDB(t, "access_proof", "access_reader")
+	fixtureSQL(t, writer, "INSERT INTO before_reconcile VALUES (1,'before')")
+	fixtureSQL(t, writer, "INSERT INTO after_reconcile(value) VALUES ('after')")
+	if fixtureValue(t, reader, "SELECT value FROM after_reconcile") != "after" {
+		t.Fatal("default privileges did not permit reader")
+	}
+	for _, statement := range []string{"CREATE TABLE forbidden(id integer)", "ALTER TABLE after_reconcile ADD COLUMN forbidden text"} {
+		if _, err := writer.Exec(statement); err == nil {
+			t.Fatal("writer DDL succeeded")
+		}
+	}
+	if _, err := reader.Exec("INSERT INTO after_reconcile(value) VALUES ('forbidden')"); err == nil {
+		t.Fatal("reader write succeeded")
+	}
+	for _, role := range []string{"proof_ro", "proof_rw"} {
+		if fixtureValue(t, bootstrap, "SELECT (rolcanlogin OR rolsuper OR rolcreatedb OR rolcreaterole OR rolinherit OR rolreplication OR rolbypassrls)::text FROM pg_roles WHERE rolname="+pq.QuoteLiteral(role)) != "false" {
+			t.Fatal("unsafe group attributes")
+		}
+	}
+	broken := access
+	broken.ReadWritePrincipals = []string{"missing_principal"}
+	if err := reconcileFixture(owner, broken); err == nil {
+		t.Fatal("missing principal accepted")
+	}
+	if fixtureValue(t, bootstrap, "SELECT pg_has_role('access_writer','proof_rw','MEMBER')::text") != "true" {
+		t.Fatal("failed reconciliation changed membership")
+	}
+	access.ReadWritePrincipals = []string{"access_writer2"}
+	if err := reconcileFixture(owner, access); err != nil {
+		t.Fatal("replacement:", err)
+	}
+	if fixtureValue(t, bootstrap, "SELECT pg_has_role('access_writer','proof_rw','MEMBER')::text") != "false" || fixtureValue(t, bootstrap, "SELECT pg_has_role('access_writer','unrelated','MEMBER')::text") != "true" {
+		t.Fatal("membership reconciliation did not preserve the ownership boundary")
+	}
+	if fixtureValue(t, bootstrap, "SELECT rolpassword FROM pg_authid WHERE rolname='access_writer'") != password {
+		t.Fatal("external password changed")
+	}
+	version, err := strconv.Atoi(fixtureValue(t, bootstrap, "SHOW server_version_num"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version >= 160000 {
+		if fixtureValue(t, bootstrap, "SELECT (admin_option AND NOT inherit_option AND NOT set_option)::text FROM pg_auth_members m JOIN pg_roles r ON r.oid=m.roleid JOIN pg_roles u ON u.oid=m.member WHERE r.rolname='proof_rw' AND u.rolname='access_owner'") != "true" {
+			t.Fatal("creator's administration-only membership was lost or broadened")
+		}
+	}
+	// Do not silently accept elevated groups or broaden the administrator's
+	// authority. Any insufficient-privilege error must roll back the transaction.
+	for _, flag := range []string{"SUPERUSER", "REPLICATION", "BYPASSRLS"} {
+		t.Run(flag, func(t *testing.T) {
+			fixtureSQL(t, bootstrap, "ALTER ROLE proof_rw "+flag)
+			err := reconcileFixture(owner, access)
+			var pgerr *pq.Error
+			if !errors.As(err, &pgerr) || pgerr.Code != "42501" {
+				t.Fatalf("expected insufficient privilege for elevated group, got %v", err)
+			}
+			fixtureSQL(t, bootstrap, "ALTER ROLE proof_rw NO"+flag)
+		})
+	}
+	if err := reconcileFixture(owner, access); err != nil {
+		t.Fatal("recovery:", err)
+	}
+	// Mutable ordinary attributes must still be hardened, and a qualified
+	// superuser must retain the original elevated-group repair behavior.
+	fixtureSQL(t, bootstrap, "ALTER ROLE proof_rw LOGIN CREATEDB CREATEROLE INHERIT")
+	if err := reconcileFixture(owner, access); err != nil {
+		t.Fatal("ordinary attribute hardening:", err)
+	}
+	fixtureSQL(t, bootstrap, "ALTER ROLE proof_rw SUPERUSER REPLICATION BYPASSRLS")
+	adminDB := fixtureDB(t, "access_proof", "postgres")
+	// Exercise attribute repair directly: changing the membership reconciler's
+	// grantor is a separate PostgreSQL privilege dependency operation.
+	repair, err := adminDB.Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer repair.Rollback()
+	if err := ensureGroupRole(context.Background(), repair, "proof_rw"); err != nil {
+		t.Fatal("privileged hardening regression:", err)
+	}
+	if err := repair.Commit(); err != nil {
+		t.Fatal(err)
+	}
+	if fixtureValue(t, bootstrap, "SELECT (rolcanlogin OR rolsuper OR rolcreatedb OR rolcreaterole OR rolinherit OR rolreplication OR rolbypassrls)::text FROM pg_roles WHERE rolname='proof_rw'") != "false" {
+		t.Fatal("hardening omitted a role attribute")
+	}
+	fixtureSQL(t, bootstrap, "CREATE ROLE no_role_admin LOGIN")
+	noAdmin := fixtureDB(t, "access_proof", "no_role_admin")
+	unowned := access
+	unowned.ReadOnlyRole, unowned.ReadWriteRole = "unowned_ro", "unowned_rw"
+	if err := reconcileFixture(noAdmin, unowned); err == nil {
+		t.Fatal("unprivileged user reconciled groups")
+	}
+	if fixtureValue(t, bootstrap, "SELECT count(*)::text FROM pg_roles WHERE rolname IN ('unowned_ro','unowned_rw')") != "0" {
+		t.Fatal("failed role creation was not atomic")
+	}
+}

--- a/scripts/qualify-controlplane.py
+++ b/scripts/qualify-controlplane.py
@@ -1,0 +1,101 @@
+"""Qualify role reconciliation on a disposable, loopback-only Docker fixture."""
+
+import json
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def main():
+    image = os.environ["POSTGRES_TEST_IMAGE"]
+    if not re.fullmatch(r"postgres@sha256:[0-9a-f]{64}", image):
+        raise ValueError("POSTGRES_TEST_IMAGE must pin the official fixture by digest")
+    container = subprocess.check_output(
+        [
+            "docker",
+            "run",
+            "--detach",
+            "--rm",
+            "--pull=never",
+            "--publish",
+            "127.0.0.1::5432",
+            "--env",
+            "POSTGRES_HOST_AUTH_METHOD=trust",
+            "--tmpfs",
+            "/var/lib/postgresql/data",
+            image,
+        ],
+        text=True,
+    ).strip()
+    try:
+        for _ in range(60):
+            result = subprocess.run(
+                [
+                    "docker",
+                    "exec",
+                    container,
+                    "pg_isready",
+                    "-h",
+                    "127.0.0.1",
+                    "-U",
+                    "postgres",
+                ],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if result.returncode == 0:
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError("fixture did not become ready")
+        ports = json.loads(
+            subprocess.check_output(
+                [
+                    "docker",
+                    "inspect",
+                    "--format",
+                    "{{json .NetworkSettings.Ports}}",
+                    container,
+                ],
+                text=True,
+            )
+        )
+        binding = ports["5432/tcp"][0]
+        if binding["HostIp"] != "127.0.0.1":
+            raise RuntimeError("fixture is not loopback-only")
+        env = os.environ.copy()
+        env["SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"] = (
+            f"postgres://postgres@127.0.0.1:{int(binding['HostPort'])}/postgres"
+        )
+        print(f"Fixture image: {image}", flush=True)
+        subprocess.run(
+            [
+                "go",
+                "test",
+                "-race",
+                "-count=1",
+                "-v",
+                "-tags",
+                "controlplaneintegration",
+                "./libs/go/controlplane",
+            ],
+            cwd=ROOT,
+            env=env,
+            check=True,
+            timeout=300,
+        )
+    finally:
+        subprocess.run(
+            ["docker", "rm", "--force", container],
+            check=True,
+            stdout=subprocess.DEVNULL,
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

External-identity reconciliation currently fails for a non-superuser role administrator when `ensureGroupRole` unconditionally specifies protected `ALTER ROLE` attributes, even though those attributes already have safe values. Read the current attributes and emit only the changes needed to harden the group.

The engine still attempts to remove unsafe attributes. If the caller lacks that authority, the transaction fails; no administrator privilege is added and no unsafe group is silently accepted.

## Validation

- The new real PostgreSQL 16.14 regression fails on unmodified upstream with SQLSTATE `42501` and passes with the change.
- Restricted administrator: repeated reconciliation, membership replacement, existing/default table and sequence access, writer DDL denial, reader write denial, external-password and unrelated-membership preservation.
- Failure cases: missing-principal rollback, elevated SUPERUSER/REPLICATION/BYPASSRLS groups rejected, and a principal without role-administration authority cannot create groups.
- Ordinary attribute hardening and authorized protected-attribute repair remain covered. PostgreSQL 16's creator administration-only membership remains present through replay.
- Existing Go library tests pass with `-race`; `go vet`, formatting and changed-commit secret scan pass.
- A dedicated CI workflow runs the isolated PostgreSQL 16 fixture pinned by image digest. That workflow and full repository CI must run on the PR before merge.

## Scope

No public API, cloud IAM, credentials, database primitive ownership or migration behavior changes. This proves stock PostgreSQL behavior, not managed-provider acceptance. Keep the reconciler identity stable: PostgreSQL grantor reassignment and administrator rotation need separate qualification. The change should ship in a versioned release before downstream consumers change their published dependency pins.
