### PR TITLE
feat: add explicit managed identity bootstrap preview

### DIFF
--- a/.github/workflows/controlplane.yml
+++ b/.github/workflows/controlplane.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - "libs/go/**"
+      - "cmd/managed-bootstrap/**"
       - "go.mod"
       - "go.sum"
       - "scripts/qualify-controlplane.py"
@@ -13,6 +14,7 @@ on:
     branches: [main]
     paths:
       - "libs/go/**"
+      - "cmd/managed-bootstrap/**"
       - "go.mod"
       - "go.sum"
       - "scripts/qualify-controlplane.py"
@@ -33,6 +35,6 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
-      - run: go vet ./libs/go ./libs/go/controlplane
+      - run: go vet ./libs/go ./libs/go/controlplane ./libs/go/bootstrap ./libs/go/schemaplan ./cmd/managed-bootstrap
       - run: docker pull "$POSTGRES_TEST_IMAGE"
       - run: python3 scripts/qualify-controlplane.py

--- a/cmd/managed-bootstrap/main.go
+++ b/cmd/managed-bootstrap/main.go
@@ -1,0 +1,44 @@
+// managed-bootstrap is an explicit migration-owner command. It does not start
+// a service, create cloud identities, or acquire provider credentials.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"github.com/codefly-dev/service-postgres/libs/go/bootstrap"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func main() {
+	var o bootstrap.Options
+	var binding string
+	flag.StringVar(&o.Directory, "package", "", "staged bootstrap directory containing plan.json and sources")
+	flag.StringVar(&binding, "binding", "", "secret-free managed identity binding JSON")
+	flag.StringVar(&o.MigrateExecutable, "migrate", "/usr/local/bin/migrate", "absolute path to the pinned golang-migrate executable")
+	flag.DurationVar(&o.Timeout, "timeout", 10*time.Minute, "total execution budget")
+	flag.DurationVar(&o.LockTimeout, "lock-timeout", 30*time.Second, "database lock budget")
+	flag.DurationVar(&o.StatementTimeout, "statement-timeout", 5*time.Minute, "statement budget")
+	flag.Parse()
+	if flag.NArg() != 0 {
+		fmt.Fprintln(os.Stderr, "unexpected positional arguments")
+		os.Exit(2)
+	}
+	if err := bootstrap.ReadJSON(binding, &o.Binding); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	o.Connection = os.Getenv("CODEFLY_POSTGRES_MIGRATION_CONNECTION")
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	result, err := bootstrap.Run(ctx, o)
+	json.NewEncoder(os.Stdout).Encode(result)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/managed-bootstrap.md
+++ b/docs/managed-bootstrap.md
@@ -7,7 +7,7 @@ database primitive. Application services supply their domain migration files;
 they do not copy this runner or the role engine.
 
 This preview is qualified on disposable PostgreSQL 16 with a restricted
-CREATEROLE migration owner and a passwordless loopback endpoint. Managed cloud
+CREATEROLE migration owner and a passwordless TCP and private Unix-socket endpoints. Managed cloud
 execution, identity proxies, container packaging and deployment integration are
 separate qualification steps. The ordinary agent `Build` still rejects
 `auth-mode: external-identity`; its password bootstrap must not be used for this
@@ -67,14 +67,23 @@ go build -trimpath -tags postgres -o /tmp/migrate \
 ```
 
 Supply `CODEFLY_POSTGRES_MIGRATION_CONNECTION` privately through the deployment
-composition. This preview accepts an explicit passwordless TCP URL, for example
+composition. This preview accepts an explicit passwordless URL, for example
 `postgres://migration_owner@127.0.0.1:5432/example?sslmode=disable` for a disposable
 local fixture or an already authenticated local proxy. Direct network endpoints
 should use their reviewed TLS mode and trust configuration. The supported query
-keys are `sslmode`, `sslrootcert`, `sslcert` and `sslkey`; the runner owns connection,
+keys are `sslmode`, `sslrootcert`, `sslcert`, `sslkey` and the private socket `host`; the runner owns connection,
 lock and statement budgets. Static passwords, hidden service files, implicit
 principals, alternate databases and arbitrary connection options are rejected.
 Inherited password/role configuration is not forwarded to the child.
+
+For an existing identity proxy's private Unix socket use, for example,
+`postgres://migration_owner@/example?host=/private/proxy&sslmode=disable`.
+The host must be one absolute socket directory, the authority host must be empty,
+and the socket port is fixed to 5432. This mode requires `sslmode=disable` because
+the separately qualified proxy owns remote authentication and TLS. The socket
+mount must be private to this owner workload and its approved identity proxy;
+this does not authorize an unauthenticated network endpoint. The local fixture
+also executes the actual Linux binaries over a Unix socket.
 
 ```sh
 /tmp/managed-bootstrap \
@@ -131,7 +140,7 @@ POSTGRES_TEST_IMAGE=postgres@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c
 ```
 
 The harness builds the actual command and pinned migration CLI, and exercises
-concurrent jobs, command replay, one migration execution, unchanged external
+concurrent jobs, TCP and Unix-socket command replay, one migration execution, unchanged external
 passwords, reader/writer DML, denied runtime DDL, default sequence privileges,
 missing-principal and LOGIN-group rejection, bounded shared-lock contention,
 dirty-state preservation, cancellation and child-session cleanup. Failure tests

--- a/docs/managed-bootstrap.md
+++ b/docs/managed-bootstrap.md
@@ -74,7 +74,7 @@ should use their reviewed TLS mode and trust configuration. The supported query
 keys are `sslmode`, `sslrootcert`, `sslcert`, `sslkey` and the private socket `host`; the runner owns connection,
 lock and statement budgets. Static passwords, hidden service files, implicit
 principals, alternate databases and arbitrary connection options are rejected.
-Inherited password/role configuration is not forwarded to the child.
+The owner connection rejects ambient service selectors and clears ambient password, TLS-client credential and role configuration before parsing. The child receives no inherited configuration.
 
 For an existing identity proxy's private Unix socket use, for example,
 `postgres://migration_owner@/example?host=/private/proxy&sslmode=disable`.

--- a/docs/managed-bootstrap.md
+++ b/docs/managed-bootstrap.md
@@ -1,0 +1,144 @@
+# Managed identity bootstrap preview
+
+The `cmd/managed-bootstrap` command applies the existing schema-plan package
+through the pinned `golang-migrate` executable, then calls
+`controlplane.ReconcileRuntimeAccess`. It is an explicit owner operation in this
+database primitive. Application services supply their domain migration files;
+they do not copy this runner or the role engine.
+
+This preview is qualified on disposable PostgreSQL 16 with a restricted
+CREATEROLE migration owner and a passwordless loopback endpoint. Managed cloud
+execution, identity proxies, container packaging and deployment integration are
+separate qualification steps. The ordinary agent `Build` still rejects
+`auth-mode: external-identity`; its password bootstrap must not be used for this
+path. The new command does not remove that guard or enable runtime startup DDL.
+
+## Inputs and ownership
+
+Supply the builder's `bootstrap/plan.json` and `bootstrap/sources` tree, plus a
+separate deployment binding. The shared `libs/go/schemaplan` package defines the
+same v1 artifact and digest used by the builder. No format or existing content
+identity changes in this preview.
+
+The binding must name pre-provisioned cloud login principals and the connected
+migration owner. For example, with entirely synthetic role names:
+
+```json
+{
+  "plan-sha256": "<SHA-256 of the exact plan.json file>",
+  "plan-digest": "sha256:<digest recorded inside that plan>",
+  "owner-role": "migration_owner",
+  "read-only-principals": ["external_reader"],
+  "read-write-principals": ["external_writer"]
+}
+```
+
+Both identities are checked. The exact file SHA additionally binds field
+boundaries and inventory bytes; the v1 plan digest is retained for compatibility.
+The plan supplies the database, NOLOGIN groups, schemas, delegated write roles,
+extensions and independently versioned migration ledgers. The deployment owner
+must review the exact plan and binding together. Group names are not inferred
+from a provider identity, and the command cannot override the plan's access
+policy. The connected `current_user` must equal the explicit owner so migration
+ownership and default privileges agree.
+
+Login identities must already exist. They must differ from the migration owner,
+the managed groups, delegated roles and each other. A configured group that is
+already a LOGIN or elevated role fails before migration. The command never
+creates login identities, alters their passwords or obtains cloud credentials.
+The canonical role engine owns NOLOGIN group creation and access reconciliation.
+Its existing restrictions on administration authority and stable grantors apply.
+
+The migration owner needs authority for the declared DDL, extension operations,
+group administration, grants and its own default privileges. The runner also
+needs permission to terminate its own child sessions, supported by PostgreSQL
+14+ and qualified here on PostgreSQL 16. It never requests superuser or bypass-RLS
+rights. Managed-provider SQL permissions still need separate qualification.
+
+## Build and run
+
+Build both executables from one reviewed, immutable checkout. The migration
+executable uses the existing version in `go.mod` (currently v4.19.1):
+
+```sh
+go build -trimpath -o /tmp/managed-bootstrap ./cmd/managed-bootstrap
+go build -trimpath -tags postgres -o /tmp/migrate \
+  github.com/golang-migrate/migrate/v4/cmd/migrate
+```
+
+Supply `CODEFLY_POSTGRES_MIGRATION_CONNECTION` privately through the deployment
+composition. This preview accepts an explicit passwordless TCP URL, for example
+`postgres://migration_owner@127.0.0.1:5432/example?sslmode=disable` for a disposable
+local fixture or an already authenticated local proxy. Direct network endpoints
+should use their reviewed TLS mode and trust configuration. The supported query
+keys are `sslmode`, `sslrootcert`, `sslcert` and `sslkey`; the runner owns connection,
+lock and statement budgets. Static passwords, hidden service files, implicit
+principals, alternate databases and arbitrary connection options are rejected.
+Inherited password/role configuration is not forwarded to the child.
+
+```sh
+/tmp/managed-bootstrap \
+  -package /mounted/bootstrap \
+  -binding /mounted/binding.json \
+  -migrate /tmp/migrate \
+  -timeout 10m -lock-timeout 30s -statement-timeout 5m
+```
+
+The deployment owner must pin both binaries and the schema package in its own
+immutable image/artifact. A local build or editable checkout is not cloud release
+evidence. This change does not ship a cloud Job or automatically publish a
+managed bootstrap image.
+
+## Execution and failure semantics
+
+The runner verifies the exact plan, lineage/file hashes and inventory before
+connecting. It executes a private snapshot of those verified bytes, so a later
+input edit cannot change a running migration. Changed bytes, duplicate versions,
+unknown fields, path traversal, symlinks and missing identity bindings fail closed.
+
+One owner connection holds the existing per-database `codefly-runtime-access`
+advisory lock across extensions, every migration subprocess and the canonical
+access transaction. Independent lineages retain their original ledgers. Concurrent
+jobs serialize; reruns use `golang-migrate`'s existing no-change behavior. There
+are no automatic migration retries or force/repair actions.
+
+A failed or dirty migration prevents access reconciliation. Migrations are not
+atomic with each other or with the final grants transaction: earlier completed
+lineages remain committed. Use [the dirty-migration runbook](dirty-migrations.md)
+to inspect and reconcile failures. Do not force a ledger clean merely to rerun.
+
+The total execution budget cancels subprocesses; lock and statement timeouts also
+bound server work. Killing a client alone is not proof that its SQL stopped, so
+the runner drains only that child's uniquely named owner sessions while it still
+holds the shared lock. Cleanup has a separate five-second bound. An uncertain
+cleanup/commit is an operator reconciliation outcome, not safe-retry permission.
+Uncatchable process loss or loss of the lock-owning connection remains a deployed
+recovery qualification gap; this local test does not claim restart recovery.
+
+Standard output is a JSON receipt containing the exact plan file SHA-256, plan digest, completed lineages,
+skipped optional extensions and whether access committed. Exit zero requires
+committed access. Errors omit SQL, connection URLs and subprocess output; inspect
+SQL state through the privileged operator path. This receipt is not a durable
+migration audit service or a substitute for the actual version ledgers.
+
+## Qualification
+
+With Docker running and the workflow's pinned fixture available locally:
+
+```sh
+POSTGRES_TEST_IMAGE=postgres@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54 \
+  python3 scripts/qualify-controlplane.py
+```
+
+The harness builds the actual command and pinned migration CLI, and exercises
+concurrent jobs, command replay, one migration execution, unchanged external
+passwords, reader/writer DML, denied runtime DDL, default sequence privileges,
+missing-principal and LOGIN-group rejection, bounded shared-lock contention,
+dirty-state preservation, cancellation and child-session cleanup. Failure tests
+verify that runtime access is not reconciled and sensitive SQL is not returned.
+The existing restricted-session and canonical role-engine suites also run.
+
+The managed command still needs an immutable deployment artifact and managed
+provider qualification before use against a shared endpoint. Provider IAM,
+workload identity, secret/token refresh, application database clients and cloud
+backup/restore are outside this runner's responsibility.

