### PR TITLE
fix: give the release tag read-backs the same retry (#100)

### DIFF
--- a/.github/scripts/tag-runtime-image.sh
+++ b/.github/scripts/tag-runtime-image.sh
@@ -12,9 +12,40 @@ readonly PROPAGATION_DELAYS=(2 4 8 16 30 30 30)
 # six-hour default, once per attempt.
 readonly READ_TIMEOUT=60
 
+# Every tag gets its own budget: one tag having propagated says nothing about
+# the next, which was published by the same call but is read afterwards.
+verify_tag() {
+  local tag=$1
+  local tagged_digest=""
+  local attempt=0
+  while :; do
+    # The fallback keeps a failed read from aborting the script under errexit
+    # before the diagnosis below can run.
+    tagged_digest=$(timeout "$READ_TIMEOUT" docker buildx imagetools inspect "$tag" |
+      awk '$1 == "Digest:" { print $2; exit }') || tagged_digest=""
+    if [[ "$tagged_digest" == "$EXPECTED_DIGEST" ]]; then
+      return 0
+    fi
+    if ((attempt >= ${#PROPAGATION_DELAYS[@]})); then
+      break
+    fi
+    sleep "${PROPAGATION_DELAYS[attempt]}"
+    attempt=$((attempt + 1))
+  done
+
+  if [[ -z "$tagged_digest" ]]; then
+    echo "$tag was published but did not resolve to a digest" >&2
+  else
+    echo "$tag resolves to $tagged_digest, want $EXPECTED_DIGEST" >&2
+  fi
+  return 1
+}
+
 : "${EXPECTED_DIGEST:?EXPECTED_DIGEST is required}"
 : "${RUNTIME_IMAGE:?RUNTIME_IMAGE is required}"
-: "${RUNTIME_TAG:?RUNTIME_TAG is required}"
+# Without this a caller that lost its tag arguments would publish nothing and
+# still exit 0, because the verification below would have nothing to walk.
+: "${1:?at least one tag is required}"
 
 # Checked up front because the read below turns any failure into another
 # retry, which would report a missing timeout as an unresolvable tag.
@@ -23,28 +54,12 @@ if ! command -v timeout >/dev/null; then
   exit 1
 fi
 
-docker buildx imagetools create --tag "$RUNTIME_TAG" "$RUNTIME_IMAGE"
-
-tagged_digest=""
-attempt=0
-while :; do
-  # The fallback keeps a failed read from aborting the script under errexit
-  # before the diagnosis below can run.
-  tagged_digest=$(timeout "$READ_TIMEOUT" docker buildx imagetools inspect "$RUNTIME_TAG" |
-    awk '$1 == "Digest:" { print $2; exit }') || tagged_digest=""
-  if [[ "$tagged_digest" == "$EXPECTED_DIGEST" ]]; then
-    exit 0
-  fi
-  if ((attempt >= ${#PROPAGATION_DELAYS[@]})); then
-    break
-  fi
-  sleep "${PROPAGATION_DELAYS[attempt]}"
-  attempt=$((attempt + 1))
+tag_flags=()
+for tag in "$@"; do
+  tag_flags+=(--tag "$tag")
 done
+docker buildx imagetools create "${tag_flags[@]}" "$RUNTIME_IMAGE"
 
-if [[ -z "$tagged_digest" ]]; then
-  echo "$RUNTIME_TAG was published but did not resolve to a digest" >&2
-else
-  echo "$RUNTIME_TAG resolves to $tagged_digest, want $EXPECTED_DIGEST" >&2
-fi
-exit 1
+for tag in "$@"; do
+  verify_tag "$tag"
+done

--- a/.github/scripts/tag-runtime-image.sh
+++ b/.github/scripts/tag-runtime-image.sh
@@ -12,12 +12,13 @@ readonly PROPAGATION_DELAYS=(2 4 8 16 30 30 30)
 # six-hour default, once per attempt.
 readonly READ_TIMEOUT=60
 
-# Every tag gets its own budget: one tag having propagated says nothing about
-# the next, which was published by the same call but is read afterwards.
+# One create publishes every tag, so they share one propagation clock and spend
+# one schedule between them. A tag first read after the earlier ones have waited
+# has already had that long to propagate, so restarting the schedule per tag
+# would buy nothing and would grow the worst case with the tag count.
 verify_tag() {
   local tag=$1
   local tagged_digest=""
-  local attempt=0
   while :; do
     # The fallback keeps a failed read from aborting the script under errexit
     # before the diagnosis below can run.
@@ -56,10 +57,12 @@ fi
 
 tag_flags=()
 for tag in "$@"; do
+  : "${tag:?tag arguments must not be empty}"
   tag_flags+=(--tag "$tag")
 done
 docker buildx imagetools create "${tag_flags[@]}" "$RUNTIME_IMAGE"
 
+attempt=0
 for tag in "$@"; do
   verify_tag "$tag"
 done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,4 +207,4 @@ jobs:
           EXPECTED_DIGEST: ${{ steps.runtime.outputs.digest }}
           RUNTIME_IMAGE: ${{ steps.runtime.outputs.reference }}
           RUNTIME_TAG: ${{ steps.runtime.outputs.tag_reference }}
-        run: .github/scripts/tag-runtime-image.sh
+        run: .github/scripts/tag-runtime-image.sh "$RUNTIME_TAG"

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -41,20 +41,10 @@ jobs:
           set -euo pipefail
           name=$(jq -er '.name' runtime-image.json)
           tag=$(jq -er '.tag' runtime-image.json)
-          digest=$(jq -er '.digest' runtime-image.json)
-          RUNTIME_IMAGE="$name@$digest"
-          docker buildx imagetools create \
-            --tag "$name:$RELEASE_TAG" \
-            --tag "$name:$tag" \
-            "$RUNTIME_IMAGE"
-          for published_tag in "$name:$RELEASE_TAG" "$name:$tag"; do
-            published_digest=$(docker buildx imagetools inspect "$published_tag" |
-              awk '$1 == "Digest:" { print $2; exit }')
-            if [[ "$published_digest" != "$digest" ]]; then
-              echo "$published_tag resolves to $published_digest, want $digest" >&2
-              exit 1
-            fi
-          done
+          EXPECTED_DIGEST=$(jq -er '.digest' runtime-image.json)
+          RUNTIME_IMAGE="$name@$EXPECTED_DIGEST"
+          export EXPECTED_DIGEST RUNTIME_IMAGE
+          .github/scripts/tag-runtime-image.sh "$name:$RELEASE_TAG" "$name:$tag"
 
   release:
     if: github.event_name == 'push'

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -11,6 +11,13 @@ on:
         required: true
         type: string
 
+# Releases share the runtime tag read from runtime-image.json, so two of them
+# publishing at once can each see the other's digest on it. They queue rather
+# than cancel: cancelling would abandon a half-published release.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -21,6 +28,9 @@ jobs:
       contents: read
       packages: write
     runs-on: ubuntu-latest
+    # The publish step waits on registry propagation, so bound the job rather
+    # than leave a hung read to GitHub's six-hour default.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 

--- a/tag_runtime_image_test.go
+++ b/tag_runtime_image_test.go
@@ -15,24 +15,28 @@ const (
 	taggedDigest = "sha256:d8847e56"
 	staleDigest  = "sha256:5731ed01"
 	taggedTag    = "ghcr.io/codefly-dev/service-postgres:postgres-17.10-pgvector-0.8.5-alpine3.24"
+	releaseTag   = "ghcr.io/codefly-dev/service-postgres:v0.0.130"
 )
 
 // readBackBudget is the number of reads the script spends before it rules on
 // the tag: one per propagation delay, plus the first read.
 const readBackBudget = 8
 
-// registry describes how ghcr.io answers reads of the tag just written: some
+// registry describes how ghcr.io answers reads of a tag just written: some
 // reads failing outright, then some serving whatever digest the tag held
-// before the push, then digest.
+// before the push, then digest. The counts apply to each tag separately,
+// because propagation is per tag.
 type registry struct {
 	failedReads int
 	staleReads  int
 	digest      string
+	// unreadableTag never resolves, however many times it is read.
+	unreadableTag string
 }
 
 func TestTagRuntimeImagePublishesTheTagBeforeReadingItBack(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, registry{digest: taggedDigest})
+	output, err := runTagRuntimeImage(t, log, registry{digest: taggedDigest}, taggedTag)
 
 	require.NoErrorf(t, err, "output: %s", output)
 	calls := readCalls(t, log)
@@ -42,7 +46,7 @@ func TestTagRuntimeImagePublishesTheTagBeforeReadingItBack(t *testing.T) {
 
 func TestTagRuntimeImageRetriesWhileTheTagCannotBeRead(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, registry{failedReads: 2, digest: taggedDigest})
+	output, err := runTagRuntimeImage(t, log, registry{failedReads: 2, digest: taggedDigest}, taggedTag)
 
 	require.NoErrorf(t, err, "output: %s", output)
 	require.Len(t, readCalls(t, log), 4)
@@ -53,7 +57,7 @@ func TestTagRuntimeImageRetriesWhileTheTagCannotBeRead(t *testing.T) {
 // unreadable tag until the budget is spent.
 func TestTagRuntimeImageRetriesWhileTheTagServesAStaleDigest(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, registry{staleReads: 2, digest: taggedDigest})
+	output, err := runTagRuntimeImage(t, log, registry{staleReads: 2, digest: taggedDigest}, taggedTag)
 
 	require.NoErrorf(t, err, "output: %s", output)
 	require.Len(t, readCalls(t, log), 4)
@@ -61,7 +65,7 @@ func TestTagRuntimeImageRetriesWhileTheTagServesAStaleDigest(t *testing.T) {
 
 func TestTagRuntimeImageFailsWhenTheTagNeverBecomesReadable(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, registry{failedReads: readBackBudget + 1})
+	output, err := runTagRuntimeImage(t, log, registry{failedReads: readBackBudget + 1}, taggedTag)
 
 	require.Error(t, err)
 	require.Contains(t, output, taggedTag+" was published but did not resolve to a digest")
@@ -72,7 +76,7 @@ func TestTagRuntimeImageFailsWhenTheTagNeverBecomesReadable(t *testing.T) {
 // a concurrent build moved it — has to redden the job, naming what it found.
 func TestTagRuntimeImageFailsWhenTheTagKeepsAnotherDigest(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	output, err := runTagRuntimeImage(t, log, registry{digest: staleDigest})
+	output, err := runTagRuntimeImage(t, log, registry{digest: staleDigest}, taggedTag)
 
 	require.Error(t, err)
 	require.Contains(t, output, taggedTag+" resolves to "+staleDigest+", want "+taggedDigest)
@@ -83,7 +87,7 @@ func TestTagRuntimeImageFailsWhenTheTagKeepsAnotherDigest(t *testing.T) {
 // that never resolved rather than as the missing dependency it is.
 func TestTagRuntimeImageFailsLoudlyWithoutTimeout(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
-	command := tagRuntimeImageCommand(t, log, registry{digest: taggedDigest})
+	command := tagRuntimeImageCommand(t, log, registry{digest: taggedDigest}, taggedTag)
 	command.Env = append(command.Env, "PATH="+t.TempDir())
 	output, err := command.CombinedOutput()
 
@@ -91,15 +95,61 @@ func TestTagRuntimeImageFailsLoudlyWithoutTimeout(t *testing.T) {
 	require.Contains(t, string(output), "timeout is required to bound registry reads")
 }
 
-func runTagRuntimeImage(t *testing.T, log string, ghcr registry) (string, error) {
+// The release publishes the version tag and the runtime tag together, so one
+// create has to carry both — and both have to be read back.
+func TestTagRuntimeImagePublishesEveryTagInOneCreate(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, registry{digest: taggedDigest}, releaseTag, taggedTag)
+
+	require.NoErrorf(t, err, "output: %s", output)
+	calls := readCalls(t, log)
+	require.Equal(t,
+		"buildx imagetools create --tag "+releaseTag+" --tag "+taggedTag+" "+taggedImage+" ",
+		calls[0],
+	)
+	require.Len(t, calls, 3, "every tag is read back, not just the first")
+}
+
+// The first tag having propagated by the time it is read says nothing about the
+// second, which is read later but lags on its own schedule.
+func TestTagRuntimeImageSpendsTheReadBackBudgetOnEveryTag(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, registry{failedReads: 2, digest: taggedDigest}, releaseTag, taggedTag)
+
+	require.NoErrorf(t, err, "output: %s", output)
+	require.Len(t, readCalls(t, log), 7, "one create, then three reads of each tag")
+}
+
+func TestTagRuntimeImageNamesTheLaterTagThatNeverResolves(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log,
+		registry{digest: taggedDigest, unreadableTag: taggedTag}, releaseTag, taggedTag)
+
+	require.Error(t, err)
+	require.Contains(t, output, taggedTag+" was published but did not resolve to a digest")
+	require.NotContains(t, output, releaseTag+" was published")
+	require.Len(t, readCalls(t, log), readBackBudget+2,
+		"one create, one read of the tag that resolved, then the full budget on the one that did not")
+}
+
+func TestTagRuntimeImageRefusesToPublishNothing(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, registry{digest: taggedDigest})
+
+	require.Error(t, err)
+	require.Contains(t, output, "at least one tag is required")
+	require.NoFileExists(t, log, "a caller without tags must publish nothing")
+}
+
+func runTagRuntimeImage(t *testing.T, log string, ghcr registry, tags ...string) (string, error) {
 	t.Helper()
-	output, err := tagRuntimeImageCommand(t, log, ghcr).CombinedOutput()
+	output, err := tagRuntimeImageCommand(t, log, ghcr, tags...).CombinedOutput()
 	return string(output), err
 }
 
-func tagRuntimeImageCommand(t *testing.T, log string, ghcr registry) *exec.Cmd {
+func tagRuntimeImageCommand(t *testing.T, log string, ghcr registry, tags ...string) *exec.Cmd {
 	t.Helper()
-	command := exec.Command("bash", ".github/scripts/tag-runtime-image.sh")
+	command := exec.Command("bash", append([]string{".github/scripts/tag-runtime-image.sh"}, tags...)...)
 	command.Env = append(os.Environ(),
 		"PATH="+fakeDocker(t)+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"DOCKER_LOG="+log,
@@ -107,15 +157,15 @@ func tagRuntimeImageCommand(t *testing.T, log string, ghcr registry) *exec.Cmd {
 		"DOCKER_STALE_READS="+strconv.Itoa(ghcr.staleReads),
 		"DOCKER_STALE_DIGEST="+staleDigest,
 		"DOCKER_DIGEST="+ghcr.digest,
+		"DOCKER_UNREADABLE_TAG="+ghcr.unreadableTag,
 		"EXPECTED_DIGEST="+taggedDigest,
 		"RUNTIME_IMAGE="+taggedImage,
-		"RUNTIME_TAG="+taggedTag,
 	)
 	return command
 }
 
 // fakeDocker also shadows sleep, so the propagation budget does not become the
-// test's runtime.
+// test's runtime. Reads are counted per tag, the way a registry propagates them.
 func fakeDocker(t *testing.T) string {
 	t.Helper()
 	bin := t.TempDir()
@@ -127,8 +177,8 @@ printf '\n' >>"$DOCKER_LOG"
 if [[ "$3" != inspect ]]; then
   exit 0
 fi
-read_number=$(grep -c 'imagetools inspect' "$DOCKER_LOG")
-if ((read_number <= DOCKER_FAILED_READS)); then
+read_number=$(grep -cF "imagetools inspect $4 " "$DOCKER_LOG")
+if [[ "$4" == "$DOCKER_UNREADABLE_TAG" ]] || ((read_number <= DOCKER_FAILED_READS)); then
   echo "ERROR: unexpected status from HEAD request to $4: 404 Not Found" >&2
   exit 1
 fi

--- a/tag_runtime_image_test.go
+++ b/tag_runtime_image_test.go
@@ -110,14 +110,30 @@ func TestTagRuntimeImagePublishesEveryTagInOneCreate(t *testing.T) {
 	require.Len(t, calls, 3, "every tag is read back, not just the first")
 }
 
-// The first tag having propagated by the time it is read says nothing about the
-// second, which is read later but lags on its own schedule.
-func TestTagRuntimeImageSpendsTheReadBackBudgetOnEveryTag(t *testing.T) {
+// Every tag is retried, not just the first one.
+func TestTagRuntimeImageRetriesEveryTagNotJustTheFirst(t *testing.T) {
 	log := filepath.Join(t.TempDir(), "docker.log")
 	output, err := runTagRuntimeImage(t, log, registry{failedReads: 2, digest: taggedDigest}, releaseTag, taggedTag)
 
 	require.NoErrorf(t, err, "output: %s", output)
 	require.Len(t, readCalls(t, log), 7, "one create, then three reads of each tag")
+}
+
+// The delay schedule is spent across the tags, not restarted for each: by the
+// time a later tag is first read, the waiting already done for the earlier ones
+// has given it exactly that long to propagate. Restarting per tag would grow
+// the worst case with the tag count while buying nothing.
+func TestTagRuntimeImageSpendsOneScheduleAcrossEveryTag(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log,
+		registry{failedReads: 3, digest: taggedDigest, unreadableTag: taggedTag}, releaseTag, taggedTag)
+
+	require.Error(t, err)
+	require.Contains(t, output, taggedTag+" was published but did not resolve to a digest")
+	// Four reads resolve the first tag, spending three delays; the second tag
+	// inherits the cursor and so gets the four that remain, not a fresh seven.
+	require.Len(t, readCalls(t, log), 10,
+		"the second tag must inherit the schedule the first one spent")
 }
 
 func TestTagRuntimeImageNamesTheLaterTagThatNeverResolves(t *testing.T) {
@@ -130,6 +146,17 @@ func TestTagRuntimeImageNamesTheLaterTagThatNeverResolves(t *testing.T) {
 	require.NotContains(t, output, releaseTag+" was published")
 	require.Len(t, readCalls(t, log), readBackBudget+2,
 		"one create, one read of the tag that resolved, then the full budget on the one that did not")
+}
+
+// An empty later tag reached docker as --tag "" because the guard only covered
+// the first argument, leaving the check asymmetric with the loop it guards.
+func TestTagRuntimeImageRefusesAnEmptyLaterTag(t *testing.T) {
+	log := filepath.Join(t.TempDir(), "docker.log")
+	output, err := runTagRuntimeImage(t, log, registry{digest: taggedDigest}, releaseTag, "")
+
+	require.Error(t, err)
+	require.Contains(t, output, "tag arguments must not be empty")
+	require.NoFileExists(t, log, "nothing may be published once an argument is rejected")
 }
 
 func TestTagRuntimeImageRefusesToPublishNothing(t *testing.T) {

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -107,7 +107,7 @@ func TestCIWorkflowValidatesLockedImageForEveryPullRequest(t *testing.T) {
 	require.Equal(t, false, candidate.With["sbom"])
 	require.Contains(t, verifyCandidate.Run, `"$ACTUAL_DIGEST" != "$EXPECTED_DIGEST"`)
 	require.Contains(t, scan.Run, `docker save --output /tmp/service-postgres-image.tar "$RUNTIME_IMAGE"`)
-	require.Equal(t, ".github/scripts/tag-runtime-image.sh", strings.TrimSpace(tag.Run))
+	require.Equal(t, `.github/scripts/tag-runtime-image.sh "$RUNTIME_TAG"`, strings.TrimSpace(tag.Run))
 	require.Equal(t, map[string]string{
 		"EXPECTED_DIGEST": "${{ steps.runtime.outputs.digest }}",
 		"RUNTIME_IMAGE":   "${{ steps.runtime.outputs.reference }}",
@@ -136,9 +136,16 @@ func TestReleaseWorkflowRetagsLockedImageWithLeastPrivilege(t *testing.T) {
 	for _, step := range imageJob.Steps {
 		require.NotContains(t, step.Uses, "docker/build-push-action")
 	}
+	// The release publishes two tags and reads both back, which is the same
+	// propagation race the CI step hit, so it has to go through the same
+	// retrying script rather than its own create-then-inspect.
 	publish := findWorkflowStep(t, imageJob, "Publish release image tags")
-	require.Contains(t, publish.Run, `"$RUNTIME_IMAGE"`)
-	require.Contains(t, publish.Run, "docker buildx imagetools create")
+	require.NotContains(t, publish.Run, "docker buildx imagetools",
+		"the release must not read a tag back on its own")
+	require.Contains(t, publish.Run, "export EXPECTED_DIGEST RUNTIME_IMAGE")
+	require.Contains(t, publish.Run,
+		`.github/scripts/tag-runtime-image.sh "$name:$RELEASE_TAG" "$name:$tag"`)
+	require.Equal(t, map[string]string{"RELEASE_TAG": "${{ github.ref_name }}"}, publish.Env)
 	buildx := findWorkflowAction(t, imageJob, "docker/setup-buildx-action")
 	require.Equal(t,
 		"image=moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec",

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,13 +14,20 @@ import (
 
 type workflowDefinition struct {
 	Permissions map[string]string      `yaml:"permissions"`
+	Concurrency workflowConcurrency    `yaml:"concurrency"`
 	Jobs        map[string]workflowJob `yaml:"jobs"`
 }
 
+type workflowConcurrency struct {
+	Group            string `yaml:"group"`
+	CancelInProgress bool   `yaml:"cancel-in-progress"`
+}
+
 type workflowJob struct {
-	Permissions map[string]string `yaml:"permissions"`
-	Steps       []workflowStep    `yaml:"steps"`
-	Uses        string            `yaml:"uses"`
+	Permissions    map[string]string `yaml:"permissions"`
+	TimeoutMinutes int               `yaml:"timeout-minutes"`
+	Steps          []workflowStep    `yaml:"steps"`
+	Uses           string            `yaml:"uses"`
 }
 
 type workflowStep struct {
@@ -142,10 +152,15 @@ func TestReleaseWorkflowRetagsLockedImageWithLeastPrivilege(t *testing.T) {
 	publish := findWorkflowStep(t, imageJob, "Publish release image tags")
 	require.NotContains(t, publish.Run, "docker buildx imagetools",
 		"the release must not read a tag back on its own")
-	require.Contains(t, publish.Run, "export EXPECTED_DIGEST RUNTIME_IMAGE")
-	require.Contains(t, publish.Run,
-		`.github/scripts/tag-runtime-image.sh "$name:$RELEASE_TAG" "$name:$tag"`)
-	require.Equal(t, map[string]string{"RELEASE_TAG": "${{ github.ref_name }}"}, publish.Env)
+	require.Equal(t, "${{ github.ref_name }}", publish.Env["RELEASE_TAG"])
+
+	// Two releases publishing at once each see the other's digest on the shared
+	// runtime tag, and the read-back retry holds that window open for minutes.
+	require.Equal(t, "${{ github.workflow }}", workflow.Concurrency.Group)
+	require.False(t, workflow.Concurrency.CancelInProgress,
+		"cancelling would abandon a half-published release")
+	require.NotZero(t, imageJob.TimeoutMinutes,
+		"a hung registry read must not run to GitHub's six-hour default")
 	buildx := findWorkflowAction(t, imageJob, "docker/setup-buildx-action")
 	require.Equal(t,
 		"image=moby/buildkit@sha256:2f5adac4ecd194d9f8c10b7b5d7bceb5186853db1b26e5abd3a657af0b7e26ec",
@@ -219,4 +234,46 @@ func findWorkflowAction(t *testing.T, job workflowJob, action string) workflowSt
 	}
 	t.Fatalf("workflow action %q not found", action)
 	return workflowStep{}
+}
+
+// releaser.yml's image job only runs on a v* tag push, so nothing else exercises
+// this step before a real release. Running its own shell against a fake registry
+// covers the wiring the string assertions cannot: that the tags it derives from
+// the lock are the ones published, that a lagging read is retried rather than
+// fatal, and that the script is invoked the way the step actually invokes it.
+func TestReleaseStepPublishesBothLockedTagsPastALaggingRead(t *testing.T) {
+	var lock struct {
+		Name   string `json:"name"`
+		Tag    string `json:"tag"`
+		Digest string `json:"digest"`
+	}
+	content, err := os.ReadFile("runtime-image.json")
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(content, &lock))
+
+	imageJob := readWorkflow(t, ".github/workflows/releaser.yml").Jobs["image"]
+	publish := findWorkflowStep(t, imageJob, "Publish release image tags")
+	log := filepath.Join(t.TempDir(), "docker.log")
+	command := exec.Command("bash", "-c", publish.Run)
+	command.Env = append(os.Environ(),
+		"PATH="+fakeDocker(t)+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"DOCKER_LOG="+log,
+		"DOCKER_FAILED_READS=1",
+		"DOCKER_STALE_READS=0",
+		"DOCKER_STALE_DIGEST="+staleDigest,
+		"DOCKER_DIGEST="+lock.Digest,
+		"DOCKER_UNREADABLE_TAG=",
+		"RELEASE_TAG=v0.0.130",
+	)
+	output, err := command.CombinedOutput()
+
+	require.NoErrorf(t, err, "output: %s", output)
+	calls := readCalls(t, log)
+	require.Equal(t,
+		"buildx imagetools create --tag "+lock.Name+":v0.0.130 --tag "+lock.Name+":"+lock.Tag+
+			" "+lock.Name+"@"+lock.Digest+" ",
+		calls[0],
+		"the release publishes exactly the two references the lock describes",
+	)
+	require.Len(t, calls, 5, "one create, then each tag read past its 404")
 }


### PR DESCRIPTION
Closes #100.

Rebased onto `main` now that #99 has merged — this PR is just its own two commits.

## Summary

- `releaser.yml` published two ghcr.io tags and read each straight back to check its digest — the same non-read-your-writes race #98 hit in `ci.yml`, but over two tags and reddening a release rather than a PR. Under `set -e` the failing command substitution aborted the step before the mismatch branch could report anything.
- `tag-runtime-image.sh` (added by #99) now takes its tags as arguments: one `imagetools create` carries them all, then **the retry schedule is spent across the tags rather than restarted for each**. One create starts one propagation clock — a tag first read after the earlier ones have waited has had exactly that long to propagate. Messages name the tag they are about.
- Releases now **queue on a concurrency group** instead of overlapping. Two releases contend on the runtime tag read from `runtime-image.json`, and the read-back retry holds that window open for minutes where the old inline inspect took seconds. They queue rather than cancel, since cancelling would abandon a half-published release. The `image` job also gets a `timeout-minutes` so a hung read cannot run to GitHub's six-hour default.
- The script refuses empty or missing tag arguments before publishing anything. Without that, a caller that lost its arguments would publish nothing and still exit 0.

<details>
<summary>Why one shared schedule rather than one per tag (worst case, 2 tags)</summary>

| | reads | sleeps | worst case | per extra tag |
|---|---|---|---|---|
| schedule per tag | 16 | 240s | **20 min** | +10 min |
| one shared schedule | ≤9 | ≤120s | **11 min** | +1 min |

Restarting the schedule per tag re-buys waiting that has already happened, and grows the worst case with the tag count.
</details>

## Risk

A release cannot be exercised before merge — `releaser.yml`'s `image` job only runs on a `v*` tag push. `TestReleaseStepPublishesBothLockedTagsPastALaggingRead` closes most of that gap by executing the step's own `run:` block against a fake registry, but the first true signal against ghcr.io is the next release.

For the record, v0.0.132 released successfully on the current (unfixed) step at 19:44 — its `Publish release image tags` took 2s. The race is transient, not constant; that is why it has stayed latent rather than evidence that it is absent.

## Test plan

- [x] `go test . -run '^TestTagRuntimeImage' -count=1` — multi-tag cases on top of #99's: one create carries every tag and every tag is read back; the schedule is spent across tags, not restarted; a *later* tag that never resolves is named, not the first; empty and missing tag arguments are refused.
- [x] `TestReleaseStepPublishesBothLockedTagsPastALaggingRead` executes `releaser.yml`'s real `run:` block against a fake registry that 404s the first read of each tag, asserting it publishes exactly the two references `runtime-image.json` describes.
- [x] Mutation-checked every new guard against the code that lacks it — verify only `$1`; per-tag loop without the retry (today's `releaser.yml`); schedule restarted per tag; exec bit dropped; concurrency group removed; `timeout-minutes` removed; no-tags guard removed. Each fails the test that names it. The exec-bit drop is caught **only** by the new release-step test, since the script tests invoke it through `bash`.
- [x] `go test ./... -skip '<the docker-heavy set CI skips>' -timeout 20m`, `go vet ./...`, `gofmt -l .`, `shellcheck .github/scripts/*.sh` — all clean, re-run after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)