### PR TITLE
chore: group dependency updates and pin every action by SHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,67 @@
+# Dependency updates for every ecosystem this repository ships.
+#
+# Each ecosystem is ONE catch-all group covering minor, patch and major, with
+# open-pull-requests-limit 1, so a week yields at most one pull request per
+# ecosystem instead of one per dependency. Dependabot cannot group across
+# ecosystems, so the number of entries below is the floor on weekly PRs.
+#
+# The github-actions entry exists because every action is pinned by commit SHA;
+# nothing else would ever move those pins.
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      gomod:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+          - major
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+          - major
+
+  - package-ecosystem: cargo
+    directory: /libs/rust
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+          - major
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+          - major


### PR DESCRIPTION
Part of an organization-wide dependency-policy rollout.

## Grouped dependency updates

`.github/dependabot.yml` now gives each ecosystem present here a **single catch-all group** over minor, patch and major, with `open-pull-requests-limit: 1`. A week now yields at most one pull request per ecosystem instead of one per dependency. Dependabot cannot group across ecosystems, so the number of entries is the floor.

Ecosystems configured (directory count in parentheses): `gomod(1) docker(1) cargo(1) github-actions(1)`

## Actions pinned by commit SHA

**0** action reference(s) rewritten from a mutable tag to a 40-character commit SHA, with the original tag kept as a trailing comment so the intent stays readable.

A tag like `@v4` is repointable by whoever controls the action, so an unpinned workflow runs whatever that tag means on the day CI fires. A SHA is immutable. This is the single highest-value CI supply-chain control, and it is why the `github-actions` entry above exists — nothing else would ever move those pins.

Unresolved references left untouched: none

## Risk

Pinning is behavior-identical today: each SHA is the exact commit the tag points at right now. The dependabot config is inert until its next scheduled run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)