### PR TITLE
Add opt-in restricted session role policy to the Go SDK

### DIFF
--- a/.github/workflows/controlplane.yml
+++ b/.github/workflows/controlplane.yml
@@ -33,6 +33,6 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - run: go vet ./libs/go/controlplane
+      - run: go vet ./libs/go ./libs/go/controlplane
       - run: docker pull "$POSTGRES_TEST_IMAGE"
       - run: python3 scripts/qualify-controlplane.py

--- a/libs/go/README.md
+++ b/libs/go/README.md
@@ -51,6 +51,31 @@ multiple queries. It affects readers only; writers keep their existing isolation
 semantics and application-owned row locking. Failed callbacks roll back as in the
 existing scoped Factory. Without this option, existing read isolation is unchanged.
 
+## Restricted sessions
+
+`WithRestrictedSession("background_jobs")` is an optional policy for `Open` and
+`OpenMaintenance`. It rejects the login or current role if either has direct or
+transitive membership in a named forbidden role, a privileged role (including
+BYPASSRLS, CREATEROLE or CREATEDB), or the current database owner. A missing named
+role fails closed. With no arguments it still checks privileged and owner roles.
+The policy uses read-only catalog queries on every new physical connection and
+every pool checkout, adding a catalog round trip to checkout. A newly forbidden
+connection is discarded before the application transaction begins. Errors do not
+expose the denied role names or credentials.
+
+This does not grant privileges, change RLS, audit table/function grants or replace
+separate process credentials. It cannot fence a concurrent GRANT after checkout;
+operators must drain affected sessions before changing role memberships. PostgreSQL
+object grants, safe search paths and application RLS remain separately qualified.
+Caller-owned pools passed to `NewFactory` or `NewMaintenance` are not rewired by
+this option; their owners must enforce the equivalent connection policy.
+Existing consumers that omit this option retain the same behavior.
+
+The isolated regression below also exercises safe sessions, direct/transitive
+membership denial, privileged/owner denial, permission changes on pooled sessions,
+reconnection after revoke and composition with maintenance validation. It uses
+fixture-only roles and no cloud identities.
+
 ## External-identity role administration
 
 `controlplane.ReconcileRuntimeAccess` is the privileged role-engine boundary for

--- a/libs/go/maintenance.go
+++ b/libs/go/maintenance.go
@@ -92,6 +92,7 @@ func OpenMaintenance(ctx context.Context, connection, applicationRole string, op
 		}
 		return nil
 	}
