### PR TITLE
fix: make postgres bootstrap builds recipe-only (#63)

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/codefly-dev/core/agents/services"
 	basev0 "github.com/codefly-dev/core/generated/go/codefly/base/v0"
@@ -15,6 +18,8 @@ import (
 	"github.com/codefly-dev/core/resources"
 	"github.com/codefly-dev/core/wool"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 // newBuildTestBuilder loads a builder whose Location points at a temporary
@@ -594,4 +599,87 @@ func TestBuildRecipeResolvesIdenticalInputsAcrossEmissions(t *testing.T) {
 	require.Equal(t, firstPlan.GetRecipes()[0].GetBuildArgs(), secondPlan.GetRecipes()[0].GetBuildArgs())
 	require.NotEmpty(t, firstPlan.GetDigest())
 	require.Equal(t, firstPlan.GetDigest(), secondPlan.GetDigest())
+}
+
+func TestBuildRecipeContractOverGRPC(t *testing.T) {
+	for _, selection := range []string{"default", "explicit", "cache-selected"} {
+		for _, output := range []string{"recipe", "missing", "relative"} {
+			t.Run(selection+"/"+output, func(t *testing.T) {
+				builder := newBuildTestBuilder(t)
+				marker := filepath.Join(builder.Location, "builder", "Dockerfile")
+				require.NoError(t, os.MkdirAll(filepath.Dir(marker), 0o755))
+				require.NoError(t, os.WriteFile(marker, []byte("caller-owned"), 0o644))
+				server := grpc.NewServer()
+				builderv0.RegisterBuilderServer(server, builder)
+				listener, err := net.Listen("tcp", "127.0.0.1:0")
+				require.NoError(t, err)
+				go func() { _ = server.Serve(listener) }()
+				t.Cleanup(server.Stop)
+				conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+				require.NoError(t, err)
+				t.Cleanup(func() { require.NoError(t, conn.Close()) })
+				client := services.NewBuilderAgentClient(conn)
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+
+				t.Setenv("PATH", t.TempDir())
+				for _, executable := range []string{"docker", "buildx"} {
+					_, err := exec.LookPath(executable)
+					require.ErrorIs(t, err, exec.ErrNotFound)
+				}
+				capabilities, err := client.BuildCapabilities(ctx, &builderv0.BuildCapabilitiesRequest{})
+				require.NoError(t, err)
+				require.True(t, capabilities.GetBuildxSelection())
+
+				directory := t.TempDir()
+				request := buildRequest(directory)
+				docker := request.GetBuildContext().GetDockerBuildContext()
+				if selection != "default" {
+					docker.BuildxBuilder = "cli-owned-builder"
+				}
+				if selection == "cache-selected" {
+					docker.Cache = &builderv0.BuildCacheOptions{
+						Backend: "registry", Scope: "postgres",
+						Imports: []string{"registry.example.com/cache/import"},
+						Exports: []string{"registry.example.com/cache/export"},
+					}
+				}
+				switch output {
+				case "missing":
+					request.OutputDirectory = ""
+				case "relative":
+					request.OutputDirectory = "relative-output"
+				}
+				response, err := client.Build(ctx, request)
+				if output == "relative" {
+					require.ErrorContains(t, err, "must be absolute")
+				} else {
+					require.NoError(t, err)
+					if output == "missing" {
+						require.Equal(t, builderv0.BuildStatus_ERROR, response.GetState().GetState())
+						require.Contains(t, response.GetState().GetMessage(), "output_directory is required")
+						require.Nil(t, response.GetResult())
+					} else {
+						require.Equal(t, builderv0.BuildStatus_SUCCESS, response.GetState().GetState(), response.GetState().GetMessage())
+						plan := response.GetResult().GetDockerBuildPlan()
+						require.NotNil(t, plan)
+						require.NoError(t, services.VerifyDockerBuildPlan(directory, plan))
+						require.Len(t, plan.GetRecipes(), 1)
+						require.Equal(t, "registry.example.com/module/postgres", plan.GetRecipes()[0].GetImage())
+						require.Nil(t, response.GetResult().GetDockerBuildResult())
+						require.Empty(t, response.GetBuildxBuilder())
+						require.Empty(t, response.GetCacheContractVersion())
+					}
+				}
+				require.Equal(t, "caller-owned", string(mustReadFile(t, marker)))
+				if output != "recipe" {
+					require.NoDirExists(t, filepath.Join(builder.Location, "bootstrap"))
+					require.NoFileExists(t, filepath.Join(builder.Location, "runtime-access.sql"))
+					entries, err := os.ReadDir(directory)
+					require.NoError(t, err)
+					require.Empty(t, entries)
+				}
+			})
+		}
+	}
 }

--- a/builder.go
+++ b/builder.go
@@ -195,6 +195,10 @@ func bootstrapExtensions(plan *schemaPlan) []BootstrapExtension {
 	return extensions
 }
 
+func (*Builder) BuildCapabilities(context.Context, *builderv0.BuildCapabilitiesRequest) (*builderv0.BuildCapabilitiesResponse, error) {
+	return &builderv0.BuildCapabilitiesResponse{BuildxSelection: true}, nil
+}
+
 func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*builderv0.BuildResponse, error) {
 	defer s.Wool.Catch()
 
@@ -204,13 +208,17 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 
 	// The emitted bootstrap still owns password-authenticated login roles.
 	// External-identity deployment metadata does not make that SQL compatible
-	// with cloud-managed logins. Fail before deleting/staging caller output or
-	// invoking Docker until an external-identity bootstrap is implemented.
+	// with cloud-managed logins. Fail before deleting/staging caller output
+	// until an external-identity bootstrap is implemented.
 	if err := s.validateAuthMode(); err != nil {
 		return s.Builder.BuildError(err)
 	}
 	if s.externalIdentity() {
 		return s.Builder.BuildError(fmt.Errorf("external-identity bootstrap generation is unsupported: the password bootstrap must not rewrite cloud-managed login roles"))
+	}
+
+	if req.GetOutputDirectory() == "" {
+		return s.Builder.BuildError(fmt.Errorf("output_directory is required: the CLI executes bootstrap image builds"))
 	}
 
 	dockerRequest, err := s.Builder.DockerBuildRequest(ctx, req)
@@ -257,42 +265,7 @@ func (s *Builder) Build(ctx context.Context, req *builderv0.BuildRequest) (*buil
 		Lineages:                       bootstrapLineages(plan),
 	}
 
-	if outputDirectory := req.GetOutputDirectory(); outputDirectory != "" {
-		return s.buildRecipe(ctx, outputDirectory, img, plan, docker)
-	}
-
-	err = shared.DeleteFile(ctx, s.Local("builder/Dockerfile"))
-	if err != nil {
-		return s.Builder.BuildError(err)
-	}
-
-	err = s.Templates(ctx, docker, services.WithBuilder(builderFS))
-	if err != nil {
-		return s.Builder.BuildError(err)
-	}
-
-	if err = s.stageBootstrapContext(ctx, plan, docker, s.Location); err != nil {
-		return s.Builder.BuildError(err)
-	}
-
-	builder, err := dockerhelpers.NewBuilder(dockerhelpers.BuilderConfiguration{
-		Root:        s.Location,
-		Dockerfile:  "builder/Dockerfile",
-		Ignorefile:  bootstrapDirectory + "/" + bootstrapIgnoreFile,
-		Destination: img,
-		Output:      s.Wool,
-	})
-	if err != nil {
-		return s.Builder.BuildError(err)
-	}
-	_, err = builder.Build(ctx)
-	if err != nil {
-		return s.Builder.BuildError(err)
-	}
-
-	s.Builder.WithDockerImages(img)
-
-	return s.Builder.BuildResponse()
+	return s.buildRecipe(ctx, req.GetOutputDirectory(), img, plan, docker)
 }
 
 // buildRecipe renders the bootstrap image's recipe into the caller-owned output

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.27.0
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.23.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.14.0
-	github.com/codefly-dev/core v0.3.11
+	github.com/codefly-dev/core v0.3.27
 	github.com/codefly-dev/gortk v0.2.0
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/jackc/pgx/v5 v5.10.0
@@ -85,6 +85,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.28 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/patternmatcher v0.6.0 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/oklog/ulid/v2 v2.1.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJ
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
-github.com/codefly-dev/core v0.3.11 h1:FPYNQ3MysUeuZmXISBl7G2PEkzijE0wBWen2sF8pqMc=
-github.com/codefly-dev/core v0.3.11/go.mod h1:4V8BP4F5mnRDZvylhC9P5N7rfifpAma5n3dW4YD+gtQ=
+github.com/codefly-dev/core v0.3.27 h1:SI0EhUvGr+WlIkuLEuTDQuMjZX5ThgmPGJO2f0NPyzM=
+github.com/codefly-dev/core v0.3.27/go.mod h1:Z9//zS5LnN1MdX5Oi9AuPkXOHYSfzi25GyPi0JU044w=
 github.com/codefly-dev/gortk v0.2.0 h1:7bOlS5valYz2zil+fZctQNcPCYBcPj86abcw9N8h1hQ=
 github.com/codefly-dev/gortk v0.2.0/go.mod h1:dDWUMFgAP063OCGhTEpV7FFUj9+zTcxxO/nV80VKEwg=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=
@@ -211,6 +211,8 @@ github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyua
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
 github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=

--- a/managed_bootstrap_test.go
+++ b/managed_bootstrap_test.go
@@ -29,7 +29,7 @@ func TestExternalIdentityBuildRejectsPasswordBootstrapBeforeWriting(t *testing.T
 	require.True(t, os.IsNotExist(err), "rejection must precede staged output")
 }
 
-func TestExternalIdentityDirectBuildFailsBeforeDocker(t *testing.T) {
+func TestExternalIdentityBuildWithoutOutputRejectsPasswordBootstrap(t *testing.T) {
 	builder := newBuildTestBuilder(t)
 	builder.AuthMode = authModeExternalIdentity
 	response, err := builder.Build(context.Background(), buildRequest(""))


### PR DESCRIPTION
Closes #63.

## Summary
- Make bootstrap image builds recipe-only: requests without `output_directory` fail before staging, and the agent no longer constructs or runs a Docker builder. Callers must use a CLI that supplies an absolute recipe destination.
- Consume Core v0.3.27 and explicitly advertise recipe-safe Buildx selection. The embedded `services.BuilderServer` and `BuilderWrapper` have no image execution fallback; no shared language runner is consumed. Cache imports/exports, builder selection, building, and pushing remain CLI-owned.
- Exercise the actual agent over TCP gRPC with Core's client, covering ordinary recipes, explicit/cache-selected builders, and missing/relative output directories with no Docker or Buildx on PATH. Existing external-identity rejection and runtime image contracts remain intact.

## Test plan
- [x] `go test . -run 'TestBuild|TestExternalIdentity.*Build' -count=1`
- [x] `go test ./... -count=1 -timeout 20m` (all packages passed; root suite 356s)
- [x] `go test . -run '^TestBuildRecipeContractOverGRPC$' -race -count=1`
- [x] `go build ./...`, `go vet ./...`, `go mod tidy -diff`, `go mod verify`, `git diff --check`
- [x] Execute the emitted plan through CLI `Builder.buildFromPlan` using a temporary Go test overlay against CLI commit `a10e6d63aa385bc3769f2030488803ee47a505c0`; plan verification and real Docker Buildx `--load` succeeded for linux/amd64. Recipe digest: `sha256:c6d9c7a83d64a38bac70dd7d09a1862e3fd1a1a15b01e5773aa6a638dfd13998`; local image digest: `sha256:8e31b1cddc99d7261d0f719c03ac097f89873048a0474e04dce471fd81a0acd5`.
- [ ] After merge, publish the corrected agent through the existing release workflow and record its tag, source commit, workflow run, and asset checksums. Migration completion remains pending that release; the local image above is validation evidence, not an agent release.

Core release evidence: tag `v0.3.27` resolves to `9267a219f28478d090c90b69b5b99900c52f8ab9`, module checksum `h1:SI0EhUvGr+WlIkuLEuTDQuMjZX5ThgmPGJO2f0NPyzM=`. [Core CI](https://github.com/codefly-dev/core/actions/runs/34623653367) and [tag publication](https://github.com/codefly-dev/core/actions/runs/34624729792) succeeded. The documented agent publication procedure requires clean, synced `main`, so this unmerged PR has not been released.
