### PR TITLE
fix(ci): move the shared runtime tag only on push (#101)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,8 +201,13 @@ jobs:
             image --quiet --format table --severity HIGH,CRITICAL \
             --exit-code 1 --input /image.tar
 
+      # The tag string is read from runtime-image.json, so every branch resolves
+      # the same one. A PR build that moved it would race every other PR on that
+      # single tag, and would repoint what releases consume while still unmerged,
+      # with nothing to move it back if the PR is closed. The candidate publish
+      # above keeps the wider guard: it pushes by digest and moves no tag.
       - name: Tag verified runtime image
-        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+        if: github.event_name == 'push'
         env:
           EXPECTED_DIGEST: ${{ steps.runtime.outputs.digest }}
           RUNTIME_IMAGE: ${{ steps.runtime.outputs.reference }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,13 @@ on:
   pull_request:
     branches: [ main ]
 
+# A push to main is the only run that moves the shared runtime tag, so it must not
+# be cancelled by the next merge: a cancelled run leaves the tag on the previous
+# digest and nothing retries it until someone pushes again. Pull requests stay
+# cancellable — they move no tag, so a superseded run is pure waste.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -25,6 +29,9 @@ jobs:
       contents: read
       packages: write
     runs-on: ubuntu-latest
+    # Pushes to main queue rather than cancel, so a hung registry read would stall
+    # every later merge until GitHub's six-hour default rather than just itself.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
@@ -206,6 +213,11 @@ jobs:
       # single tag, and would repoint what releases consume while still unmerged,
       # with nothing to move it back if the PR is closed. The candidate publish
       # above keeps the wider guard: it pushes by digest and moves no tag.
+      #
+      # Every step above gates this one, so a commit that relocks the digest and
+      # then fails the scan leaves the tag on the older digest until a later push
+      # to main goes green. That is the point — an image that fails a CRITICAL
+      # scan must not become what a plain `docker pull` of the tag returns.
       - name: Tag verified runtime image
         if: github.event_name == 'push'
         env:

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -131,6 +131,24 @@ func TestCIWorkflowValidatesLockedImageForEveryPullRequest(t *testing.T) {
 	)
 }
 
+// The runtime tag string is read from runtime-image.json, so every branch
+// resolves the same one and the ref-keyed concurrency group does not serialize
+// branches against each other. Only a push may move it: a PR build that did
+// would race every other PR on that single tag, and would repoint what releases
+// consume before merging. The candidate publish keeps the wider guard — it
+// pushes by digest, moves no tag, and the verification below it needs that push
+// for a same-repo PR that relocks the digest.
+func TestCIWorkflowMovesTheSharedRuntimeTagOnlyOnPush(t *testing.T) {
+	imageJob := readWorkflow(t, ".github/workflows/ci.yml").Jobs["image"]
+
+	tag := findWorkflowStep(t, imageJob, "Tag verified runtime image")
+	require.Equal(t, "github.event_name == 'push'", tag.If)
+
+	candidate := findWorkflowStep(t, imageJob, "Publish runtime image candidate")
+	require.Contains(t, candidate.If,
+		"github.event.pull_request.head.repo.full_name == github.repository")
+}
+
 func TestReleaseWorkflowRetagsLockedImageWithLeastPrivilege(t *testing.T) {
 	workflow := readWorkflow(t, ".github/workflows/releaser.yml")
 	require.Equal(t, map[string]string{"contents": "read"}, workflow.Permissions)

--- a/workflow_test.go
+++ b/workflow_test.go
@@ -19,8 +19,10 @@ type workflowDefinition struct {
 }
 
 type workflowConcurrency struct {
-	Group            string `yaml:"group"`
-	CancelInProgress bool   `yaml:"cancel-in-progress"`
+	Group string `yaml:"group"`
+	// Actions accepts either a literal or an expression here, so a bool-typed
+	// field would fail to parse a workflow that varies it per event.
+	CancelInProgress any `yaml:"cancel-in-progress"`
 }
 
 type workflowJob struct {
@@ -135,18 +137,35 @@ func TestCIWorkflowValidatesLockedImageForEveryPullRequest(t *testing.T) {
 // resolves the same one and the ref-keyed concurrency group does not serialize
 // branches against each other. Only a push may move it: a PR build that did
 // would race every other PR on that single tag, and would repoint what releases
-// consume before merging. The candidate publish keeps the wider guard — it
-// pushes by digest, moves no tag, and the verification below it needs that push
-// for a same-repo PR that relocks the digest.
+// consume before merging. (The candidate publish keeps the wider guard, which is
+// why the asymmetry above it is deliberate: it pushes by digest, moves no tag,
+// and the verification after it needs that push for a same-repo PR that relocks
+// the digest.)
+//
+// The guard is matched loosely because Actions treats `${{ ... }}` around it as
+// equivalent; what must not reappear is any pull_request term.
 func TestCIWorkflowMovesTheSharedRuntimeTagOnlyOnPush(t *testing.T) {
-	imageJob := readWorkflow(t, ".github/workflows/ci.yml").Jobs["image"]
+	tag := findWorkflowStep(t, readWorkflow(t, ".github/workflows/ci.yml").Jobs["image"],
+		"Tag verified runtime image")
 
-	tag := findWorkflowStep(t, imageJob, "Tag verified runtime image")
-	require.Equal(t, "github.event_name == 'push'", tag.If)
+	require.Contains(t, tag.If, "github.event_name == 'push'")
+	require.NotContains(t, tag.If, "pull_request",
+		"a pull request must not move the tag every other branch resolves")
+}
 
-	candidate := findWorkflowStep(t, imageJob, "Publish runtime image candidate")
-	require.Contains(t, candidate.If,
-		"github.event.pull_request.head.repo.full_name == github.repository")
+// Restricting the tag to pushes leaves exactly one run able to move it, so that
+// run must survive to reach the step. Cancelling it on the next merge would
+// strand the tag on the previous digest with nothing to retry it, and pull
+// requests — which move no tag — stay cancellable. Queueing pushes instead of
+// cancelling them is what makes the job timeout load-bearing: without it a hung
+// registry read blocks every later merge, not just its own run.
+func TestCIWorkflowNeverCancelsTheRunThatMovesTheTag(t *testing.T) {
+	workflow := readWorkflow(t, ".github/workflows/ci.yml")
+
+	require.Equal(t, "${{ github.workflow }}-${{ github.ref }}", workflow.Concurrency.Group)
+	require.Equal(t, "${{ github.event_name == 'pull_request' }}", workflow.Concurrency.CancelInProgress)
+	require.NotZero(t, workflow.Jobs["image"].TimeoutMinutes,
+		"a queued push must not wait out GitHub's six-hour default")
 }
 
 func TestReleaseWorkflowRetagsLockedImageWithLeastPrivilege(t *testing.T) {
@@ -175,7 +194,7 @@ func TestReleaseWorkflowRetagsLockedImageWithLeastPrivilege(t *testing.T) {
 	// Two releases publishing at once each see the other's digest on the shared
 	// runtime tag, and the read-back retry holds that window open for minutes.
 	require.Equal(t, "${{ github.workflow }}", workflow.Concurrency.Group)
-	require.False(t, workflow.Concurrency.CancelInProgress,
+	require.Equal(t, false, workflow.Concurrency.CancelInProgress,
 		"cancelling would abandon a half-published release")
 	require.NotZero(t, imageJob.TimeoutMinutes,
 		"a hung registry read must not run to GitHub's six-hour default")


### PR DESCRIPTION
Closes #101.

## Summary

- The runtime tag string is read from `runtime-image.json`, so it is the same string on every branch, while `concurrency` is keyed on `github.ref` — branches are not serialized against each other. Restricting `Tag verified runtime image` to `push` events removes the only writer that could collide, and also fixes the second consequence the issue names, which the alternative does not: an unmerged PR no longer repoints the tag releases consume, with nothing to move it back if the PR is closed. Keying the job's `concurrency` on the tag would serialize the races away while still letting a PR move a tag it has no business moving, and would put every PR's ~7-minute `image` job in one global queue.
- That leaves a single writer, so the run holding it must survive to reach the step. `cancel-in-progress` is now `${{ github.event_name == 'pull_request' }}`: a push to `main` queues instead of being cancelled by the next merge, which would otherwise strand the tag on the previous digest with nothing to retry it. PRs move no tag and stay cancellable. Queueing pushes is what makes `timeout-minutes: 90` load-bearing — a hung registry read would otherwise block every later merge, not just its own run.
- **What this gives up:** PR builds no longer exercise the real `docker buildx imagetools create`, real ghcr auth, or real tag propagation. `tag_runtime_image_test.go` covers the script on every PR but against a *fake* docker, so a break in the real path (a buildx bump, a permissions change) now reddens `main` post-merge instead of the PR. Publishing PR builds to a PR-scoped tag would have kept that coverage with no shared-tag write; it was rejected for the untagged/tagged litter it accumulates in GHCR, which is a retention-policy problem rather than an impossibility.
- **Residual staleness, by design:** every step gates the tag step, so a commit that relocks the digest and then fails the trivy scan leaves the tag on the older digest until a later push to `main` goes green. That is intended — an image failing a CRITICAL scan must not be what a plain `docker pull` of the tag returns. No automated consumer is affected: `FullName()` prefers digest over tag, no Go code or test resolves that tag string, and `releaser.yml` republishes it from the lock on release.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`
- [x] Full CI unit-test suite: `go test ./... -skip '^(TestCreateToRunDocker|TestDirtyMigrationFailsClosed|TestLifecycleContractDocker|TestMigrationLockBudgetExpiresWhilePeerHoldsTheLock|TestMigrationStatementBudgetExpiresAndPreservesTheLedger)$' -timeout 20m`
- [x] Both new tests were run against the pre-fix `ci.yml` and observed to fail — `TestCIWorkflowMovesTheSharedRuntimeTagOnlyOnPush` on the `pull_request` term in the old guard, `TestCIWorkflowNeverCancelsTheRunThatMovesTheTag` on `cancel-in-progress: true` — then to pass against this one.
- [x] The tag guard written as `${{ github.event_name == 'push' }}` also passes, confirming the assertion matches Actions' semantics rather than one exact string.
- [ ] This PR's own `image` job is the observable check: `Tag verified runtime image` must show as skipped and the job stay green. The `main` build after merge must run it.

## Risk

`cancel-in-progress` now varies per event. If the expression were ever mis-evaluated, `main` pushes would revert to cancelling — the pre-existing behavior — rather than failing; `TestCIWorkflowNeverCancelsTheRunThatMovesTheTag` pins the expression so it cannot be silently rewritten. Both changes are one-line reverts with no persisted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)