+	installRestrictedSession(pc, c)
 	pool, err := pgxpool.NewWithConfig(ctx, pc)
 	if err != nil {
 		return nil, nil, errors.New("cannot open maintenance Postgres capability")

--- a/libs/go/open.go
+++ b/libs/go/open.go
@@ -40,6 +40,8 @@ func Open(
 		installAccessTokenProvider(readerConfig, configuration.accessTokenProvider)
 		installAccessTokenProvider(writerConfig, configuration.accessTokenProvider)
 	}
+	installRestrictedSession(readerConfig, configuration)
+	installRestrictedSession(writerConfig, configuration)
 	readerPool, err := pgxpool.NewWithConfig(ctx, readerConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open read-only Postgres capability: %w", err)

--- a/libs/go/session_policy.go
+++ b/libs/go/session_policy.go
@@ -1,0 +1,83 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// WithRestrictedSession makes Open and OpenMaintenance reject privileged or
+// database-owner sessions and membership in any denied role, including transitive
+// membership. Missing denied roles fail closed. Checks run for every new physical
+// connection and every pool checkout; this is not a fence against a concurrent
+// GRANT after checkout. Role changes must also follow an operator drain policy.
+//
+// This option grants nothing and changes no role or transaction settings. It is
+// opt-in for compatibility. Caller-owned pools supplied to NewFactory or
+// NewMaintenance remain the caller's qualification responsibility.
+func WithRestrictedSession(deniedRoles ...string) Option {
+	roles := append([]string(nil), deniedRoles...)
+	return func(c *config) error {
+		seen := map[string]bool{}
+		for _, role := range roles {
+			if strings.TrimSpace(role) != role || role == "" || len(role) > 63 || strings.ContainsRune(role, '\x00') || seen[role] {
+				return errors.New("restricted-session roles must be distinct nonempty PostgreSQL identifiers")
+			}
+			seen[role] = true
+		}
+		c.restrictedSession = true
+		c.deniedRoles = append([]string{}, roles...)
+		return nil
+	}
+}
+
+func checkRestrictedSession(ctx context.Context, conn *pgx.Conn, denied []string) error {
+	var allowed bool
+	err := conn.QueryRow(ctx, `
+ SELECT
+ NOT EXISTS (
+  SELECT 1 FROM pg_roles r
+  WHERE (r.rolname=session_user OR r.rolname=current_user
+         OR pg_has_role(session_user,r.oid,'MEMBER')
+         OR pg_has_role(current_user,r.oid,'MEMBER'))
+    AND (r.rolsuper OR r.rolcreatedb OR r.rolcreaterole OR r.rolreplication OR r.rolbypassrls)
+ )
+ AND NOT EXISTS (
+  SELECT 1 FROM pg_database d WHERE d.datname=current_database()
+  AND (pg_has_role(session_user,d.datdba,'MEMBER') OR pg_has_role(current_user,d.datdba,'MEMBER'))
+ )
+ AND NOT EXISTS (
+  SELECT 1 FROM unnest($1::text[]) denied(name)
+  LEFT JOIN pg_roles r ON r.rolname=denied.name
+  WHERE r.oid IS NULL OR pg_has_role(session_user,r.oid,'MEMBER')
+     OR pg_has_role(current_user,r.oid,'MEMBER')
+ )`, denied).Scan(&allowed)
+	if err != nil || !allowed {
+		return errors.New("Postgres session does not satisfy its restricted role policy")
+	}
+	return nil
+}
+
+func installRestrictedSession(pc *pgxpool.Config, c config) {
+	if !c.restrictedSession {
+		return
+	}
+	after, before := pc.AfterConnect, pc.BeforeAcquire
+	pc.AfterConnect = func(ctx context.Context, conn *pgx.Conn) error {
+		if after != nil {
+			if err := after(ctx, conn); err != nil {
+				return err
+			}
+		}
+		return checkRestrictedSession(ctx, conn, c.deniedRoles)
+	}
+	pc.BeforeAcquire = func(ctx context.Context, conn *pgx.Conn) bool {
+		if before != nil && !before(ctx, conn) {
+			return false
+		}
+		return checkRestrictedSession(ctx, conn, c.deniedRoles) == nil
+	}
+}

--- a/libs/go/session_policy_test.go
+++ b/libs/go/session_policy_test.go
@@ -1,0 +1,231 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestRestrictedSessionOption(t *testing.T) {
+	for _, roles := range [][]string{{""}, {" group"}, {"group", "group"}, {strings.Repeat("x", 64)}, {"bad\x00role"}} {
+		if _, err := configured(WithRestrictedSession(roles...)); err == nil {
+			t.Fatal("invalid denied roles accepted")
+		}
+	}
+	roles := []string{"background_jobs"}
+	option := WithRestrictedSession(roles...)
+	roles[0] = "changed"
+	c, err := configured(option)
+	if err != nil || !c.restrictedSession || c.deniedRoles[0] != "background_jobs" {
+		t.Fatal("option retained mutable caller data")
+	}
+	c.deniedRoles[0] = "changed again"
+	c2, err := configured(option)
+	if err != nil || c2.deniedRoles[0] != "background_jobs" {
+		t.Fatal("configurations share mutable role data")
+	}
+	if _, err := configured(WithRestrictedSession()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The DSN must name a disposable local database with a superuser fixture owner.
+// CI supplies its own isolated container. No developer or hosted database is used.
+func TestRestrictedSessionPostgres(t *testing.T) {
+	dsn := os.Getenv("SESSION_POLICY_TEST_DSN")
+	if dsn == "" {
+		t.Skip("SESSION_POLICY_TEST_DSN is required for the real-database role regression")
+	}
+	endpoint, err := url.Parse(dsn)
+	if err != nil || endpoint.Scheme != "postgres" || (endpoint.Hostname() != "127.0.0.1" && endpoint.Hostname() != "localhost" && endpoint.Hostname() != "::1") {
+		t.Fatal("role regression requires a loopback PostgreSQL URL")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	admin, err := pgx.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal("cannot connect to isolated role fixture")
+	}
+	defer admin.Close(context.Background())
+	exec := func(sql string) {
+		t.Helper()
+		if _, err := admin.Exec(ctx, sql); err != nil {
+			t.Fatal(err)
+		}
+	}
+	prefix := fmt.Sprintf("policy_%d_", time.Now().UnixNano())
+	role := func(name string) string { return prefix + name }
+	ident := func(name string) string { return pgx.Identifier{role(name)}.Sanitize() }
+	names := []string{"reader", "writer", "jobs", "intermediate", "owner", "privileged"}
+	for _, name := range names {
+		attrs := "NOLOGIN"
+		if name == "reader" || name == "writer" {
+			attrs = "LOGIN NOINHERIT PASSWORD 'isolated-fixture-only'"
+		}
+		exec("CREATE ROLE " + ident(name) + " " + attrs)
+	}
+	originalOwner := ""
+	if err := admin.QueryRow(ctx, "SELECT pg_get_userbyid(datdba) FROM pg_database WHERE datname=current_database()").Scan(&originalOwner); err != nil {
+		t.Fatal(err)
+	}
+	db := ""
+	if err := admin.QueryRow(ctx, "SELECT current_database()").Scan(&db); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		cleanup, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stop()
+		if _, err := admin.Exec(cleanup, "ALTER DATABASE "+pgx.Identifier{db}.Sanitize()+" OWNER TO "+pgx.Identifier{originalOwner}.Sanitize()); err != nil {
+			t.Error(err)
+		}
+		for _, name := range names {
+			if _, err := admin.Exec(cleanup, "DROP ROLE "+ident(name)); err != nil {
+				t.Error(err)
+			}
+		}
+	}()
+	connection := func(name string) string {
+		u := *endpoint
+		u.User = url.UserPassword(role(name), "isolated-fixture-only")
+		return u.String()
+	}
+	policy := WithRestrictedSession(role("jobs"))
+	auth := fakeAuthenticator{principal: testPrincipal{tenant: "tenant", user: "user"}}
+	open := func(option ...Option) (*Factory, func(), error) {
+		return Open(ctx, connection("reader"), connection("writer"), auth, option...)
+	}
+	assertRejected := func() {
+		t.Helper()
+		_, close, err := open(policy)
+		if close != nil {
+			close()
+		}
+		if err == nil {
+			t.Fatal("unsafe session accepted")
+		}
+		if strings.Contains(err.Error(), "isolated-fixture-only") || strings.Contains(err.Error(), role("writer")) {
+			t.Fatal("role-policy error disclosed credentials or identity")
+		}
+	}
+	t.Run("safe and missing role", func(t *testing.T) {
+		_, close, err := open(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		close()
+		_, close, err = open(WithRestrictedSession(role("absent")))
+		if close != nil {
+			close()
+		}
+		if err == nil {
+			t.Fatal("missing denied role accepted")
+		}
+	})
+	t.Run("direct and transitive membership", func(t *testing.T) {
+		exec("GRANT " + ident("jobs") + " TO " + ident("writer"))
+		assertRejected()
+		// Without the opt-in policy, existing consumers keep their prior behavior.
+		_, close, err := open()
+		if err != nil {
+			t.Fatal(err)
+		}
+		close()
+		exec("REVOKE " + ident("jobs") + " FROM " + ident("writer"))
+		exec("GRANT " + ident("jobs") + " TO " + ident("intermediate"))
+		exec("GRANT " + ident("intermediate") + " TO " + ident("reader"))
+		assertRejected()
+		exec("REVOKE " + ident("intermediate") + " FROM " + ident("reader"))
+	})
+	t.Run("privileged and owner membership", func(t *testing.T) {
+		exec("ALTER ROLE " + ident("privileged") + " CREATEROLE")
+		exec("GRANT " + ident("privileged") + " TO " + ident("writer"))
+		assertRejected()
+		exec("REVOKE " + ident("privileged") + " FROM " + ident("writer"))
+		exec("ALTER ROLE " + ident("reader") + " BYPASSRLS")
+		assertRejected()
+		exec("ALTER ROLE " + ident("reader") + " NOBYPASSRLS")
+		exec("ALTER DATABASE " + pgx.Identifier{db}.Sanitize() + " OWNER TO " + ident("owner"))
+		exec("GRANT " + ident("owner") + " TO " + ident("writer"))
+		assertRejected()
+		exec("REVOKE " + ident("owner") + " FROM " + ident("writer"))
+	})
+	t.Run("permission change on pooled session", func(t *testing.T) {
+		factory, close, err := open(policy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer close()
+		writer, err := factory.Writer(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		calls := 0
+		transaction := func(ctx context.Context, tx WriteTx) error { calls++; _, err := tx.Exec(ctx, "SELECT 1"); return err }
+		if err := writer.InTransaction(ctx, transaction); err != nil {
+			t.Fatal(err)
+		}
+		exec("GRANT " + ident("jobs") + " TO " + ident("writer"))
+		if err := writer.InTransaction(ctx, transaction); err == nil {
+			t.Fatal("existing pool accepted newly forbidden membership")
+		}
+		if calls != 1 {
+			t.Fatal("application callback ran under forbidden authority")
+		}
+		exec("REVOKE " + ident("jobs") + " FROM " + ident("writer"))
+		if err := writer.InTransaction(ctx, transaction); err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("maintenance composes existing validation", func(t *testing.T) {
+		exec("GRANT " + ident("jobs") + " TO " + ident("writer"))
+		_, close, err := OpenMaintenance(ctx, connection("writer"), role("jobs"), WithRestrictedSession())
+		if err != nil {
+			t.Fatal(err)
+		}
+		close()
+		_, close, err = OpenMaintenance(ctx, connection("writer"), role("jobs"), policy)
+		if close != nil {
+			close()
+		}
+		if err == nil {
+			t.Fatal("maintenance ignored denied group")
+		}
+		exec("ALTER ROLE " + ident("jobs") + " LOGIN")
+		_, close, err = OpenMaintenance(ctx, connection("writer"), role("jobs"), WithRestrictedSession())
+		if close != nil {
+			close()
+		}
+		if err == nil {
+			t.Fatal("existing maintenance login-role check bypassed")
+		}
+	})
+	t.Run("existing connection hooks preserved", func(t *testing.T) {
+		pc, err := pgxpool.ParseConfig(connection("reader"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		after, before := false, false
+		pc.AfterConnect = func(context.Context, *pgx.Conn) error { after = true; return nil }
+		pc.BeforeAcquire = func(context.Context, *pgx.Conn) bool { before = true; return true }
+		c, _ := configured(policy)
+		installRestrictedSession(pc, c)
+		pool, err := pgxpool.NewWithConfig(ctx, pc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer pool.Close()
+		if err := pool.Ping(ctx); err != nil {
+			t.Fatal(err)
+		}
+		if !after || !before {
+			t.Fatal("existing connection hooks were replaced")
+		}
+	})
+}

--- a/libs/go/store.go
+++ b/libs/go/store.go
@@ -154,6 +154,8 @@ type config struct {
 	operationTimeout    time.Duration
 	readIsolation       pgx.TxIsoLevel
 	accessTokenProvider AccessTokenProvider
+	restrictedSession   bool
+	deniedRoles         []string
 }
 
 // Option configures the RLS settings used by application policies.

--- a/scripts/qualify-controlplane.py
+++ b/scripts/qualify-controlplane.py
@@ -1,4 +1,4 @@
-"""Qualify role reconciliation on a disposable, loopback-only Docker fixture."""
+"""Qualify role reconciliation and session restrictions on an isolated fixture."""
 
 import json
 import os
@@ -72,7 +72,15 @@ def main():
         env["SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"] = (
             f"postgres://postgres@127.0.0.1:{int(binding['HostPort'])}/postgres"
         )
+        env["SESSION_POLICY_TEST_DSN"] = env["SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"]
         print(f"Fixture image: {image}", flush=True)
+        subprocess.run(
+            ["go", "test", "-race", "-count=1", "-v", "./libs/go", "-run", "^TestRestrictedSession"],
+            cwd=ROOT,
+            env=env,
+            check=True,
+            timeout=120,
+        )
         subprocess.run(
             [
                 "go",


### PR DESCRIPTION
Adds opt-in `WithRestrictedSession(deniedRoles...)` for SDK-owned connections. Applications that separate request credentials from background credentials can reject direct or transitive membership in forbidden roles, privileged roles and the database owner. Missing forbidden roles fail closed. The policy checks new connections and pool checkouts and composes with existing maintenance validation; it grants no privileges and exposes no pool.

Existing consumers remain unchanged when the option is omitted. This is not a fence against a concurrent GRANT after checkout and does not audit object grants or RLS. Operators must drain affected sessions for permission changes; caller-owned pools remain their owner's responsibility. Checkout adds one catalog round trip.

Validation: library race tests and vet pass; disposable PostgreSQL 16 regression passes for safe/denied roles, transitive and owner membership, privilege changes on pooled sessions, recovery after revoke, existing hook composition and legacy behavior. The existing digest-pinned isolated CI harness now runs this regression as well as role-engine qualification. Staged secret scan is clean.
