### PR TITLE
ci(release): register arm64 emulation before the release test suite (#104)

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -62,6 +62,13 @@ jobs:
     permissions:
       contents: read
     uses: codefly-dev/core/.github/workflows/go-service-release.yml@f16e045805dbd213cdbebf98d5f7cbe802496d7c
+    with:
+      # The bootstrap-image tests build linux/arm64 and refuse to run without
+      # emulation registered ("CI must register emulation"). ci.yml gets it from
+      # docker/setup-qemu-action; the shared release workflow has no such step,
+      # so every release failed at `release / test` and goreleaser never ran (#104).
+      # binfmt registration is the same thing setup-qemu-action does.
+      setup-run: docker run --privileged --rm tonistiigi/binfmt --install arm64
     secrets: inherit
 
   backfill:


### PR DESCRIPTION
Fixes #104.

`releaser.yml` delegates to core's shared `go-service-release.yml`, whose test job runs `go test -v ./...` with no multi-arch emulation. This repo's bootstrap-image tests build `linux/arm64` and fail fast without it (`CI must register emulation (docker/setup-qemu-action)`), so `release / test` fails on every tag and `release / goreleaser` is skipped — v0.0.131 published no agent binaries and `codefly` cannot download it.

Uses the workflow's existing `setup-run` hook to register binfmt emulation (`tonistiigi/binfmt --install arm64`), the same registration `docker/setup-qemu-action` performs in `ci.yml`. No change to the shared workflow or to the other services using it.

After merge: cut **v0.0.132** (tags are immutable; v0.0.131 cannot be repaired), then module-document-store bumps its store/vector agent pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)