--- a/libs/go/README.md
+++ b/libs/go/README.md
@@ -117,3 +117,15 @@ It loads no cloud credentials and accepts no managed endpoint. The dedicated
 restricted-admin replay and membership replacement, existing/default table and
 sequence grants, runtime DDL denial, preserved external passwords/unrelated
 memberships, rollback, elevated-role rejection and authorized hardening.
+
+## Explicit managed schema bootstrap
+
+The [managed bootstrap preview](../../docs/managed-bootstrap.md) composes the
+shared schema-plan artifact, existing `golang-migrate` executable and canonical
+role engine under the database control-plane lock. It accepts an explicit
+passwordless owner endpoint and separately bound existing external principals.
+Use `cmd/managed-bootstrap` for this owner operation; it is not part of the
+request-scoped Store API. Its isolated PostgreSQL qualification is included in
+`scripts/qualify-controlplane.py`. Managed deployment packaging and cloud
+qualification remain separate, and the agent's external-identity Build guard
+continues to reject password-bootstrap generation.

--- a/libs/go/bootstrap/package.go
+++ b/libs/go/bootstrap/package.go
@@ -1,0 +1,207 @@
+// Package bootstrap applies an attested schema package through the existing
+// golang-migrate executable and the canonical controlplane access reconciler.
+// It is a migration-owner boundary, never an application runtime capability.
+package bootstrap
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/codefly-dev/service-postgres/libs/go/schemaplan"
+)
+
+var migrationName = regexp.MustCompile(schemaplan.MigrationFileNamePattern)
+var ledgerName = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,62}$`)
+
+// Binding is explicit, secret-free deployment input. The expected plan digest
+// binds both SQL and group-role policy; cloud login principals are separate
+// deployment bindings and must already exist. The owner must be the connected
+// current_user so migrations and default privileges have the same owner.
+type Binding struct {
+	PlanSHA256          string   `json:"plan-sha256"`
+	PlanDigest          string   `json:"plan-digest"`
+	OwnerRole           string   `json:"owner-role"`
+	ReadOnlyPrincipals  []string `json:"read-only-principals"`
+	ReadWritePrincipals []string `json:"read-write-principals"`
+}
+
+func ReadJSON(path string, target any) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return errors.New("cannot open configuration file")
+	}
+	defer f.Close()
+	return decodeJSON(io.LimitReader(f, 4<<20), target)
+}
+
+func decodeJSON(r io.Reader, target any) error {
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return errors.New("invalid configuration JSON")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		return errors.New("configuration must contain one JSON object")
+	}
+	return nil
+}
+
+// snapshot verifies all content before any database connection, then copies only
+// attested bytes into a private directory. Migration execution cannot observe a
+// later edit to the input package. Neither staged directories nor files may be
+// symlinks. Unexpected files, duplicate versions and traversal fail closed.
+func snapshot(directory string, binding Binding) (schemaplan.Plan, string, error) {
+	var p schemaplan.Plan
+	fail := func(message string) (schemaplan.Plan, string, error) { return p, "", errors.New(message) }
+	data, readErr := os.ReadFile(filepath.Join(directory, "plan.json"))
+	if readErr != nil || len(data) > 4<<20 {
+		return fail("cannot read bounded schema plan")
+	}
+	hash := sha256.Sum256(data)
+	if binding.PlanSHA256 != hex.EncodeToString(hash[:]) {
+		return fail("schema plan file identity mismatch")
+	}
+	if err := decodeJSON(bytes.NewReader(data), &p); err != nil {
+		return p, "", err
+	}
+	if p.ContractVersion != schemaplan.ContractVersion || p.Digest != p.ContentDigest() || p.Digest != binding.PlanDigest {
+		return fail("schema plan identity mismatch")
+	}
+	if err := validateBinding(p, binding); err != nil {
+		return p, "", err
+	}
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return p, "", errors.New("cannot open schema package")
+	}
+	defer root.Close()
+	temp, err := os.MkdirTemp("", "postgres-managed-bootstrap-")
+	if err != nil {
+		return p, "", err
+	}
+	success := false
+	defer func() {
+		if !success {
+			os.RemoveAll(temp)
+		}
+	}()
+	stages, ledgers := map[string]bool{}, map[string]bool{}
+	for _, l := range p.Lineages {
+		if !component(l.Stage) || !component(l.Label) || !ledgerName.MatchString(l.Ledger) || stages[l.Stage] || ledgers[l.Ledger] || len(l.Files) == 0 || l.Digest != l.ContentDigest() {
+			return fail("invalid or duplicate schema lineage")
+		}
+		stages[l.Stage] = true
+		ledgers[l.Ledger] = true
+		source := "sources/" + l.Stage
+		for _, path := range []string{"sources", source} {
+			info, e := root.Lstat(path)
+			if e != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+				return fail("invalid schema source directory")
+			}
+		}
+		entries, e := fs.ReadDir(root.FS(), source)
+		if e != nil || len(entries) != len(l.Files) {
+			return fail("schema source inventory mismatch")
+		}
+		if e = os.Mkdir(filepath.Join(temp, l.Stage), 0700); e != nil {
+			return p, "", e
+		}
+		names, versions := map[string]bool{}, map[string]bool{}
+		previous := ""
+		for _, f := range l.Files {
+			match := migrationName.FindStringSubmatch(f.Name)
+			if !component(f.Name) || len(match) == 0 || f.Name <= previous || names[f.Name] {
+				return fail("invalid or unordered migration inventory")
+			}
+			previous = f.Name
+			names[f.Name] = true
+			version, e := strconv.ParseUint(match[1], 10, 64)
+			if e != nil {
+				return fail("invalid migration version")
+			}
+			key := fmt.Sprintf("%d.%s", version, match[2])
+			if versions[key] {
+				return fail("duplicate migration version and direction")
+			}
+			versions[key] = true
+			path := source + "/" + f.Name
+			info, e := root.Lstat(path)
+			if e != nil || !info.Mode().IsRegular() {
+				return fail("migration must be a regular file")
+			}
+			data, e := root.ReadFile(path)
+			if e != nil {
+				return fail("cannot read migration")
+			}
+			hash := sha256.Sum256(data)
+			if "sha256:"+hex.EncodeToString(hash[:]) != f.Digest {
+				return fail("migration content identity mismatch")
+			}
+			if e = os.WriteFile(filepath.Join(temp, l.Stage, f.Name), data, 0600); e != nil {
+				return p, "", e
+			}
+		}
+	}
+	// Ordering itself is attested, but duplicate extension declarations are invalid.
+	extensions := map[string]bool{}
+	for _, e := range p.Extensions {
+		if !identifier(e.Name) || extensions[e.Name] {
+			return fail("invalid extension declaration")
+		}
+		extensions[e.Name] = true
+	}
+	success = true
+	return p, temp, nil
+}
+
+func component(s string) bool {
+	return s != "" && s != "." && s != ".." && !strings.ContainsAny(s, "/\\\x00")
+}
+func identifier(s string) bool {
+	return strings.TrimSpace(s) != "" && len(s) <= 63 && !strings.ContainsRune(s, 0)
+}
+
+func validateBinding(p schemaplan.Plan, b Binding) error {
+	if !identifier(p.Database) || !identifier(b.OwnerRole) || !identifier(p.Access.ReadOnlyRole) || !identifier(p.Access.ReadWriteRole) || len(p.Access.Schemas) == 0 {
+		return errors.New("database, owner, groups and schemas are required")
+	}
+	seen := map[string]bool{b.OwnerRole: true}
+	for _, group := range []string{p.Access.ReadOnlyRole, p.Access.ReadWriteRole} {
+		if seen[group] {
+			return errors.New("owner and managed groups must differ")
+		}
+		seen[group] = true
+	}
+	for _, roles := range [][]string{p.Access.ReadWriteRoles, b.ReadOnlyPrincipals, b.ReadWritePrincipals} {
+		for _, r := range roles {
+			if !identifier(r) || seen[r] {
+				return errors.New("role bindings must be distinct valid identifiers")
+			}
+			seen[r] = true
+		}
+	}
+	if len(b.ReadOnlyPrincipals) == 0 || len(b.ReadWritePrincipals) == 0 {
+		return errors.New("explicit reader and writer principals are required")
+	}
+	schemas := append([]string(nil), p.Access.Schemas...)
+	sort.Strings(schemas)
+	for i, s := range schemas {
+		if !identifier(s) || (i > 0 && s == schemas[i-1]) {
+			return errors.New("invalid or duplicate runtime schema")
+		}
+	}
+	return nil
+}

--- a/libs/go/bootstrap/package_test.go
+++ b/libs/go/bootstrap/package_test.go
@@ -148,3 +148,32 @@ func TestPrivateSocketConnection(t *testing.T) {
 		}
 	}
 }
+
+func TestManagedOwnerIgnoresAmbientCredentialsAndServices(t *testing.T) {
+	for key, value := range map[string]string{
+		"PGPASSWORD": "private sentinel", "PGPASSFILE": "/missing/passfile",
+		"PGSERVICE": "ambient-service", "PGSERVICEFILE": "/missing/service-file",
+		"PGSSLCERT": "/missing/client-certificate", "PGSSLKEY": "/missing/client-key",
+		"PGSSLROOTCERT": "/missing/trust-root", "PGSSLPASSWORD": "private sentinel",
+		"PGOPTIONS": "-c role=unintended-owner", "PGPORT": "6543",
+	} {
+		t.Setenv(key, value)
+	}
+	_, p, b := packageFixture(t, "SELECT 1;")
+	o := Options{Binding: b, Connection: "postgres://bootstrap_owner@127.0.0.1/bootstrap_proof?sslmode=require", LockTimeout: time.Second, StatementTimeout: time.Second}
+	dsn, e := connection(o, p)
+	if e != nil {
+		t.Fatal(e)
+	}
+	if _, e := managedConfig(dsn, o); e == nil {
+		t.Fatal("ambient service selector accepted")
+	}
+	t.Setenv("PGSERVICE", "")
+	cfg, e := managedConfig(dsn, o)
+	if e != nil {
+		t.Fatal("inherited ambient credential input:", e)
+	}
+	if cfg.Password != "" || cfg.Port != 5432 || cfg.User != "bootstrap_owner" || cfg.Database != "bootstrap_proof" || cfg.TLSConfig == nil || len(cfg.TLSConfig.Certificates) != 0 || cfg.RuntimeParams["role"] != "" || cfg.RuntimeParams["search_path"] != "public" {
+		t.Fatal("ambient configuration crossed the managed owner boundary")
+	}
+}

--- a/libs/go/bootstrap/package_test.go
+++ b/libs/go/bootstrap/package_test.go
@@ -1,0 +1,129 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/codefly-dev/service-postgres/libs/go/schemaplan"
+)
+
+func packageFixture(t *testing.T, sql string) (string, schemaplan.Plan, Binding) {
+	t.Helper()
+	dir := t.TempDir()
+	h := sha256.Sum256([]byte(sql))
+	l := schemaplan.Lineage{Label: "application", Ledger: "schema_migrations_application", Stage: "00-application", Files: []schemaplan.File{{Name: "001_table.up.sql", Digest: "sha256:" + hex.EncodeToString(h[:])}}}
+	l.Digest = l.ContentDigest()
+	p := schemaplan.Plan{ContractVersion: schemaplan.ContractVersion, Database: "bootstrap_proof", Lineages: []schemaplan.Lineage{l}, Access: schemaplan.Access{ReadOnlyRole: "bootstrap_ro", ReadWriteRole: "bootstrap_rw", Schemas: []string{"public"}}}
+	p.Digest = p.ContentDigest()
+	b := Binding{OwnerRole: "bootstrap_owner", ReadOnlyPrincipals: []string{"bootstrap_reader"}, ReadWritePrincipals: []string{"bootstrap_writer"}}
+	os.MkdirAll(filepath.Join(dir, "sources", l.Stage), 0700)
+	os.WriteFile(filepath.Join(dir, "sources", l.Stage, l.Files[0].Name), []byte(sql), 0600)
+	writePlan(t, dir, p, &b)
+	return dir, p, b
+}
+func writePlan(t *testing.T, dir string, p schemaplan.Plan, b *Binding) {
+	t.Helper()
+	p.Digest = p.ContentDigest()
+	data, e := json.Marshal(p)
+	if e != nil {
+		t.Fatal(e)
+	}
+	h := sha256.Sum256(data)
+	b.PlanSHA256 = hex.EncodeToString(h[:])
+	b.PlanDigest = p.Digest
+	if e = os.WriteFile(filepath.Join(dir, "plan.json"), data, 0600); e != nil {
+		t.Fatal(e)
+	}
+}
+
+func TestPackageRejectsDriftAndAmbiguousInputs(t *testing.T) {
+	for _, kind := range []string{"changed-bytes", "extra-file", "symlink", "traversal", "duplicate-ledger", "duplicate-version", "owner-is-group", "principal-is-group", "missing-principals", "wrong-pin", "group-login-association", "unknown-field"} {
+		t.Run(kind, func(t *testing.T) {
+			dir, p, b := packageFixture(t, "CREATE TABLE example(id integer);")
+			file := filepath.Join(dir, "sources", "00-application", "001_table.up.sql")
+			switch kind {
+			case "changed-bytes":
+				os.WriteFile(file, []byte("SELECT 'private sentinel';"), 0600)
+			case "extra-file":
+				os.WriteFile(filepath.Join(filepath.Dir(file), "002_unexpected.up.sql"), []byte("SELECT 1"), 0600)
+			case "symlink":
+				os.Remove(file)
+				os.Symlink("/etc/passwd", file)
+			case "traversal":
+				p.Lineages[0].Stage = "../elsewhere"
+				writePlan(t, dir, p, &b)
+			case "duplicate-ledger":
+				p.Lineages = append(p.Lineages, p.Lineages[0])
+				writePlan(t, dir, p, &b)
+			case "duplicate-version":
+				f := p.Lineages[0].Files[0]
+				f.Name = "1_duplicate.up.sql"
+				p.Lineages[0].Files = append(p.Lineages[0].Files, f)
+				p.Lineages[0].Digest = p.Lineages[0].ContentDigest()
+				os.WriteFile(filepath.Join(filepath.Dir(file), f.Name), []byte("CREATE TABLE example(id integer);"), 0600)
+				writePlan(t, dir, p, &b)
+			case "owner-is-group":
+				b.OwnerRole = p.Access.ReadOnlyRole
+			case "principal-is-group":
+				b.ReadWritePrincipals = []string{p.Access.ReadOnlyRole}
+			case "missing-principals":
+				b.ReadOnlyPrincipals = nil
+			case "wrong-pin":
+				b.PlanSHA256 = strings.Repeat("0", 64)
+			case "group-login-association":
+				b.ReadOnlyPrincipals = b.ReadWritePrincipals
+			case "unknown-field":
+				data, _ := os.ReadFile(filepath.Join(dir, "plan.json"))
+				data = append([]byte(`{"password":"private sentinel",`), data[1:]...)
+				os.WriteFile(filepath.Join(dir, "plan.json"), data, 0600)
+				h := sha256.Sum256(data)
+				b.PlanSHA256 = hex.EncodeToString(h[:])
+			}
+			_, tmp, e := snapshot(dir, b)
+			if tmp != "" {
+				os.RemoveAll(tmp)
+			}
+			if e == nil {
+				t.Fatal("accepted unsafe package")
+			}
+			if strings.Contains(e.Error(), "private sentinel") {
+				t.Fatal("sensitive contents leaked")
+			}
+		})
+	}
+}
+
+func TestSnapshotRetainsVerifiedBytes(t *testing.T) {
+	dir, _, b := packageFixture(t, "SELECT 1;")
+	_, tmp, e := snapshot(dir, b)
+	if e != nil {
+		t.Fatal(e)
+	}
+	defer os.RemoveAll(tmp)
+	os.WriteFile(filepath.Join(dir, "sources", "00-application", "001_table.up.sql"), []byte("SELECT 2;"), 0600)
+	data, e := os.ReadFile(filepath.Join(tmp, "00-application", "001_table.up.sql"))
+	if e != nil || string(data) != "SELECT 1;" {
+		t.Fatal("verified snapshot changed")
+	}
+}
+
+func TestConnectionIsExplicitAndPasswordless(t *testing.T) {
+	_, p, b := packageFixture(t, "SELECT 1;")
+	for _, dsn := range []string{"postgres://bootstrap_owner:secret@127.0.0.1/bootstrap_proof?sslmode=disable", "postgres://bootstrap_owner@127.0.0.1/bootstrap_proof?password=secret&sslmode=disable", "postgres://other@127.0.0.1/bootstrap_proof?sslmode=disable", "postgres://bootstrap_owner@127.0.0.1/wrong?sslmode=disable", "postgres://bootstrap_owner@127.0.0.1/bootstrap_proof?sslmode=disable&options=secret", "postgres://bootstrap_owner@127.0.0.1/bootstrap_proof?sslmode=disable&sslmode=require"} {
+		_, e := connection(Options{Binding: b, Connection: dsn}, p)
+		if e == nil || strings.Contains(e.Error(), "secret") {
+			t.Fatal("accepted or exposed invalid connection")
+		}
+	}
+	_, e := Run(context.Background(), Options{Timeout: time.Second, LockTimeout: time.Hour})
+	if e == nil {
+		t.Fatal("invalid budgets accepted")
+	}
+}

--- a/libs/go/bootstrap/package_test.go
+++ b/libs/go/bootstrap/package_test.go
@@ -127,3 +127,24 @@ func TestConnectionIsExplicitAndPasswordless(t *testing.T) {
 		t.Fatal("invalid budgets accepted")
 	}
 }
+
+func TestPrivateSocketConnection(t *testing.T) {
+	_, p, b := packageFixture(t, "SELECT 1;")
+	good := "postgres://bootstrap_owner@/bootstrap_proof?host=/private/proxy&sslmode=disable"
+	dsn, e := connection(Options{Binding: b, Connection: good, LockTimeout: time.Second, StatementTimeout: time.Second}, p)
+	if e != nil || !strings.Contains(dsn, "port=5432") {
+		t.Fatal("private socket binding rejected:", e)
+	}
+	for _, dsn := range []string{
+		"postgres://bootstrap_owner@remote/bootstrap_proof?host=/private/proxy&sslmode=disable",
+		"postgres://bootstrap_owner@remote/bootstrap_proof?host=&sslmode=disable",
+		"postgres://bootstrap_owner@remote,other/bootstrap_proof?sslmode=disable",
+		"postgres://bootstrap_owner@/bootstrap_proof?host=relative&sslmode=disable",
+		"postgres://bootstrap_owner@/bootstrap_proof?host=/private/proxy,remote&sslmode=disable",
+		"postgres://bootstrap_owner@/bootstrap_proof?host=/private/proxy&sslmode=require",
+	} {
+		if _, e = connection(Options{Binding: b, Connection: dsn}, p); e == nil {
+			t.Fatal("ambiguous socket accepted")
+		}
+	}
+}

--- a/libs/go/bootstrap/run.go
+++ b/libs/go/bootstrap/run.go
@@ -67,13 +67,10 @@ func Run(ctx context.Context, o Options) (result Result, err error) {
 	if e != nil {
 		return result, e
 	}
-	cfg, e := pgx.ParseConfig(dsn)
+	cfg, e := managedConfig(dsn, o)
 	if e != nil {
-		return result, errors.New("invalid managed connection")
+		return result, e
 	}
-	// pgx can otherwise discover a local .pgpass even though the URL is clean.
-	cfg.Password = ""
-	cfg.RuntimeParams = map[string]string{"lock_timeout": fmt.Sprint(o.LockTimeout.Milliseconds()), "statement_timeout": fmt.Sprint(o.StatementTimeout.Milliseconds()), "search_path": "public"}
 	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
 	defer cancel()
 	db := stdlib.OpenDB(*cfg)
@@ -261,4 +258,34 @@ func drainChild(conn *sql.Conn, application string) error {
 		return errors.New("migration session cleanup uncertain; reconcile owner sessions before retry")
 	}
 	return nil
+}
+
+// pgx merges URL settings over environment/default files. Override identity,
+// TLS credential defaults and reject an ambient service selector before parsing, rather than clearing a
+// password only after an ambient service or client certificate was loaded.
+func managedConfig(dsn string, o Options) (*pgx.ConnConfig, error) {
+	if os.Getenv("PGSERVICE") != "" {
+		return nil, errors.New("ambient PostgreSQL service binding is unsupported")
+	}
+	u, err := url.Parse(dsn)
+	if err != nil {
+		return nil, errors.New("invalid managed connection")
+	}
+	q := u.Query()
+	for key, value := range map[string]string{"password": "", "passfile": "/dev/null", "servicefile": "/dev/null", "sslpassword": "", "sslsni": "1", "sslnegotiation": "postgres", "options": "", "target_session_attrs": "any"} {
+		q.Set(key, value)
+	}
+	for _, key := range []string{"sslcert", "sslkey", "sslrootcert"} {
+		if _, explicit := q[key]; !explicit {
+			q.Set(key, "")
+		}
+	}
+	u.RawQuery = q.Encode()
+	cfg, err := pgx.ParseConfig(u.String())
+	if err != nil {
+		return nil, errors.New("invalid managed connection")
+	}
+	cfg.Password = ""
+	cfg.RuntimeParams = map[string]string{"lock_timeout": fmt.Sprint(o.LockTimeout.Milliseconds()), "statement_timeout": fmt.Sprint(o.StatementTimeout.Milliseconds()), "search_path": "public"}
+	return cfg, nil
 }

--- a/libs/go/bootstrap/run.go
+++ b/libs/go/bootstrap/run.go
@@ -1,0 +1,242 @@
+package bootstrap
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/codefly-dev/service-postgres/libs/go/controlplane"
+	"github.com/codefly-dev/service-postgres/libs/go/schemaplan"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/stdlib"
+	"github.com/lib/pq"
+)
+
+// Options accepts a passwordless TCP endpoint supplied by an authenticated
+// proxy/tunnel. Cloud authentication and the executable's immutable packaging
+// remain deployment-owner responsibilities. This runner never obtains tokens.
+type Options struct {
+	Directory         string
+	Binding           Binding
+	Connection        string
+	MigrateExecutable string
+	Timeout           time.Duration
+	LockTimeout       time.Duration
+	StatementTimeout  time.Duration
+}
+
+type Result struct {
+	PlanSHA256        string   `json:"plan-sha256"`
+	PlanDigest        string   `json:"plan-digest"`
+	CompletedLineages []string `json:"completed-lineages"`
+	SkippedExtensions []string `json:"skipped-extensions"`
+	AccessCommitted   bool     `json:"access-committed"`
+}
+
+// Run serializes every lineage and access reconciliation with the same lock
+// used by the service runtime and password bootstrap. Migrations are not one
+// transaction with grants: failed/dirty lineages stop access reconciliation and
+// require the existing dirty-migration runbook. Safe reruns use existing ledgers.
+// Errors deliberately omit SQL, connection strings and subprocess output.
+func Run(ctx context.Context, o Options) (result Result, err error) {
+	if ctx == nil || o.Timeout < time.Second || o.Timeout > time.Hour || o.LockTimeout < time.Millisecond || o.LockTimeout > o.Timeout || o.StatementTimeout < time.Millisecond || o.StatementTimeout > o.Timeout {
+		return result, errors.New("invalid managed bootstrap time budgets")
+	}
+	if !filepath.IsAbs(o.MigrateExecutable) {
+		return result, errors.New("absolute migrate executable path is required")
+	}
+	info, e := os.Stat(o.MigrateExecutable)
+	if e != nil || !info.Mode().IsRegular() || info.Mode().Perm()&0111 == 0 {
+		return result, errors.New("migrate executable is unavailable")
+	}
+	p, staged, e := snapshot(o.Directory, o.Binding)
+	if e != nil {
+		return result, e
+	}
+	defer os.RemoveAll(staged)
+	dsn, e := connection(o, p)
+	if e != nil {
+		return result, e
+	}
+	cfg, e := pgx.ParseConfig(dsn)
+	if e != nil {
+		return result, errors.New("invalid managed connection")
+	}
+	// pgx can otherwise discover a local .pgpass even though the URL is clean.
+	cfg.Password = ""
+	cfg.RuntimeParams = map[string]string{"lock_timeout": fmt.Sprint(o.LockTimeout.Milliseconds()), "statement_timeout": fmt.Sprint(o.StatementTimeout.Milliseconds()), "search_path": "public"}
+	ctx, cancel := context.WithTimeout(ctx, o.Timeout)
+	defer cancel()
+	db := stdlib.OpenDB(*cfg)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	defer db.Close()
+	conn, e := db.Conn(ctx)
+	if e != nil {
+		return result, errors.New("managed database connection failed")
+	}
+	defer conn.Close()
+	var database, owner string
+	if e = conn.QueryRowContext(ctx, "SELECT current_database(),current_user").Scan(&database, &owner); e != nil || database != p.Database || owner != o.Binding.OwnerRole {
+		return result, errors.New("connected database or migration owner does not match binding")
+	}
+	if e = preflight(ctx, conn, p, o.Binding); e != nil {
+		return result, e
+	}
+	if _, e = conn.ExecContext(ctx, `SELECT pg_advisory_lock(hashtext('codefly-runtime-access:' || current_database()))`); e != nil {
+		return result, errors.New("managed bootstrap lock unavailable")
+	}
+	// This connection is never returned to an idle pool, including on failure;
+	// closing it releases the session lock even when cancellation prevents unlock.
+	result.PlanDigest = p.Digest
+	result.PlanSHA256 = o.Binding.PlanSHA256
+	for _, extension := range p.Extensions {
+		if _, e = conn.ExecContext(ctx, "CREATE EXTENSION IF NOT EXISTS "+pq.QuoteIdentifier(extension.Name)); e != nil {
+			if extension.Required {
+				return result, errors.New("required extension failed")
+			}
+			result.SkippedExtensions = append(result.SkippedExtensions, extension.Name)
+		}
+	}
+	for _, l := range p.Lineages {
+		if e = ctx.Err(); e != nil {
+			return result, errors.New("managed bootstrap deadline or cancellation")
+		}
+		u, _ := url.Parse(dsn)
+		q := u.Query()
+		q.Set("x-migrations-table", l.Ledger)
+		application := fmt.Sprintf("codefly-bootstrap-%x", randomIdentity())
+		q.Set("application_name", application)
+		u.RawQuery = q.Encode()
+		command := exec.CommandContext(ctx, o.MigrateExecutable, "-path", filepath.Join(staged, l.Stage), "-database", u.String(), "up")
+		// No inherited PG service/password settings, cloud credentials or unrelated
+		// secrets. The DSN is passwordless, including in the child process arguments.
+		command.Env = []string{"PGPASSFILE=/dev/null"}
+		command.WaitDelay = time.Second
+		runErr := command.Run()
+		// Killing a client does not prove its server-side statement has stopped.
+		// Drain this child's uniquely named owner sessions before releasing the
+		// shared control-plane lock, including after deadline cancellation.
+		if e = drainChild(conn, application); e != nil {
+			return result, e
+		}
+		if runErr != nil {
+			return result, errors.New("migration lineage failed; inspect its ledger using docs/dirty-migrations.md")
+		}
+		result.CompletedLineages = append(result.CompletedLineages, l.Label)
+	}
+	tx, e := conn.BeginTx(ctx, nil)
+	if e != nil {
+		return result, errors.New("cannot begin runtime access reconciliation")
+	}
+	defer tx.Rollback()
+	// Recheck under lock after migrations before the canonical engine can alter
+	// group attributes. A preexisting LOGIN role is not a managed group.
+	if e = preflight(ctx, tx, p, o.Binding); e != nil {
+		return result, e
+	}
+	a := controlplane.RuntimeAccess{Database: p.Database, OwnerRole: o.Binding.OwnerRole, ReadOnlyRole: p.Access.ReadOnlyRole, ReadWriteRole: p.Access.ReadWriteRole, Schemas: p.Access.Schemas, ReadWriteRoles: p.Access.ReadWriteRoles, ReconcileReadWriteRoleMemberships: true, AuthMode: controlplane.AuthModeExternalIdentity, ReadOnlyPrincipals: o.Binding.ReadOnlyPrincipals, ReadWritePrincipals: o.Binding.ReadWritePrincipals}
+	if e = controlplane.ReconcileRuntimeAccess(ctx, tx, a); e != nil {
+		return result, errors.New("runtime access reconciliation failed")
+	}
+	if e = tx.Commit(); e != nil {
+		return result, errors.New("runtime access commit failed; verify database state before retry")
+	}
+	result.AccessCommitted = true
+	return result, nil
+}
+
+type querier interface {
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
+func preflight(ctx context.Context, db querier, p schemaplan.Plan, b Binding) error {
+	for _, group := range []string{p.Access.ReadOnlyRole, p.Access.ReadWriteRole} {
+		var login bool
+		e := db.QueryRowContext(ctx, "SELECT (rolcanlogin OR rolsuper OR rolcreatedb OR rolcreaterole OR rolreplication OR rolbypassrls) FROM pg_roles WHERE rolname=$1", group).Scan(&login)
+		if e != nil && !errors.Is(e, sql.ErrNoRows) {
+			return errors.New("cannot verify managed group")
+		}
+		if login {
+			return errors.New("managed group binding names a login or elevated role")
+		}
+	}
+	for _, principals := range [][]string{b.ReadOnlyPrincipals, b.ReadWritePrincipals} {
+		for _, principal := range principals {
+			var login bool
+			if e := db.QueryRowContext(ctx, "SELECT rolcanlogin FROM pg_roles WHERE rolname=$1", principal).Scan(&login); e != nil || !login {
+				return errors.New("external principal must be an existing login role")
+			}
+		}
+	}
+	return nil
+}
+
+func connection(o Options, p schemaplan.Plan) (string, error) {
+	invalid := errors.New("managed connection requires an explicit passwordless postgres TCP URL matching the plan and owner")
+	u, e := url.Parse(o.Connection)
+	if e != nil || u == nil || u.Scheme != "postgres" || u.User == nil || u.User.Username() != o.Binding.OwnerRole || u.Hostname() == "" || u.Path != "/"+p.Database || u.Fragment != "" {
+		return "", invalid
+	}
+	if _, password := u.User.Password(); password {
+		return "", invalid
+	}
+	q, e := url.ParseQuery(u.RawQuery)
+	if e != nil {
+		return "", invalid
+	}
+	for key, values := range q {
+		switch key {
+		case "sslmode", "sslrootcert", "sslcert", "sslkey":
+		default:
+			return "", invalid
+		}
+		if len(values) != 1 {
+			return "", invalid
+		}
+	}
+	if q.Get("sslmode") == "" {
+		return "", invalid
+	}
+	q.Set("connect_timeout", "5")
+	q.Set("lock_timeout", fmt.Sprint(o.LockTimeout.Milliseconds()))
+	q.Set("statement_timeout", fmt.Sprint(o.StatementTimeout.Milliseconds()))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func randomIdentity() [16]byte { var id [16]byte; rand.Read(id[:]); return id }
+
+func drainChild(conn *sql.Conn, application string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rows, err := conn.QueryContext(ctx, `SELECT pg_terminate_backend(pid,2000) FROM pg_stat_activity
+ WHERE application_name=$1 AND usename=current_user AND datname=current_database() AND pid<>pg_backend_pid()`, application)
+	if err != nil {
+		return errors.New("migration session cleanup uncertain; reconcile owner sessions before retry")
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var stopped bool
+		if rows.Scan(&stopped) != nil {
+			return errors.New("migration session cleanup uncertain; reconcile owner sessions before retry")
+		}
+	}
+	if rows.Err() != nil || rows.Close() != nil {
+		return errors.New("migration session cleanup uncertain; reconcile owner sessions before retry")
+	}
+	// A session can exit between the activity snapshot and termination. A false
+	// signal result is safe only when the final observation confirms absence.
+	var remaining int
+	if err = conn.QueryRowContext(ctx, `SELECT count(*) FROM pg_stat_activity WHERE application_name=$1 AND usename=current_user AND datname=current_database()`, application).Scan(&remaining); err != nil || remaining != 0 {
+		return errors.New("migration session cleanup uncertain; reconcile owner sessions before retry")
+	}
+	return nil
+}

--- a/libs/go/bootstrap/run.go
+++ b/libs/go/bootstrap/run.go
@@ -6,10 +6,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/codefly-dev/service-postgres/libs/go/controlplane"
@@ -19,7 +21,7 @@ import (
 	"github.com/lib/pq"
 )
 
-// Options accepts a passwordless TCP endpoint supplied by an authenticated
+// Options accepts a passwordless TCP or private Unix-socket endpoint supplied by an authenticated
 // proxy/tunnel. Cloud authentication and the executable's immutable packaging
 // remain deployment-owner responsibilities. This runner never obtains tokens.
 type Options struct {
@@ -180,9 +182,9 @@ func preflight(ctx context.Context, db querier, p schemaplan.Plan, b Binding) er
 }
 
 func connection(o Options, p schemaplan.Plan) (string, error) {
-	invalid := errors.New("managed connection requires an explicit passwordless postgres TCP URL matching the plan and owner")
+	invalid := errors.New("managed connection requires an explicit passwordless postgres URL matching the plan and owner")
 	u, e := url.Parse(o.Connection)
-	if e != nil || u == nil || u.Scheme != "postgres" || u.User == nil || u.User.Username() != o.Binding.OwnerRole || u.Hostname() == "" || u.Path != "/"+p.Database || u.Fragment != "" {
+	if e != nil || u == nil || u.Scheme != "postgres" || u.User == nil || u.User.Username() != o.Binding.OwnerRole || u.Path != "/"+p.Database || u.Fragment != "" {
 		return "", invalid
 	}
 	if _, password := u.User.Password(); password {
@@ -194,7 +196,7 @@ func connection(o Options, p schemaplan.Plan) (string, error) {
 	}
 	for key, values := range q {
 		switch key {
-		case "sslmode", "sslrootcert", "sslcert", "sslkey":
+		case "sslmode", "sslrootcert", "sslcert", "sslkey", "host":
 		default:
 			return "", invalid
 		}
@@ -202,9 +204,29 @@ func connection(o Options, p schemaplan.Plan) (string, error) {
 			return "", invalid
 		}
 	}
+	if _, present := q["host"]; present && q.Get("host") == "" {
+		return "", invalid
+	}
+	if strings.Contains(u.Hostname(), ",") {
+		return "", invalid
+	}
+	if socket := q.Get("host"); socket != "" {
+		if u.Host != "" || !filepath.IsAbs(socket) || strings.ContainsAny(socket, ",\x00") || q.Get("sslmode") != "disable" {
+			return "", invalid
+		}
+		q.Set("port", "5432")
+	} else {
+		if u.Hostname() == "" {
+			return "", invalid
+		}
+		if u.Port() == "" {
+			u.Host = net.JoinHostPort(u.Hostname(), "5432")
+		}
+	}
 	if q.Get("sslmode") == "" {
 		return "", invalid
 	}
+	q.Set("search_path", "public")
 	q.Set("connect_timeout", "5")
 	q.Set("lock_timeout", fmt.Sprint(o.LockTimeout.Milliseconds()))
 	q.Set("statement_timeout", fmt.Sprint(o.StatementTimeout.Milliseconds()))

--- a/libs/go/bootstrap/run_integration_test.go
+++ b/libs/go/bootstrap/run_integration_test.go
@@ -1,0 +1,225 @@
+//go:build controlplaneintegration
+
+package bootstrap
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func fixtureDB(t *testing.T, database, user string) *sql.DB {
+	t.Helper()
+	u, e := url.Parse(os.Getenv("SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"))
+	if e != nil || u == nil || u.Scheme != "postgres" || u.Hostname() != "127.0.0.1" || u.Port() == "" {
+		t.Fatal("use scripts/qualify-controlplane.py with its disposable loopback fixture")
+	}
+	u.Path = "/" + database
+	u.User = url.User(user)
+	u.RawQuery = "sslmode=disable&connect_timeout=5"
+	db, e := sql.Open("postgres", u.String())
+	if e != nil {
+		t.Fatal(e)
+	}
+	t.Cleanup(func() { db.Close() })
+	return db
+}
+func statement(t *testing.T, db *sql.DB, sql string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, e := db.ExecContext(ctx, sql); e != nil {
+		t.Fatal(e)
+	}
+}
+func value(t *testing.T, db *sql.DB, sql string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var v string
+	if e := db.QueryRowContext(ctx, sql).Scan(&v); e != nil {
+		t.Fatal(e)
+	}
+	return v
+}
+
+func TestManagedBootstrapRestrictedPostgres(t *testing.T) {
+	admin := fixtureDB(t, "postgres", "postgres")
+	statement(t, admin, "CREATE ROLE bootstrap_owner LOGIN CREATEROLE NOSUPERUSER NOBYPASSRLS")
+	statement(t, admin, "CREATE ROLE bootstrap_reader LOGIN INHERIT PASSWORD 'fixture-only'")
+	statement(t, admin, "CREATE ROLE bootstrap_writer LOGIN INHERIT PASSWORD 'fixture-only'")
+	statement(t, admin, "CREATE DATABASE bootstrap_proof OWNER bootstrap_owner")
+	owner := fixtureDB(t, "bootstrap_proof", "bootstrap_owner")
+	reader := fixtureDB(t, "bootstrap_proof", "bootstrap_reader")
+	writer := fixtureDB(t, "bootstrap_proof", "bootstrap_writer")
+	password := value(t, admin, "SELECT rolpassword FROM pg_authid WHERE rolname='bootstrap_writer'")
+	// The deliberate delay overlaps concurrent bootstraps; the unguarded INSERT
+	// exposes duplicate execution of the migration rather than hiding it.
+	dir, p, b := packageFixture(t, "CREATE TABLE receipts(id serial PRIMARY KEY,value text); INSERT INTO receipts(value) VALUES ('once'); SELECT pg_sleep(0.3);")
+	u, _ := url.Parse(os.Getenv("SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"))
+	u.Path = "/bootstrap_proof"
+	u.User = url.User(b.OwnerRole)
+	u.RawQuery = "sslmode=disable"
+	o := Options{Directory: dir, Binding: b, Connection: u.String(), MigrateExecutable: os.Getenv("SERVICE_POSTGRES_MIGRATE_EXECUTABLE"), Timeout: 10 * time.Second, LockTimeout: 3 * time.Second, StatementTimeout: 5 * time.Second}
+	t.Run("missing principal rejects before migration", func(t *testing.T) {
+		bad := o
+		bad.Binding.ReadWritePrincipals = []string{"missing_external"}
+		if _, e := Run(context.Background(), bad); e == nil {
+			t.Fatal("accepted missing principal")
+		}
+		if value(t, owner, "SELECT (to_regclass('receipts') IS NULL)::text") != "true" {
+			t.Fatal("provider work preceded principal validation")
+		}
+	})
+	t.Run("login group rejects before migration", func(t *testing.T) {
+		statement(t, admin, "CREATE ROLE bootstrap_ro LOGIN")
+		if _, e := Run(context.Background(), o); e == nil {
+			t.Fatal("would rewrite cloud login")
+		}
+		statement(t, admin, "DROP ROLE bootstrap_ro")
+		if value(t, owner, "SELECT (to_regclass('receipts') IS NULL)::text") != "true" {
+			t.Fatal("migration ran")
+		}
+	})
+	t.Run("concurrent jobs and replay", func(t *testing.T) {
+		var wg sync.WaitGroup
+		errs := make(chan error, 2)
+		for i := 0; i < 2; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				r, e := Run(context.Background(), o)
+				if e == nil && !r.AccessCommitted {
+					t.Error("missing committed access")
+				}
+				errs <- e
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for e := range errs {
+			if e != nil {
+				t.Fatal(e)
+			}
+		}
+		if value(t, owner, "SELECT count(*)::text FROM receipts") != "1" {
+			t.Fatal("migration executed more than once")
+		}
+		if value(t, owner, "SELECT (version=1 AND NOT dirty)::text FROM schema_migrations_application") != "true" {
+			t.Fatal("ledger mismatch")
+		}
+	})
+	t.Run("principals unchanged and restricted", func(t *testing.T) {
+		if value(t, admin, "SELECT rolpassword FROM pg_authid WHERE rolname='bootstrap_writer'") != password {
+			t.Fatal("password changed")
+		}
+		statement(t, writer, "INSERT INTO receipts(value) VALUES ('writer')")
+		if value(t, reader, "SELECT count(*)::text FROM receipts") != "2" {
+			t.Fatal("reader cannot read")
+		}
+		for _, db := range []*sql.DB{reader, writer} {
+			if _, e := db.Exec("CREATE TABLE forbidden(id integer)"); e == nil {
+				t.Fatal("runtime DDL succeeded")
+			}
+		}
+		if _, e := reader.Exec("INSERT INTO receipts(value) VALUES ('forbidden')"); e == nil {
+			t.Fatal("reader DML succeeded")
+		}
+		statement(t, owner, "CREATE TABLE after_bootstrap(id serial,value text)")
+		statement(t, writer, "INSERT INTO after_bootstrap(value) VALUES ('default privileges')")
+		if value(t, reader, "SELECT value FROM after_bootstrap") != "default privileges" {
+			t.Fatal("default privileges mismatch")
+		}
+	})
+	t.Run("shared lock bounded and released", func(t *testing.T) {
+		conn, e := owner.Conn(context.Background())
+		if e != nil {
+			t.Fatal(e)
+		}
+		defer conn.Close()
+		if _, e = conn.ExecContext(context.Background(), "SELECT pg_advisory_lock(hashtext('codefly-runtime-access:' || current_database()))"); e != nil {
+			t.Fatal(e)
+		}
+		blocked := o
+		blocked.LockTimeout = 100 * time.Millisecond
+		start := time.Now()
+		_, e = Run(context.Background(), blocked)
+		if e == nil || time.Since(start) > 2*time.Second {
+			t.Fatal("lock not bounded")
+		}
+		conn.ExecContext(context.Background(), "SELECT pg_advisory_unlock_all()")
+		if _, e = Run(context.Background(), o); e != nil {
+			t.Fatal("failed job leaked lock:", e)
+		}
+	})
+	t.Run("served command replay", func(t *testing.T) {
+		binding := filepath.Join(t.TempDir(), "binding.json")
+		data, _ := json.Marshal(b)
+		os.WriteFile(binding, data, 0600)
+		cmd := exec.Command(os.Getenv("SERVICE_POSTGRES_BOOTSTRAP_EXECUTABLE"), "-package", dir, "-binding", binding, "-migrate", o.MigrateExecutable, "-timeout", "10s", "-lock-timeout", "3s", "-statement-timeout", "5s")
+		cmd.Env = []string{"CODEFLY_POSTGRES_MIGRATION_CONNECTION=" + o.Connection, "PGPASSWORD=fixture-should-not-be-used", "PGOPTIONS=-c role=bootstrap_reader"}
+		output, e := cmd.CombinedOutput()
+		if e != nil {
+			t.Fatal("command failed:", e, string(output))
+		}
+		var r Result
+		if e = json.Unmarshal(output, &r); e != nil || !r.AccessCommitted || r.PlanDigest != p.Digest {
+			t.Fatal("command receipt mismatch")
+		}
+	})
+	t.Run("dirty failure and cancellation skip access", func(t *testing.T) {
+		// Separate ledgers let this test exercise dirty recovery without forcing or
+		// repairing the successful lineage. The sentinel must never appear in logs.
+		for _, kind := range []string{"dirty", "cancel"} {
+			t.Run(kind, func(t *testing.T) {
+				statement(t, owner, "REVOKE bootstrap_rw FROM bootstrap_writer")
+				sqlText := "SELECT 'private sentinel'::integer;"
+				if kind == "cancel" {
+					sqlText = "SELECT pg_sleep(20);"
+				}
+				d, plan, binding := packageFixture(t, sqlText)
+				plan.Lineages[0].Ledger = "schema_migrations_" + kind
+				plan.Lineages[0].Digest = plan.Lineages[0].ContentDigest()
+				writePlan(t, d, plan, &binding)
+				failed := o
+				failed.Directory = d
+				failed.Binding = binding
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				if kind == "cancel" {
+					time.AfterFunc(300*time.Millisecond, cancel)
+				}
+				start := time.Now()
+				r, e := Run(ctx, failed)
+				if e == nil || r.AccessCommitted || strings.Contains(e.Error(), "private sentinel") {
+					t.Fatal("unsafe failure result")
+				}
+				if value(t, owner, "SELECT pg_has_role('bootstrap_writer','bootstrap_rw','MEMBER')::text") != "false" {
+					t.Fatal("failed migration changed runtime access")
+				}
+				if value(t, owner, "SELECT count(*)::text FROM pg_stat_activity WHERE application_name LIKE 'codefly-bootstrap-%'") != "0" {
+					t.Fatal("child database session survived lock release")
+				}
+				if kind == "cancel" && time.Since(start) > 3*time.Second {
+					t.Fatal("cancellation did not stop child")
+				}
+				if kind == "dirty" {
+					if value(t, owner, "SELECT dirty::text FROM schema_migrations_dirty") != "true" {
+						t.Fatal("dirty state lost")
+					}
+					if r, e = Run(context.Background(), failed); e == nil || r.AccessCommitted {
+						t.Fatal("dirty state silently repaired")
+					}
+				}
+			})
+		}
+	})
+}

--- a/libs/go/bootstrap/run_integration_test.go
+++ b/libs/go/bootstrap/run_integration_test.go
@@ -175,6 +175,36 @@ func TestManagedBootstrapRestrictedPostgres(t *testing.T) {
 			t.Fatal("command receipt mismatch")
 		}
 	})
+
+	t.Run("private proxy socket command replay", func(t *testing.T) {
+		container := os.Getenv("SERVICE_POSTGRES_FIXTURE_CONTAINER")
+		if container == "" {
+			t.Fatal("fixture container required")
+		}
+		binding := filepath.Join(t.TempDir(), "binding.json")
+		data, _ := json.Marshal(b)
+		if e := os.WriteFile(binding, data, 0600); e != nil {
+			t.Fatal(e)
+		}
+		for _, pair := range [][2]string{{dir, "/tmp/schema-package"}, {binding, "/tmp/binding.json"}} {
+			ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+			output, e := exec.CommandContext(ctx, "docker", "cp", pair[0], container+":"+pair[1]).CombinedOutput()
+			cancel()
+			if e != nil {
+				t.Fatal("fixture copy:", e, string(output))
+			}
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+		defer cancel()
+		output, e := exec.CommandContext(ctx, "docker", "exec", "--env", "CODEFLY_POSTGRES_MIGRATION_CONNECTION=postgres://bootstrap_owner@/bootstrap_proof?host=/var/run/postgresql&sslmode=disable", container, "/tmp/managed-bootstrap", "-package", "/tmp/schema-package", "-binding", "/tmp/binding.json", "-migrate", "/tmp/migrate", "-timeout", "10s", "-lock-timeout", "3s", "-statement-timeout", "5s").CombinedOutput()
+		if e != nil {
+			t.Fatal("private socket command:", e, string(output))
+		}
+		var result Result
+		if e = json.Unmarshal(output, &result); e != nil || !result.AccessCommitted || result.PlanSHA256 != b.PlanSHA256 {
+			t.Fatal("socket receipt mismatch")
+		}
+	})
 	t.Run("dirty failure and cancellation skip access", func(t *testing.T) {
 		// Separate ledgers let this test exercise dirty recovery without forcing or
 		// repairing the successful lineage. The sentinel must never appear in logs.

--- a/libs/go/schemaplan/plan.go
+++ b/libs/go/schemaplan/plan.go
@@ -1,0 +1,77 @@
+// Package schemaplan defines the content-addressed artifact shared by the
+// service builder and explicit database bootstrap runners. It contains no secrets.
+package schemaplan
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+)
+
+const ContractVersion = "codefly.dev/postgres-schema-plan/v1"
+const MigrationFileNamePattern = `^([0-9]+)_.+\.(up|down)\.[A-Za-z0-9]+$`
+
+type Plan struct {
+	ContractVersion string      `json:"contract-version"`
+	Database        string      `json:"database"`
+	Extensions      []Extension `json:"extensions"`
+	Lineages        []Lineage   `json:"lineages"`
+	Access          Access      `json:"access"`
+	Digest          string      `json:"digest"`
+}
+
+type Extension struct {
+	Name     string `json:"name"`
+	Required bool   `json:"required"`
+}
+
+type Lineage struct {
+	Label  string `json:"label"`
+	Ledger string `json:"ledger"`
+	Stage  string `json:"stage"`
+	Digest string `json:"digest"`
+	Files  []File `json:"files"`
+}
+
+type File struct {
+	Name   string `json:"name"`
+	Digest string `json:"digest"`
+}
+
+type Access struct {
+	ReadOnlyRole   string   `json:"read-only-role"`
+	ReadWriteRole  string   `json:"read-write-role"`
+	Schemas        []string `json:"schemas"`
+	ReadWriteRoles []string `json:"read-write-roles"`
+}
+
+// ContentDigest preserves the v1 builder's deterministic identity.
+func (p Plan) ContentDigest() string {
+	h := sha256.New()
+	write := func(values ...string) {
+		for _, v := range values {
+			h.Write([]byte(v))
+			h.Write([]byte{0})
+		}
+	}
+	write(p.ContractVersion, p.Database)
+	for _, e := range p.Extensions {
+		write(e.Name, fmt.Sprint(e.Required))
+	}
+	write(p.Access.ReadOnlyRole, p.Access.ReadWriteRole)
+	write(p.Access.Schemas...)
+	write(p.Access.ReadWriteRoles...)
+	for _, l := range p.Lineages {
+		write(l.Label, l.Ledger, l.Stage, l.Digest)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+func (l Lineage) ContentDigest() string {
+	h := sha256.New()
+	h.Write([]byte(l.Label + "\x00" + l.Ledger + "\x00"))
+	for _, f := range l.Files {
+		h.Write([]byte(f.Name + "\x00" + f.Digest + "\x00"))
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}

--- a/migrations.go
+++ b/migrations.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"github.com/codefly-dev/service-postgres/libs/go/schemaplan"
 	"io/fs"
 	"os"
 	"regexp"
@@ -59,7 +60,7 @@ func (m migrationSource) label() string {
 // the file it shadows and makes the source driver reject the entire lineage as a
 // duplicate. Requiring a plain extension excludes the leftovers while keeping
 // every real migration, whatever it is named (.sql, .pgsql, .psql).
-const migrationFileNamePattern = `^([0-9]+)_.+\.(up|down)\.[A-Za-z0-9]+$`
+const migrationFileNamePattern = schemaplan.MigrationFileNamePattern
 
 var migrationFileName = regexp.MustCompile(migrationFileNamePattern)
 

--- a/schemaplan.go
+++ b/schemaplan.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"github.com/codefly-dev/service-postgres/libs/go/schemaplan"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,7 +14,7 @@ import (
 
 // schemaPlanContractVersion identifies the bootstrap artifact's plan format. A
 // consumer reading bootstrap/plan.json checks it before interpreting the fields.
-const schemaPlanContractVersion = "codefly.dev/postgres-schema-plan/v1"
+const schemaPlanContractVersion = schemaplan.ContractVersion
 
 // schemaPlan is the packaged form of the resolved schema prerequisites: what the
 // bootstrap image carries, and what it applies. Resolving and validating the
@@ -186,34 +187,14 @@ func fileDigest(path string) (string, error) {
 // digest is the plan's content identity: a deterministic function of every
 // lineage's ledger, staged location and file contents, the required extensions,
 // and the runtime-role grant inputs. Mutating one migration file changes it.
-func (p *schemaPlan) digest() string {
-	hasher := sha256.New()
-	write := func(values ...string) {
-		for _, value := range values {
-			_, _ = hasher.Write([]byte(value))
-			_, _ = hasher.Write([]byte{0})
-		}
-	}
-	write(schemaPlanContractVersion, p.database)
-	for _, extension := range p.extensions {
-		write(extension.name, fmt.Sprint(extension.required))
-	}
-	write(p.access.readOnlyRole, p.access.readWriteRole)
-	write(p.access.schemas...)
-	write(p.access.readWriteRoles...)
-	for _, lineage := range p.lineages {
-		write(lineage.label(), lineage.trackingTable(), lineage.stage, lineage.digest)
-	}
-	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
-}
+func (p *schemaPlan) digest() string { return p.artifactWithoutDigest().ContentDigest() }
 
-func lineageDigest(lineage schemaLineage) string {
-	hasher := sha256.New()
-	_, _ = hasher.Write([]byte(lineage.label() + "\x00" + lineage.trackingTable() + "\x00"))
-	for _, file := range lineage.files {
-		_, _ = hasher.Write([]byte(file.name + "\x00" + file.digest + "\x00"))
+func lineageDigest(l schemaLineage) string {
+	artifact := schemaLineageArtifact{Label: l.label(), Ledger: l.trackingTable()}
+	for _, f := range l.files {
+		artifact.Files = append(artifact.Files, schemaFileArtifact{Name: f.name, Digest: f.digest})
 	}
-	return "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+	return artifact.ContentDigest()
 }
 
 // stagedChecksums renders the staged content as a sha256sum manifest, relative
@@ -258,41 +239,19 @@ func resolveSchemaAccess(settings *Settings) (schemaAccess, error) {
 // It is deliberately machine-independent and secret-free: staged locations and
 // content digests rather than filesystem provenance, role names rather than
 // credentials. Two machines building one commit must publish identical bytes.
-type schemaPlanArtifact struct {
-	ContractVersion string                    `json:"contract-version"`
-	Database        string                    `json:"database"`
-	Extensions      []schemaExtensionArtifact `json:"extensions"`
-	Lineages        []schemaLineageArtifact   `json:"lineages"`
-	Access          schemaAccessArtifact      `json:"access"`
-	Digest          string                    `json:"digest"`
-}
-
-type schemaExtensionArtifact struct {
-	Name     string `json:"name"`
-	Required bool   `json:"required"`
-}
-
-type schemaLineageArtifact struct {
-	Label  string               `json:"label"`
-	Ledger string               `json:"ledger"`
-	Stage  string               `json:"stage"`
-	Digest string               `json:"digest"`
-	Files  []schemaFileArtifact `json:"files"`
-}
-
-type schemaFileArtifact struct {
-	Name   string `json:"name"`
-	Digest string `json:"digest"`
-}
-
-type schemaAccessArtifact struct {
-	ReadOnlyRole   string   `json:"read-only-role"`
-	ReadWriteRole  string   `json:"read-write-role"`
-	Schemas        []string `json:"schemas"`
-	ReadWriteRoles []string `json:"read-write-roles"`
-}
+type schemaPlanArtifact = schemaplan.Plan
+type schemaExtensionArtifact = schemaplan.Extension
+type schemaLineageArtifact = schemaplan.Lineage
+type schemaFileArtifact = schemaplan.File
+type schemaAccessArtifact = schemaplan.Access
 
 func (p *schemaPlan) artifact() schemaPlanArtifact {
+	a := p.artifactWithoutDigest()
+	a.Digest = a.ContentDigest()
+	return a
+}
+
+func (p *schemaPlan) artifactWithoutDigest() schemaPlanArtifact {
 	extensions := make([]schemaExtensionArtifact, 0, len(p.extensions))
 	for _, extension := range p.extensions {
 		extensions = append(extensions, schemaExtensionArtifact{Name: extension.name, Required: extension.required})
@@ -322,6 +281,5 @@ func (p *schemaPlan) artifact() schemaPlanArtifact {
 			Schemas:        p.access.schemas,
 			ReadWriteRoles: p.access.readWriteRoles,
 		},
-		Digest: p.digest(),
 	}
 }

--- a/scripts/qualify-controlplane.py
+++ b/scripts/qualify-controlplane.py
@@ -5,6 +5,7 @@ import os
 import re
 import subprocess
 import time
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -73,6 +74,17 @@ def main():
             f"postgres://postgres@127.0.0.1:{int(binding['HostPort'])}/postgres"
         )
         env["SESSION_POLICY_TEST_DSN"] = env["SERVICE_POSTGRES_CONTROLPLANE_TEST_DSN"]
+        with tempfile.TemporaryDirectory(prefix="postgres-bootstrap-tools-") as tool_dir:
+            migrate = str(Path(tool_dir) / "migrate")
+            bootstrap = str(Path(tool_dir) / "managed-bootstrap")
+            subprocess.run(["go", "build", "-tags", "postgres", "-o", migrate,
+                            "github.com/golang-migrate/migrate/v4/cmd/migrate"], cwd=ROOT, check=True, timeout=180)
+            subprocess.run(["go", "build", "-o", bootstrap, "./cmd/managed-bootstrap"],
+                           cwd=ROOT, check=True, timeout=180)
+            env["SERVICE_POSTGRES_MIGRATE_EXECUTABLE"] = migrate
+            env["SERVICE_POSTGRES_BOOTSTRAP_EXECUTABLE"] = bootstrap
+            subprocess.run(["go", "test", "-race", "-count=1", "-v", "-tags", "controlplaneintegration",
+                            "./libs/go/bootstrap"], cwd=ROOT, env=env, check=True, timeout=120)
         print(f"Fixture image: {image}", flush=True)
         subprocess.run(
             ["go", "test", "-race", "-count=1", "-v", "./libs/go", "-run", "^TestRestrictedSession"],

--- a/scripts/qualify-controlplane.py
+++ b/scripts/qualify-controlplane.py
@@ -81,6 +81,21 @@ def main():
                             "github.com/golang-migrate/migrate/v4/cmd/migrate"], cwd=ROOT, check=True, timeout=180)
             subprocess.run(["go", "build", "-o", bootstrap, "./cmd/managed-bootstrap"],
                            cwd=ROOT, check=True, timeout=180)
+            architecture = subprocess.check_output(
+                ["docker", "inspect", "--format", "{{.Architecture}}", image], text=True).strip()
+            if architecture not in {"amd64", "arm64"}:
+                raise ValueError("unsupported fixture architecture")
+            linux_env = env.copy()
+            linux_env.update(GOOS="linux", GOARCH=architecture, CGO_ENABLED="0")
+            for name, package, tags in [
+                ("migrate", "github.com/golang-migrate/migrate/v4/cmd/migrate", ["-tags", "postgres"]),
+                ("managed-bootstrap", "./cmd/managed-bootstrap", []),
+            ]:
+                target = str(Path(tool_dir) / (name + "-linux"))
+                subprocess.run(["go", "build", *tags, "-o", target, package],
+                               cwd=ROOT, env=linux_env, check=True, timeout=180)
+                subprocess.run(["docker", "cp", target, f"{container}:/tmp/{name}"], check=True)
+            env["SERVICE_POSTGRES_FIXTURE_CONTAINER"] = container
             env["SERVICE_POSTGRES_MIGRATE_EXECUTABLE"] = migrate
             env["SERVICE_POSTGRES_BOOTSTRAP_EXECUTABLE"] = bootstrap
             subprocess.run(["go", "test", "-race", "-count=1", "-v", "-tags", "controlplaneintegration",

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -78,9 +78,11 @@ existing generated runtime-access program rewrites password-authenticated login
 roles, which is incompatible with cloud-managed identities. Rejection occurs
 before staged output is changed or Docker runs. Do not switch to password mode
 or patch the emitted SQL to get a managed deployment through this gate; a
-primitive-owned external-identity bootstrap must integrate the canonical managed
-role contract first. The shared schema-plan packaging does not itself establish
-that compatibility.
+the explicit `cmd/managed-bootstrap` preview in service-postgres integrates the
+canonical role engine separately. See the owning repository's
+`docs/managed-bootstrap.md` for its bindings and local qualification. Managed
+image/Job packaging and cloud qualification remain separate; schema-plan
+packaging alone does not establish that compatibility.
 
 For tenant isolation, application migrations must enable row-level security and define policies against transaction-local tenant/user settings. Go services should use the service-owned library at `github.com/codefly-dev/service-postgres/libs/go`, which resolves an authenticated principal from context, issues separate read-only/read-write stores without exposing raw pools, and provides tenant-scoped transaction advisory locks without exposing tenant identity to repository code.
 

--- a/templates/agent/README.md.tmpl
+++ b/templates/agent/README.md.tmpl
@@ -77,8 +77,8 @@ but bootstrap image/recipe generation is currently rejected in this mode. The
 existing generated runtime-access program rewrites password-authenticated login
 roles, which is incompatible with cloud-managed identities. Rejection occurs
 before staged output is changed or Docker runs. Do not switch to password mode
-or patch the emitted SQL to get a managed deployment through this gate; a
-the explicit `cmd/managed-bootstrap` preview in service-postgres integrates the
+or patch the emitted SQL to get a managed deployment through this gate.
+The explicit `cmd/managed-bootstrap` preview in service-postgres integrates the
 canonical role engine separately. See the owning repository's
 `docs/managed-bootstrap.md` for its bindings and local qualification. Managed
 image/Job packaging and cloud qualification remain separate; schema-plan


### PR DESCRIPTION
## Change

Add an explicit managed-identity bootstrap command for passwordless PostgreSQL endpoints. It consumes the shared, attested schema plan, runs the existing pinned golang-migrate executable, and reconciles access through the canonical role engine under one database control-plane lock.

The runner requires exact plan-file/content pins and explicit pre-provisioned principal bindings. It verifies migration bytes before connecting, preserves existing ledgers and cloud login passwords, rejects LOGIN/elevated group bindings, and stops access reconciliation on dirty or failed migrations. Cancellation drains only the uniquely named child owner sessions before releasing the lock; SQL and connection details are omitted from command errors.

This is a locally qualified primitive preview. The agent's external-identity Build guard remains in place. Immutable managed image/Job packaging, provider execution and deployed recovery remain separate checkpoints. No cloud identifiers, credentials, private source or deployment evidence are included.

## Validation

- `go test . -run 'Test(ExternalIdentity.*Build|BootstrapBuild|Build|SchemaPlan|PromotableExternalIdentity|CIWorkflow)' -count=1`
- `go test -race ./libs/go/... ./cmd/managed-bootstrap`
- `go vet ./libs/go/bootstrap ./libs/go/schemaplan ./cmd/managed-bootstrap`
- `POSTGRES_TEST_IMAGE=postgres@sha256:fe03a7605299a34ddf5e4f285dff78c3d7190a576b3c6b46f2fcff69f4bffd54 python3 scripts/qualify-controlplane.py`
- Staged diff whitespace, secret and infrastructure-identifier checks passed.

The isolated PostgreSQL 16 suite executes the actual command and migration CLI, concurrent/repeated jobs, restricted-admin reconciliation, default sequence privileges, runtime DDL/reader DML denial, unchanged passwords, missing identity/LOGIN group rejection, bounded lock contention, dirty-state preservation and cancellation cleanup. It also reruns the existing canonical role and restricted-session suites. The workflow now runs this qualification for managed-command changes.
